### PR TITLE
fix: crash on meetups page when nextMeetup is undefined

### DIFF
--- a/packages/frontendmu-nuxt/pages/meetups.vue
+++ b/packages/frontendmu-nuxt/pages/meetups.vue
@@ -4,7 +4,7 @@ import { isDateToday } from '../utils/helpers'
 
 const { allMeetups, meetupsGroupedByYear, nextMeetup, todaysMeetups } = useMeetups({})
 
-const nextMeetupId = nextMeetup.value.id
+const nextMeetupId = nextMeetup.value?.id
 </script>
 
 <template>


### PR DESCRIPTION
This PR fixes a 500 error on the /meetups page that occurs when there are no upcoming meetups. It adds optional chaining to the `nextMeetup.value.id` access.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Strengthened meetups page stability by implementing more defensive data access patterns that safely handle cases where meetup details may be temporarily unavailable, preventing potential runtime errors and ensuring reliable functionality during page load and data transitions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->