### PR TITLE
rename everything to coders.mu

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Front-End coders Mauritius is a free meetup that's dedicated to all aspect of Front-End development. it occurs in general one a month at announced date and place. Feel free to join!
 
-Live website : [https://frontend.mu/](https://frontend.mu/)
+Live website : [https://frontend.coders.mu/](https://frontend.coders.mu/)
 
 ## Getting Started
 

--- a/packages/frontendmu-astro/api/cloudflare-worker-auth-picture.js
+++ b/packages/frontendmu-astro/api/cloudflare-worker-auth-picture.js
@@ -9,7 +9,7 @@
  */
 
 async function fetchPicture(accessToken, googleClientId, googleClientSecret) {
-    const directusApiEndpoint = 'https://directus.frontend.mu/users/me';
+    const directusApiEndpoint = 'https://directus.coders.mu/users/me';
     let result = await fetch(directusApiEndpoint, {
         headers: {
             Authorization: `Bearer ${accessToken}`,
@@ -102,7 +102,7 @@ async function uploadImageToDirectus(imageUrl, directusAccessToken, directusUser
 
     let base64String = await fromUrlToBase64(imageUrl);
 
-    const DIRECTUS_PROJECT_URL = 'https://directus.frontend.mu';
+    const DIRECTUS_PROJECT_URL = 'https://directus.coders.mu';
 
     try {
         // Make a POST request to /files in the Directus instance

--- a/packages/frontendmu-astro/api/vercel-function-auth-picture.ts
+++ b/packages/frontendmu-astro/api/vercel-function-auth-picture.ts
@@ -6,7 +6,7 @@ const googleClientId = process.env.AUTH_GOOGLE_CLIENT_ID;
 const googleClientSecret = process.env.AUTH_GOOGLE_CLIENT_SECRET;
 
 
-const directusApiEndpoint = 'https://directus.frontend.mu/users/me';
+const directusApiEndpoint = 'https://directus.coders.mu/users/me';
 
 async function fetchPicture(accessToken: string) {
 	let result = await fetch(directusApiEndpoint, {
@@ -88,7 +88,7 @@ async function uploadImageToDirectus(imageUrl: string, directusAccessToken: stri
 
 	let base64String = await fromUrlToBase64(imageUrl);
 
-	const DIRECTUS_PROJECT_URL = 'https://directus.frontend.mu';
+	const DIRECTUS_PROJECT_URL = 'https://directus.coders.mu';
 
 	try {
 		// Make a POST request to /files in the Directus instance

--- a/packages/frontendmu-astro/astro.config.mjs
+++ b/packages/frontendmu-astro/astro.config.mjs
@@ -4,7 +4,7 @@ import sitemap from "@astrojs/sitemap";
 import Icons from "unplugin-icons/vite";
 import vue from "@astrojs/vue";
 import sentry from "@sentry/astro";
-let site = "https://frontend.mu";
+let site = "https://coders.mu";
 
 // https://vercel.com/docs/concepts/projects/environment-variables/system-environment-variables
 if (

--- a/packages/frontendmu-astro/scripts/directus-client.js
+++ b/packages/frontendmu-astro/scripts/directus-client.js
@@ -2,7 +2,7 @@ import { createDirectus, rest } from '@directus/sdk';
 
 const getDirectusClient = async () => {
   // const directus = new Directus();
-  const client = createDirectus('https://directus.frontend.mu').with(rest());
+  const client = createDirectus('https://directus.coders.mu').with(rest());
   return client;
 };
 

--- a/packages/frontendmu-astro/src/auth-utils/useAuth.ts
+++ b/packages/frontendmu-astro/src/auth-utils/useAuth.ts
@@ -112,7 +112,7 @@ export default function useAuth(client: DirectusClient<any> & AuthenticationClie
     async function loginWithSSO() {
         try {
             const res = await fetch(
-                "https://directus.frontend.mu/auth/refresh",
+                "https://directus.coders.mu/auth/refresh",
                 {
                     method: "POST",
                     credentials: "include", // this is required in order to send the refresh token cookie
@@ -280,7 +280,7 @@ export default function useAuth(client: DirectusClient<any> & AuthenticationClie
         if (eventListIds.includes(parseInt(eventId))) {
             // console.log('Already RSVPd, skipping')
         } else {
-            const result = await fetch(`https://directus.frontend.mu/users/me`, {
+            const result = await fetch(`https://directus.coders.mu/users/me`, {
                 method: "PATCH",
                 headers: {
                     "Content-Type": "application/json",
@@ -422,7 +422,7 @@ export default function useAuth(client: DirectusClient<any> & AuthenticationClie
 
     async function cloudFunctionUpdateProfilePicture(userId) {
 
-        const FUNCTION_AUTH_PICTURE_URL = `https://auth-picture.frontend.mu/`
+        const FUNCTION_AUTH_PICTURE_URL = `https://auth-picture.coders.mu/`
 
         const result = await fetch(FUNCTION_AUTH_PICTURE_URL, {
             method: 'POST',

--- a/packages/frontendmu-astro/src/components/EventJSONLD.astro
+++ b/packages/frontendmu-astro/src/components/EventJSONLD.astro
@@ -61,7 +61,7 @@ const schema = {
     {
       "@type": "Organization",
       name: "Frontend Coders Mauritius",
-      url: "https://frontend.mu",
+      url: "https://coders.mu",
     },
   ],
   keywords: [

--- a/packages/frontendmu-astro/src/components/Meetup.vue
+++ b/packages/frontendmu-astro/src/components/Meetup.vue
@@ -205,7 +205,7 @@ const viewMore = () => {
                     <dd class="flex justify-between rounded-md bg-gray-100 mt-2 px-2 py-1 lg:w-[450px]">
                       <input id="myInput"
                         class="text-md break-words bg-gray-100pr-2 tracking-tight bg-gray-100 text-gray-600 line-clamp-3 w-[500px]"
-                        type="text" :value="`https://frontend.mu/meetup/${props.routeId}/`" />
+                        type="text" :value="`https://coders.mu/meetup/${props.routeId}/`" />
                       <div class="cursor-pointer" @click="copy">
                         <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
                           <path d="M8 3a1 1 0 011-1h2a1 1 0 110 2H9a1 1 0 01-1-1z" />

--- a/packages/frontendmu-astro/src/components/MeetupSingle.astro
+++ b/packages/frontendmu-astro/src/components/MeetupSingle.astro
@@ -61,8 +61,6 @@ function fetchAlbumDetails(albumName: string | null) {
   }
 }
 
-
-
 let currentAlbum = fetchAlbumDetails(props.getCurrentEvent.album);
 ---
 
@@ -119,7 +117,6 @@ let currentAlbum = fetchAlbumDetails(props.getCurrentEvent.album);
             </div>
 
             <MeetupSonspor sponsors={props.getCurrentEvent.sponsors} />
-            
           </div>
         </div>
       </div>
@@ -277,7 +274,7 @@ let currentAlbum = fetchAlbumDetails(props.getCurrentEvent.album);
                     id="myInput"
                     class="text-md break-words bg-gray-100pr-2 tracking-tight bg-gray-100 text-gray-600 line-clamp-3 w-[500px]"
                     type="text"
-                    value={`https://frontend.mu/meetup/${props.routeId}/`}
+                    value={`https://coders.mu/meetup/${props.routeId}/`}
                     onclick="copy();"
                   />
                   <div class="cursor-pointer" onclick="copy();">

--- a/packages/frontendmu-astro/src/components/MeetupSonspor.astro
+++ b/packages/frontendmu-astro/src/components/MeetupSonspor.astro
@@ -29,7 +29,7 @@ let sponsorTypeMap = {
               <Image
                 class="h-16 w-20 md:w-auto object-contain md:object-cover"
                 src={
-                  `https://directus.frontend.mu/assets/` +
+                  `https://directus.coders.mu/assets/` +
                   sponsor.Sponsor_id.Logo.filename_disk
                 }
                 alt={sponsor.Sponsor_id.Name}

--- a/packages/frontendmu-astro/src/components/SpeakerSingle.astro
+++ b/packages/frontendmu-astro/src/components/SpeakerSingle.astro
@@ -132,7 +132,7 @@ const speaker_photo = getGithubUrl(props.speaker.person.github_account);
                     id="myInput"
                     class="text-md break-words bg-gray-100pr-2 tracking-tight bg-gray-100 text-gray-600 line-clamp-3 w-[500px]"
                     type="text"
-                    value={`https://frontend.mu/meetup/${props.routeId}/`}
+                    value={`https://coders.mu/meetup/${props.routeId}/`}
                     onclick="copy();"
                   />
                   <div class="cursor-pointer" onclick="copy();">

--- a/packages/frontendmu-astro/src/components/Sponsors.astro
+++ b/packages/frontendmu-astro/src/components/Sponsors.astro
@@ -26,7 +26,7 @@ import HeaderLink from "./HeaderLink.astro";
             >
               We're lucky to have sponsors support our community. If you're
               interested in sponsoring us, please reach out to us <a
-                href="mailto:hello@frontend.mu"
+                href="mailto:sandeep+frontendmu@ramgolam.com"
                 class="underline">here</a
               >.
             </p>

--- a/packages/frontendmu-astro/src/pages/about.astro
+++ b/packages/frontendmu-astro/src/pages/about.astro
@@ -10,7 +10,9 @@ const description = "About us";
 <Layout title={title} description={description}>
   <ContentBlock>
     <BaseHeading class="text-center md:text-left">About us</BaseHeading>
-    <div class="prose text-verse-600 dark:text-verse-300 pt-4 pb-16 text-center md:text-left">
+    <div
+      class="prose text-verse-600 dark:text-verse-300 pt-4 pb-16 text-center md:text-left"
+    >
       <p>
         Front-End Coders Mauritius is a community around front-end development
         based in Mauritius. We also organise monthly meetups free for anyone
@@ -18,7 +20,10 @@ const description = "About us";
       </p>
 
       <p>
-        Do you want to know more? <a class="text-verse-600 dark:text-verse-300" href="mailto:sandeep@ramgolam.com">
+        Do you want to know more? <a
+          class="text-verse-600 dark:text-verse-300"
+          href="mailto:sandeep+frontendmu@ramgolam.com"
+        >
           Get in touch with the organisers
         </a>
       </p>

--- a/packages/frontendmu-astro/src/pages/sponsors.astro
+++ b/packages/frontendmu-astro/src/pages/sponsors.astro
@@ -16,7 +16,7 @@ const description = "";
         <p class="text-xl text-verse-600 dark:text-verse-200">
           We're lucky to have sponsors support our community. If you're
           interested in sponsoring us, please reach out to the organizers <a
-            href="mailto:hello@frontend.mu"
+            href="mailto:sandeep+frontendmu@ramgolam.com"
             class="underline">here</a
           >.
         </p>

--- a/packages/frontendmu-astro/src/utils/helpers.ts
+++ b/packages/frontendmu-astro/src/utils/helpers.ts
@@ -58,9 +58,9 @@ export const mapToValidUser = (user: any): User => {
 
 
 export const DIRECTUS_URL = () => {
-  return 'https://directus.frontend.mu';
+  return 'https://directus.coders.mu';
   // return process.env.NODE_ENV === 'production'
-  //   ? 'https://directus.frontend.mu'
+  //   ? 'https://directus.coders.mu'
   //   : 'http://localhost:8055'
 }
 

--- a/packages/frontendmu-data/scripts/directus-client.js
+++ b/packages/frontendmu-data/scripts/directus-client.js
@@ -2,7 +2,7 @@ import { createDirectus, rest } from '@directus/sdk';
 
 const getDirectusClient = async () => {
   // const directus = new Directus();
-  const client = createDirectus('https://directus.frontend.mu').with(rest());
+  const client = createDirectus('https://directus.coders.mu').with(rest());
   return client;
 };
 

--- a/packages/frontendmu-nuxt/auth-utils/useAuth.ts
+++ b/packages/frontendmu-nuxt/auth-utils/useAuth.ts
@@ -108,7 +108,7 @@ export default function useAuth(client: DirectusClient<any> & AuthenticationClie
   async function loginWithSSO() {
     try {
       const res = await fetch(
-        'https://directus.frontend.mu/auth/refresh',
+        'https://directus.coders.mu/auth/refresh',
         {
           method: 'POST',
           credentials: 'include', // this is required in order to send the refresh token cookie
@@ -290,7 +290,7 @@ export default function useAuth(client: DirectusClient<any> & AuthenticationClie
       // console.log('Already RSVPd, skipping')
     }
     else {
-      const result = await fetch(`https://directus.frontend.mu/users/me`, {
+      const result = await fetch(`https://directus.coders.mu/users/me`, {
         method: 'PATCH',
         headers: {
           'Content-Type': 'application/json',
@@ -434,7 +434,7 @@ export default function useAuth(client: DirectusClient<any> & AuthenticationClie
   }
 
   async function cloudFunctionUpdateProfilePicture(userId: string) {
-    const FUNCTION_AUTH_PICTURE_URL = `https://auth-picture.frontend.mu/`
+    const FUNCTION_AUTH_PICTURE_URL = `https://auth-picture.coders.mu/`
 
     const result = await fetch(FUNCTION_AUTH_PICTURE_URL, {
       method: 'POST',

--- a/packages/frontendmu-nuxt/components/home/SponsorHighlight.vue
+++ b/packages/frontendmu-nuxt/components/home/SponsorHighlight.vue
@@ -13,12 +13,16 @@ import sponsors from '../../../frontendmu-data/data/sponsors.js'
               <!-- <flip-book class="mt-[-16%] md:mt-[-12%]" /> -->
               <p class="max-w-3xl mx-auto text-xl text-verse-600 dark:text-verse-200 text-center">
                 We're lucky to have sponsors support our community. If you're
-                interested in sponsoring us, <a href="mailto:hello@frontend.mu" title="Email us"
-                  class="underline">please reach out to us here</a>.
+                interested in sponsoring us, <a
+                  href="mailto:sandeep+frontendmu@ramgolam.com" title="Email us"
+                  class="underline"
+                >please reach out to us here</a>.
               </p>
               <div class="grid place-items-center">
-                <NuxtLink to="/sponsors"
-                  class="bg-verse-500 hover:bg-verse-600 transition-colors duration-200 text-md block w-48 rounded-full px-4 py-4 text-center font-medium text-white md:w-52 md:px-6 md:text-lg">
+                <NuxtLink
+                  to="/sponsors"
+                  class="bg-verse-500 hover:bg-verse-600 transition-colors duration-200 text-md block w-48 rounded-full px-4 py-4 text-center font-medium text-white md:w-52 md:px-6 md:text-lg"
+                >
                   View all sponsors
                 </NuxtLink>
               </div>
@@ -27,16 +31,20 @@ import sponsors from '../../../frontendmu-data/data/sponsors.js'
             <div class="grid grid-cols-2 md:grid-cols-3 xl:grid-cols-5 gap-4">
               <template v-for="sponsorType of sponsors">
                 <template v-for="sponsor of sponsorType.sponsors" :key="sponsor.name">
-                  <a :title="sponsor.description" target="_blank" :href="sponsor.sponsorUrl"
-                    class="mt-4 h-full md:mt-0 relative rounded-xl  flex justify-between items-center flex-col gap-4 group bg-white dark:bg-verse-200 dark:backdrop-blur-sm p-6 shadow-md transition-all hover:shadow-lg">
+                  <a
+                    :title="sponsor.description" target="_blank" :href="sponsor.sponsorUrl"
+                    class="mt-4 h-full md:mt-0 relative rounded-xl  flex justify-between items-center flex-col gap-4 group bg-white dark:bg-verse-200 dark:backdrop-blur-sm p-6 shadow-md transition-all hover:shadow-lg"
+                  >
                     <div>
                       <span class="text-2xl font-bold text-center w-full block dark:text-verse-900">
                         {{ sponsor.name }}
                       </span>
                     </div>
                     <img :src="`/img/sponsors/${sponsor.logo}`" :alt="sponsor.description">
-                    <div v-if="sponsor.description"
-                      class="bg-gray-300 py-1 px-4 text-xs w-full text-center text-gray-500 dark:text-black font-medium rounded-2xl self-end">
+                    <div
+                      v-if="sponsor.description"
+                      class="bg-gray-300 py-1 px-4 text-xs w-full text-center text-gray-500 dark:text-black font-medium rounded-2xl self-end"
+                    >
                       {{ sponsor.description }}
                     </div>
                   </a>

--- a/packages/frontendmu-nuxt/components/meetup/Sponsor.vue
+++ b/packages/frontendmu-nuxt/components/meetup/Sponsor.vue
@@ -23,7 +23,7 @@ function sponsorClassList(sponsor) {
 }
 
 function sponsorLogoUrl(sponsor) {
-  return `https://directus.frontend.mu/assets/${sponsor.Sponsor_id.Logo.filename_disk}`
+  return `https://directus.coders.mu/assets/${sponsor.Sponsor_id.Logo.filename_disk}`
 }
 </script>
 

--- a/packages/frontendmu-nuxt/components/site/MeetupSponsors.vue
+++ b/packages/frontendmu-nuxt/components/site/MeetupSponsors.vue
@@ -2,7 +2,7 @@
 import type { Sponsor } from '@/utils/types'
 
 function sponsorLogoUrl(sponsor: Sponsor) {
-  return `https://directus.frontend.mu/assets/${sponsor.Sponsor_id.Logo.filename_disk}`
+  return `https://directus.coders.mu/assets/${sponsor.Sponsor_id.Logo.filename_disk}`
 }
 
 const { allSponsors } = useMeetups({})

--- a/packages/frontendmu-nuxt/components/site/Menu.vue
+++ b/packages/frontendmu-nuxt/components/site/Menu.vue
@@ -80,7 +80,7 @@ const links: TMenu = {
       },
       {
         title: 'Advent Calendar',
-        href: 'https://advent.frontend.mu',
+        href: 'https://advent.coders.mu',
         class: 'external-link',
         target: '_blank',
         rel: 'noopener noreferrer',
@@ -107,7 +107,7 @@ const links: TMenu = {
   },
   // advent: {
   //   title: 'Advent Calendar',
-  //   href: 'https://advent.frontend.mu',
+  //   href: 'https://advent.coders.mu',
   //   class: 'external-link',
   //   target: '_blank',
   //   rel: 'noopener noreferrer',
@@ -190,8 +190,10 @@ onMounted(toggleHeader)
     <div class="menu theme-light w-full">
       <div class="flex justify-between items-center contain">
         <div class="flex">
-          <NuxtLink href="/" class="flex gap-2 text-verse-500 dark:text-verse-200" title="frontend.mu"
-            @contextmenu="handleRightClick">
+          <NuxtLink
+            href="/" class="flex gap-2 text-verse-500 dark:text-verse-200" title="frontend.mu"
+            @contextmenu="handleRightClick"
+          >
             <SiteLogo class="w-10" />
             <span class="hidden text-lg font-bold leading-none tracking-tighter md:text-3xl md:block">
               frontend.mu

--- a/packages/frontendmu-nuxt/nuxt.config.ts
+++ b/packages/frontendmu-nuxt/nuxt.config.ts
@@ -70,7 +70,7 @@ export default defineNuxtConfig({
   },
 
   site: {
-    url: 'https://frontend.mu',
+    url: 'https://coders.mu',
     name: 'Front-End Coders Mauritius',
     description: 'A community around frontend, tech and development in general based in Mauritius. We also organise monthly meetups free for anyone interested to attend.',
     defaultLocale: 'en', // not needed if you have @nuxtjs/i18n installed

--- a/packages/frontendmu-nuxt/pages/about.vue
+++ b/packages/frontendmu-nuxt/pages/about.vue
@@ -15,7 +15,7 @@ const description = "About us";
 
       <p>
         Do you want to know more? <a class="text-verse-600 dark:text-verse-300"
-                                     href="mailto:sandeep@ramgolam.com"
+                                     href="mailto:sandeep+frontendmu@ramgolam.com"
         >
           Get in touch with the organisers
         </a>

--- a/packages/frontendmu-nuxt/pages/sponsors.vue
+++ b/packages/frontendmu-nuxt/pages/sponsors.vue
@@ -14,7 +14,7 @@ const description = "";
         <p class="text-xl text-verse-600 dark:text-verse-200">
           We're lucky to have sponsors support our community. If you're
           interested in sponsoring us,<a
-            href="mailto:hello@frontend.mu"
+            href="mailto:sandeep+frontendmu@ramgolam.com"
             class="underline hover:bg-verse-50 dark:bg-verse-950"
             title="Please reach out to us via email"
           >

--- a/packages/frontendmu-nuxt/utils/helpers.ts
+++ b/packages/frontendmu-nuxt/utils/helpers.ts
@@ -59,9 +59,9 @@ export function mapToValidUser(user: any): User {
 }
 
 export function DIRECTUS_URL() {
-  return 'https://directus.frontend.mu'
+  return 'https://directus.coders.mu'
   // return process.env.NODE_ENV === 'production'
-  //   ? 'https://directus.frontend.mu'
+  //   ? 'https://directus.coders.mu'
   //   : 'http://localhost:8055'
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated all website, API, and asset URLs from frontend.mu to coders.mu across the platform.
  - Updated contact and sponsorship email addresses to sandeep+frontendmu@ramgolam.com.
- **Documentation**
  - Revised the README to reflect the new live website URL.
- **Style**
  - Minor formatting improvements in some component templates for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->