### PR TITLE
fix: update computed props to hide missing profile details and add job title

### DIFF
--- a/packages/frontendmu-data/data/speakers-profile.json
+++ b/packages/frontendmu-data/data/speakers-profile.json
@@ -11,6 +11,7 @@
     "bio": "Front-End Engineer | Streamer (Twitch)",
     "job_title": "Senior Front-end Engineer @  Livestorm",
     "location": "Mauritius",
+    "website": "",
     "github": "cedpoilly",
     "twitter": ""
   }

--- a/packages/frontendmu-nuxt/components/speaker/Single.vue
+++ b/packages/frontendmu-nuxt/components/speaker/Single.vue
@@ -16,11 +16,12 @@ const person = computed(() => props.speaker.person)
 const sessions = computed(() => props.speaker.sessions)
 
 const profile = computed(() => props.speaker.profile)
-const hasProfileBio = computed(() => profile.value.bio !== '')
-const hasProfileLocation = computed(() => profile.value.location !== '')
-const hasProfileWebsite = computed(() => profile.value.website !== '')
-const hasProfileGithub = computed(() => profile.value.github !== '')
-const hasProfileTwitter = computed(() => profile.value.twitter !== '')
+const hasProfileBio = computed(() => profile.value.bio && profile.value.bio !== '')
+const hasProfileJobTitle = computed(() => profile.value.job_title && profile.value.job_title !== '')
+const hasProfileLocation = computed(() => profile.value.location && profile.value.location !== '')
+const hasProfileWebsite = computed(() => profile.value.website && profile.value.website !== '')
+const hasProfileGithub = computed(() => profile.value.github && profile.value.github !== '')
+const hasProfileTwitter = computed(() => profile.value.twitter && profile.value.twitter !== '')
 
 const speaker_photo = getGithubUrl(person.value.github_account)
 </script>
@@ -94,6 +95,10 @@ const speaker_photo = getGithubUrl(person.value.github_account)
                 </p>
 
                 <nav class="grid gap-2 *:flex *:justify-start *:items-center *:gap-2">
+                  <span v-if="hasProfileJobTitle">
+                    <Icon name="lucide:code-xml" mode="svg" class="size-6" />{{ profile.job_title }}
+                  </span>
+
                   <span v-if="hasProfileLocation">
                     <Icon name="lucide:map-pin" mode="svg" class="size-6" />{{ profile.location }}
                   </span>


### PR DESCRIPTION
- Update speakers-profile.json file to add missing `website` key
- Update check in `SpeakerSingle.vue` component to hide missing speaker profile details
- Update markup in `SpeakerSingle.vue` component to display speaker's job title

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced speaker profile display with the addition of job title visibility.
  
- **Bug Fixes**
	- Improved logic for checking the presence of profile attributes to prevent false positives from empty strings. 

- **Documentation**
	- Updated conditions for rendering profile information to ensure accuracy in displayed data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->