### PR TITLE
Refine Adonis mobile navigation

### DIFF
--- a/packages/frontendmu-adonis/inertia/components/layout/Menu.vue
+++ b/packages/frontendmu-adonis/inertia/components/layout/Menu.vue
@@ -766,7 +766,7 @@ onUnmounted(() => {
                 </button>
               </div>
 
-              <div class="shrink-0">
+              <div class="shrink-0 -translate-x-px">
                 <slot name="dock-right" />
               </div>
             </div>

--- a/packages/frontendmu-adonis/inertia/components/shared/ColorModeToggle.vue
+++ b/packages/frontendmu-adonis/inertia/components/shared/ColorModeToggle.vue
@@ -33,7 +33,8 @@ onMounted(() => {
 
 <template>
   <button
-    class="group relative w-10 h-10 flex items-center justify-center rounded-xl squircle bg-gray-50 dark:bg-verse-900/40 border border-gray-100 dark:border-verse-800 transition-all hover:border-verse-500 hover:bg-white dark:hover:bg-verse-900 active:scale-95"
+    type="button"
+    class="group relative inline-flex h-11 w-11 items-center justify-center rounded-2xl border border-gray-100 bg-white text-gray-600 shadow-sm transition-all hover:border-verse-500/30 hover:bg-white hover:text-verse-500 active:scale-95 dark:border-verse-800 dark:bg-verse-950/70 dark:text-gray-300 dark:hover:border-verse-600 dark:hover:bg-verse-950/70 dark:hover:text-verse-300"
     @click="cycleMode"
     aria-label="Toggle color mode"
   >


### PR DESCRIPTION
## Summary
- rework the Adonis mobile navigation into an accessible modal/disclosure menu
- animate the mobile menu shell from the header bar and align the close button with the menu trigger
- polish spacing with shared mobile insets and a cleaner quick actions layout

## Screenshots
### Closed state (dark mode)
![Closed mobile header dark mode](https://gist.githubusercontent.com/cedpoilly/9a2bfa77372477ba1b725a24d6ddb97e/raw/771597587e365e5e89012aaeddddb7027e25222f/pr-mobile-menu-closed-dark.svg)

### Open state (dark mode)
![Open mobile menu dark mode](https://gist.githubusercontent.com/cedpoilly/9a2bfa77372477ba1b725a24d6ddb97e/raw/45ced1b85e5332d0793605f22b9eb11b9057e3a4/pr-mobile-menu-open-dark.svg)

## Testing
- manually verified the mobile menu locally and over the LAN dev server
- automated tests not run


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mobile navigation drawer with expandable menu sections and quick actions
  * Keyboard navigation support for mobile menu interactions
  * Enhanced focus management and accessibility features

* **Style**
  * Refreshed color mode toggle button styling and hover interactions
  * Improved mobile menu visual design with dark mode support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->