### PR TITLE
Run pending migrations during deploy

### DIFF
--- a/.github/workflows/deploy-adonis.yml
+++ b/.github/workflows/deploy-adonis.yml
@@ -46,10 +46,17 @@ jobs:
           key: ${{ secrets.VPS_SSH_KEY }}
           envs: GHCR_TOKEN
           script: |
+            set -euo pipefail
             cd /root/frontend.mu/packages/frontendmu-adonis
             git pull
             echo "$GHCR_TOKEN" | docker login ghcr.io -u github --password-stdin
             docker pull ghcr.io/frontendmu/frontend.mu/adonis:latest
+            # Run pending migrations against the freshly pulled image before
+            # rolling traffic over. `docker compose run --rm` uses the new image
+            # with the service's volume mounts and env, then disposes the
+            # container. If a migration fails, the deploy halts here so the
+            # currently-running app keeps serving requests.
+            DOMAIN=coders.mu docker compose run --rm app node ace migration:run --force
             DOMAIN=coders.mu docker compose up -d
         env:
           GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Deploys currently rebuild and restart the container but never apply schema changes. Any PR that ships a migration leaves production out of sync until someone SSHes in and runs `ace migration:run --force` by hand.

The slug migration from #333 was the latest casualty — UUID-based meetup routes kept working, but every slug-based route (including the /api-docs examples) failed in production because slugs were never backfilled.

## Change

Inserts a single step into the deploy script that runs pending migrations against the freshly pulled image, before the rolling restart:

```sh
DOMAIN=coders.mu docker compose run --rm app node ace migration:run --force
```

- `docker compose run --rm` starts a one-shot container from the new image with the same volume mounts and env as the `app` service, then cleans it up
- Running migrations *before* `docker compose up -d` means the app never boots against an out-of-date schema
- `set -euo pipefail` ensures any migration failure halts the script — the currently-running app stays up, traffic keeps flowing, and the issue can be investigated without a half-deployed state

## Test plan

- [x] YAML lint / syntax: workflow parses
- [ ] After merge, merge `main` → `production` and observe the Actions run — the new step should appear and complete with either "Already up to date" (no pending migrations) or the names of migrations it applied
- [ ] Separately, the broken production DB needs a one-time manual `migration:run --force` to backfill the slug column from #333. This PR does not retroactively fix that — it just prevents the next occurrence

## Not included

- Automatic rollback on migration failure — migrations are generally forward-only, and a loud halt is safer than best-effort rollback for a low-traffic admin app

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**No user-facing changes in this release.**

* **Chores**
  * Enhanced deployment reliability with improved error handling and database migration validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->