### PR TITLE
fix: pnpm version

### DIFF
--- a/.github/workflows/directus-data-sync.yml
+++ b/.github/workflows/directus-data-sync.yml
@@ -23,8 +23,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9.2.0
 
       - name: Install dependencies
         run: pnpm install --filter @frontend.mu/data


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration to use the default pnpm version provided by the setup action, removing the explicit version pin. This reduces maintenance overhead and aligns with upstream defaults.
  * No impact on product functionality or UI. Builds and deployments continue as expected; no action required from users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->