### PR TITLE
Add slides link

### DIFF
--- a/packages/frontendmu-nuxt/components/meetup/SessionList.vue
+++ b/packages/frontendmu-nuxt/components/meetup/SessionList.vue
@@ -1,8 +1,7 @@
 <script setup lang="ts">
-// import { Image } from "astro:assets";
 import { getGithubUrl } from '@/utils/helpers'
 import type { Session } from '@/utils/types'
-// import { vTransitionName } from "@/utils/helpers";
+import { vTransitionName } from "@/utils/helpers";
 
 const props = defineProps({
   sessions: {
@@ -22,26 +21,36 @@ function getSpeakerPhoto(githubAccount: string) {
       Agenda
     </div>
     <ul role="list" class="flex flex-col gap-6">
-      <li v-for="(session, index) in sessions" :key="index" class="space-y-4 flex gap-10 relative">
-        <img class="h-20 w-20 rounded-full lg:h-24 lg:w-24"
-             :src="getSpeakerPhoto(session.Session_id.speakers.github_account)" :alt="session.Session_id.speakers.name"
-             :title="session.Session_id.speakers.name" width="300" height="300"
-             :style="vTransitionName(session?.Session_id.speakers?.name, 'photo')"
+      <li v-for="(session, index) in sessions" :key="index" class="flex flex-row items-center sm:items-start gap-5 lg:gap-10 relative">
+        <img
+          class="h-16 sm:h-20 w-16 sm:w-20 rounded-full lg:h-24 lg:w-24"
+          :src="getSpeakerPhoto(session.Session_id.speakers.github_account)" :alt="session.Session_id.speakers.name"
+          :title="session.Session_id.speakers.name" width="300" height="300"
+          :style="vTransitionName(session?.Session_id.speakers?.name, 'photo')"
         >
 
-        <div class="space-y-2">
-          <div>
-            <h3 class="font-heading text-xs font-medium lg:text-xl text-verse-500 dark:text-verse-400">
-              {{ session.Session_id.speakers.name }}
-            </h3>
-            <p class="text-xs font-bold lg:text-2xl text-verse-800 dark:text-verse-200">
-              {{ session.Session_id.title }}
-            </p>
-          </div>
+        <div>
+          <h3 class="font-heading text-xs font-medium sm:text-sm md:text-base lg:text-xl text-verse-500 dark:text-verse-400">
+            {{ session.Session_id.speakers.name }}
+          </h3>
+          <p class="text-sm font-bold sm:text-base md:text-lg lg:text-2xl text-verse-800 dark:text-verse-200">
+            {{ session.Session_id.title }}
+          </p>
+          <NuxtLink
+            v-if="session.Session_id.deck"
+            :href="session.Session_id.deck"
+            target="_blank"
+            rel="noopener noreferrer nofollow"
+            class="w-fit flex flex-row items-center gap-1 py-2 sticky z-[1] text-xs sm:text-sm md:text-base lg:text-lg underline"
+          >
+            View slides
+            <Icon name="noto:backhand-index-pointing-right" class="w-4 h-4" />
+          </NuxtLink>
         </div>
 
-        <NuxtLink :href="`/speaker/${session.Session_id.speakers.id}`" class="absolute inset-0"
-                  :title="`Speaker name: ${session.Session_id.speakers.name}`"
+        <NuxtLink
+          :href="`/speaker/${session.Session_id.speakers.id}`" class="absolute inset-0"
+          :title="`Speaker name: ${session.Session_id.speakers.name}`"
         >
           <span class="sr-only">{{ session.Session_id.speakers.name }}</span>
         </NuxtLink>

--- a/packages/frontendmu-nuxt/components/meetup/Single.vue
+++ b/packages/frontendmu-nuxt/components/meetup/Single.vue
@@ -41,15 +41,11 @@ const currentAlbum = computed(() => fetchAlbumDetails(props.getCurrentEvent?.alb
           <div class="relative">
             <!-- Content area -->
             <div>
-              <template v-if="isDateInFuture(getCurrentEvent.Date || '')">
+              <template v-if="isDateInFuture(new Date(getCurrentEvent.Date || new Date))">
                 <div class="flex flex-col pb-4 gap-2 md:flex-row md:justify-between md:items-center">
                   <div class="flex w-full items-center justify-start">
                     <p
-                      class="p-2 rounded-full text-sm font-medium tracking-wide uppercase px-4" :class="[
-                        isDateInFuture(getCurrentEvent.Date || '')
-                          ? 'tagStyle bg-green-100 text-green-800'
-                          : 'tagStyle bg-yellow-100 text-yellow-800',
-                      ]"
+                      class="p-2 rounded-full text-sm font-medium tracking-wide uppercase px-4 tagStyle bg-green-100 text-green-800"
                     >
                       happening soon
                     </p>

--- a/packages/frontendmu-nuxt/components/speaker/EventsList.vue
+++ b/packages/frontendmu-nuxt/components/speaker/EventsList.vue
@@ -12,23 +12,32 @@ const props = defineProps({
 <template>
   <div>
     <ul role="list" class="flex flex-col gap-8 py-8">
-      <li v-for="(session, index) in sessions" :key="index">
-        <NuxtLink :href="`/meetup/${session.Events_id.id}`" class="space-y-4 flex gap-10">
-          <span class="sr-only">{{ session.Events_id.title }}</span>
-          <div class="space-y-2">
-            <div>
-              <span class="text-gray-500 font-bold font-mono">
-                {{ new Date(session.Events_id.Date).toDateString() }}
-              </span>
-              <h3 class="text-xs font-medium lg:text-xl text-verse-400">
-                {{ session.Events_id.title }}
-              </h3>
-              <p class="text-xs font-medium lg:text-2xl text-verse-500 dark:text-verse-200">
-                {{ session.Session_id.title }}
-              </p>
-            </div>
+      <li v-for="(session, index) in sessions" :key="index" class="relative space-y-4 flex gap-10">
+        <span class="sr-only">{{ session.Events_id.title }}</span>
+        <div class="space-y-2">
+          <div>
+            <span class="text-gray-500 font-bold font-mono">
+              {{ new Date(session.Events_id.Date).toDateString() }}
+            </span>
+            <h3 class="text-xs font-medium lg:text-xl text-verse-400">
+              {{ session.Events_id.title }}
+            </h3>
+            <p class="text-xs font-medium lg:text-2xl text-verse-500 dark:text-verse-200">
+              {{ session.Session_id.title }}
+            </p>
+            <NuxtLink
+              v-if="session.Session_id.deck"
+              :href="session.Session_id.deck"
+              target="_blank"
+              rel="noopener noreferrer nofollow"
+              class="w-fit flex flex-row items-center gap-1 py-2 sticky z-[1] text-xs sm:text-sm md:text-base lg:text-lg underline"
+            >
+              View slides
+              <Icon name="noto:backhand-index-pointing-right" class="w-4 h-4" />
+            </NuxtLink>
           </div>
-        </NuxtLink>
+        </div>
+        <NuxtLink :href="`/meetup/${session.Events_id.id}`" class="absolute inset-0" />
       </li>
     </ul>
   </div>

--- a/packages/frontendmu-nuxt/utils/types.ts
+++ b/packages/frontendmu-nuxt/utils/types.ts
@@ -255,6 +255,7 @@ export interface Meetup {
 export interface SessionDetail {
   title: string
   speakers: Speaker
+  deck?: string
 }
 
 export interface Speaker {


### PR DESCRIPTION
This PR adds a link to access a session's slides whenever it's available.

Affected pages:
- `meetup/[id]`
- `speaker/[id]`

P.s. I noticed there was an [open issue](https://github.com/frontendmu/frontend.mu/issues/44) that seems to have been stale for a while.

`meetup/[id]`:

![image](https://github.com/user-attachments/assets/1424e90d-5c4e-4982-bfd8-ddc05081c1de)

`speaker/[id]`:

![image](https://github.com/user-attachments/assets/bc3b71f2-900c-491c-9cd7-4f232d7922aa)

Closes #44.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a clickable link to access session slides when available.

- **Style**
  - Enhanced layouts and responsive design for session and event listings.
  - Optimized text and image sizing for improved viewing across devices.

- **Bug Fixes**
  - Improved event date handling to ensure a consistent status display and prevent potential errors.

- **Chores**
  - Added an optional property for session details to include a presentation deck.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->