### PR TITLE
Modify slides link icon

### DIFF
--- a/packages/frontendmu-nuxt/components/meetup/SessionList.vue
+++ b/packages/frontendmu-nuxt/components/meetup/SessionList.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
-import { getGithubUrl } from '@/utils/helpers'
+import { getGithubUrl, vTransitionName } from '@/utils/helpers'
 import type { Session } from '@/utils/types'
-import { vTransitionName } from "@/utils/helpers";
 
 const props = defineProps({
   sessions: {
@@ -43,8 +42,8 @@ function getSpeakerPhoto(githubAccount: string) {
             rel="noopener noreferrer nofollow"
             class="w-fit flex flex-row items-center gap-1 py-2 sticky z-[1] text-xs sm:text-sm md:text-base lg:text-lg underline"
           >
+            <Icon name="bx:slideshow" class="w-3 sm:w-4 lg:w-5 h-3 sm:h-4 lg:h-5" />
             View slides
-            <Icon name="noto:backhand-index-pointing-right" class="w-4 h-4" />
           </NuxtLink>
         </div>
 

--- a/packages/frontendmu-nuxt/components/speaker/EventsList.vue
+++ b/packages/frontendmu-nuxt/components/speaker/EventsList.vue
@@ -22,7 +22,7 @@ const props = defineProps({
             <h3 class="text-xs font-medium lg:text-xl text-verse-400">
               {{ session.Events_id.title }}
             </h3>
-            <p class="text-xs font-medium lg:text-2xl text-verse-500 dark:text-verse-200">
+            <p class="text-base sm:text-lg md:text-xl lg:text-2xl font-medium text-verse-500 dark:text-verse-200">
               {{ session.Session_id.title }}
             </p>
             <NuxtLink
@@ -32,8 +32,8 @@ const props = defineProps({
               rel="noopener noreferrer nofollow"
               class="w-fit flex flex-row items-center gap-1 py-2 sticky z-[1] text-xs sm:text-sm md:text-base lg:text-lg underline"
             >
+              <Icon name="bx:slideshow" class="w-3 sm:w-4 lg:w-5 h-3 sm:h-4 lg:h-5" />
               View slides
-              <Icon name="noto:backhand-index-pointing-right" class="w-4 h-4" />
             </NuxtLink>
           </div>
         </div>


### PR DESCRIPTION
As suggested [here](https://github.com/frontendmu/frontend.mu/pull/267#issuecomment-2718463958), this PR modifies the session link icon and some minor styling changes.

![image](https://github.com/user-attachments/assets/2e7baf06-cfd7-411b-a25f-0a0b0d088f43)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Slide view links now feature refreshed icons for a modern look.
- **Style**
	- Enhanced text sizing in event listings improves readability and responsiveness across devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->