### PR TITLE
fix: GitHub references from old Front-End-Coders-Mauritius to frontendmu

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -43,7 +43,7 @@ body = """
 trim = true
 # postprocessors
 postprocessors = [
-  { pattern = '<REPO>', replace = "https://github.com/Front-End-Coders-Mauritius/frontend.mu" }, # replace repository URL
+  { pattern = '<REPO>', replace = "https://github.com/frontendmu/frontend.mu" }, # replace repository URL
 ]
 
 [git]

--- a/packages/frontendmu-astro/src/components/HomeSocialPresence.astro
+++ b/packages/frontendmu-astro/src/components/HomeSocialPresence.astro
@@ -25,7 +25,7 @@ import IconLinkedin from "./icons/icon-linkedin.astro";
     </SocialCard>
 
     <SocialCard
-      href="https://github.com/Front-End-Coders-Mauritius"
+      href="https://github.com/frontendmu"
       class="bg-[#333] text-sm md:text-normal"
     >
       <p slot="tagline">GitHub</p>

--- a/packages/frontendmu-astro/src/components/MainMenu.astro
+++ b/packages/frontendmu-astro/src/components/MainMenu.astro
@@ -26,7 +26,7 @@ const links = {
   },
   github: {
     title: "Github",
-    href: "https://github.com/Front-End-Coders-Mauritius",
+    href: "https://github.com/frontendmu",
     class: "hidden md:block",
   },
 };

--- a/packages/frontendmu-astro/src/components/MegaMenu.astro
+++ b/packages/frontendmu-astro/src/components/MegaMenu.astro
@@ -49,7 +49,7 @@ const links: TMenu = {
       },
       {
         title: "GitHub",
-        href: "https://github.com/Front-End-Coders-Mauritius?ref=frontend.mu",
+        href: "https://github.com/frontendmu?ref=frontend.mu",
         class: "",
       },
       {
@@ -75,7 +75,7 @@ const links: TMenu = {
   },
   github: {
     title: "Github",
-    href: "https://github.com/Front-End-Coders-Mauritius",
+    href: "https://github.com/frontendmu",
     class: "hidden md:block",
   },
 };

--- a/packages/frontendmu-astro/src/components/TeamComponent.astro
+++ b/packages/frontendmu-astro/src/components/TeamComponent.astro
@@ -153,7 +153,7 @@ const contributors: Contributor[] = Contributors;
           return (
             <li>
               <a
-                href={`https://github.com/Front-End-Coders-Mauritius/frontendmu-astro/commits?author=${person.username}`}
+                href={`https://github.com/frontendmu/frontend.mu/commits?author=${person.username}`}
                 target="_blank"
                 class="space-y-4"
               >

--- a/packages/frontendmu-nuxt/components/home/SocialPresence.vue
+++ b/packages/frontendmu-nuxt/components/home/SocialPresence.vue
@@ -22,7 +22,7 @@
         </template>
       </HomeSocialCard>
 
-      <HomeSocialCard href="https://github.com/Front-End-Coders-Mauritius" class="bg-[#333] text-sm md:text-normal">
+      <HomeSocialCard href="https://github.com/frontendmu" class="bg-[#333] text-sm md:text-normal">
         <template #tagline>
           <p>GitHub</p>
         </template>

--- a/packages/frontendmu-nuxt/components/site/Menu.vue
+++ b/packages/frontendmu-nuxt/components/site/Menu.vue
@@ -67,7 +67,7 @@ const links: TMenu = {
       },
       {
         title: "GitHub",
-        href: "https://github.com/Front-End-Coders-Mauritius?ref=frontend.mu",
+        href: "https://github.com/frontendmu?ref=frontend.mu",
         class: "",
       },
       {
@@ -197,7 +197,7 @@ onMounted(toggleHeader);
         </nav>
         <div>
           <div class="flex items-center gap-2">
-            <!-- <a target="_blank" href="https://github.com/Front-End-Coders-Mauritius">
+            <!-- <a target="_blank" href="hhttps://github.com/frontendmu/frontend.mu/">
               <span class="sr-only">GitHub Repository</span>
               <Icon name="carbon:logo-github" class="w-4 h-4 text-verse-600 dark:text-verse-100" />
             </a> -->

--- a/packages/frontendmu-nuxt/components/site/Menu.vue
+++ b/packages/frontendmu-nuxt/components/site/Menu.vue
@@ -197,7 +197,7 @@ onMounted(toggleHeader);
         </nav>
         <div>
           <div class="flex items-center gap-2">
-            <!-- <a target="_blank" href="hhttps://github.com/frontendmu/frontend.mu/">
+            <!-- <a target="_blank" href="https://github.com/frontendmu/frontend.mu/">
               <span class="sr-only">GitHub Repository</span>
               <Icon name="carbon:logo-github" class="w-4 h-4 text-verse-600 dark:text-verse-100" />
             </a> -->

--- a/packages/frontendmu-nuxt/pages/team.vue
+++ b/packages/frontendmu-nuxt/pages/team.vue
@@ -93,7 +93,7 @@ const NuxtLink = resolveComponent('NuxtLink')
 
       <ul id="team" role="list" class="mx-auto grid grid-cols-2 gap-x-4 gap-y-8 sm:grid-cols-4 md:gap-x-6 lg:gap-x-8">
         <li v-for="person in contributors" :key="person.username">
-          <a :href="`https://github.com/Front-End-Coders-Mauritius/frontendmu-astro/commits?author=${person.username}`"
+          <a :href="`https://github.com/frontendmu/frontend.mu/commits/?author=${person.username}`"
             target="_blank" class="space-y-4">
             <img
               class="mx-auto h-20 w-20 rounded-full border-verse-2 shadow-lg 00 border p-2 lg:w-48 lg:h-48 profile-avatar"


### PR DESCRIPTION
There are numerous references to https://github.com/Front-End-Coders-Mauritius on the website. This PR proposes an update to all references on the website. 

An additional sweep is required to updated Gists and other references I am not familiar with.

![image](https://github.com/user-attachments/assets/b2d4a05a-0ac6-4dea-9ee1-34adcb63c6e8)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Updated GitHub links across various components to point to the new repository URL.

- **Bug Fixes**
	- Corrected GitHub links in the navigation and social presence components to ensure proper redirection.

- **Chores**
	- Minor adjustments to commented-out code for clarity and accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->