### PR TITLE
Restore meetup photo galleries via google-photos-sync

### DIFF
--- a/packages/frontendmu-adonis/app/models/event_photo.ts
+++ b/packages/frontendmu-adonis/app/models/event_photo.ts
@@ -1,11 +1,19 @@
 import { DateTime } from 'luxon'
-import { BaseModel, column, belongsTo } from '@adonisjs/lucid/orm'
+import { randomUUID } from 'node:crypto'
+import { BaseModel, column, belongsTo, beforeCreate } from '@adonisjs/lucid/orm'
 import type { BelongsTo } from '@adonisjs/lucid/types/relations'
 import Event from '#models/event'
 
 export default class EventPhoto extends BaseModel {
+  static selfAssignPrimaryKey = true
+
   @column({ isPrimary: true })
   declare id: string
+
+  @beforeCreate()
+  static assignUuid(photo: EventPhoto) {
+    if (!photo.id) photo.id = randomUUID()
+  }
 
   @column()
   declare eventId: string

--- a/packages/frontendmu-adonis/app/transformers/event_transformer.ts
+++ b/packages/frontendmu-adonis/app/transformers/event_transformer.ts
@@ -6,6 +6,10 @@ import type Sponsor from '#models/sponsor'
 import SessionTransformer from '#transformers/session_transformer'
 import SponsorTransformer from '#transformers/sponsor_transformer'
 
+function thumbnailFor(url: string, width: number): string {
+  return `https://images.weserv.nl/?url=${encodeURIComponent(url)}&w=${width}&output=webp`
+}
+
 export default class EventTransformer extends BaseTransformer<Event> {
   toObject() {
     const sessions = (
@@ -51,6 +55,7 @@ export default class EventTransformer extends BaseTransformer<Event> {
       photos: photos.map((photo) => ({
         id: photo.id,
         photoUrl: photo.photoUrl,
+        thumbnailUrl: thumbnailFor(photo.photoUrl, 800),
         caption: photo.caption,
       })),
     }

--- a/packages/frontendmu-adonis/commands/photos_sync.ts
+++ b/packages/frontendmu-adonis/commands/photos_sync.ts
@@ -1,0 +1,92 @@
+import { BaseCommand } from '@adonisjs/core/ace'
+import type { CommandOptions } from '@adonisjs/core/types/ace'
+import Event from '#models/event'
+import EventPhoto from '#models/event_photo'
+
+const INDEX_URL = 'https://raw.githubusercontent.com/frontendmu/google-photos-sync/main/index.json'
+const CDN_BASE = 'https://cdn.jsdelivr.net/gh/frontendmu/google-photos-sync@main/'
+
+export default class PhotosSync extends BaseCommand {
+  static commandName = 'photos:sync'
+  static description = 'Sync event_photos rows from the google-photos-sync index.json'
+
+  static options: CommandOptions = {
+    startApp: true,
+  }
+
+  async run() {
+    this.logger.info(`Fetching ${INDEX_URL}`)
+    const response = await fetch(INDEX_URL)
+    if (!response.ok) {
+      this.logger.error(`Failed to fetch index.json: ${response.status} ${response.statusText}`)
+      this.exitCode = 1
+      return
+    }
+
+    const raw = (await response.json()) as Record<string, string[]>
+    const index = new Map<string, string[]>()
+    for (const [key, paths] of Object.entries(raw)) {
+      index.set(key.trim(), paths)
+    }
+    this.logger.info(`Loaded ${index.size} albums from index.json`)
+
+    const events = await Event.query().whereNotNull('albumName')
+    this.logger.info(`Found ${events.length} events with album_name`)
+
+    let added = 0
+    let removed = 0
+    let reordered = 0
+    let skipped = 0
+
+    for (const event of events) {
+      const album = event.albumName!.trim()
+      const paths = index.get(album)
+      if (!paths) {
+        this.logger.warning(`  [skip] ${event.title} — "${album}" not in index.json`)
+        skipped++
+        continue
+      }
+
+      const desired = paths.map((p, order) => ({ photoUrl: CDN_BASE + p, order }))
+      const desiredByUrl = new Map(desired.map((d) => [d.photoUrl, d]))
+
+      const existing = await EventPhoto.query().where('eventId', event.id)
+      const existingByUrl = new Map(existing.map((p) => [p.photoUrl, p]))
+
+      const toAdd = desired.filter((d) => !existingByUrl.has(d.photoUrl))
+      if (toAdd.length) {
+        await EventPhoto.createMany(
+          toAdd.map((d) => ({
+            eventId: event.id,
+            photoUrl: d.photoUrl,
+            order: d.order,
+          }))
+        )
+        added += toAdd.length
+      }
+
+      for (const photo of existing) {
+        const d = desiredByUrl.get(photo.photoUrl)
+        if (d && d.order !== photo.order) {
+          photo.order = d.order
+          await photo.save()
+          reordered++
+        }
+      }
+
+      const toRemoveIds = existing.filter((p) => !desiredByUrl.has(p.photoUrl)).map((p) => p.id)
+      if (toRemoveIds.length) {
+        await EventPhoto.query().whereIn('id', toRemoveIds).delete()
+        removed += toRemoveIds.length
+      }
+
+      this.logger.info(
+        `  [ok]   ${event.title} — +${toAdd.length} -${toRemoveIds.length} total=${desired.length}`
+      )
+    }
+
+    this.logger.success(
+      `Sync complete: +${added} added, -${removed} removed, ${reordered} reordered, ${skipped} skipped`
+    )
+  }
+}

--- a/packages/frontendmu-adonis/config/shield.ts
+++ b/packages/frontendmu-adonis/config/shield.ts
@@ -18,6 +18,8 @@ const shieldConfig = defineConfig({
         'https://avatars.githubusercontent.com',
         'https://github.com',
         'https://lh3.googleusercontent.com',
+        'https://cdn.jsdelivr.net',
+        'https://images.weserv.nl',
       ],
       fontSrc: [`'self'`, 'https://fonts.gstatic.com'],
       connectSrc: [`'self'`, 'https://fonts.googleapis.com', 'https://fonts.gstatic.com'],

--- a/packages/frontendmu-adonis/database/migrations/1776800000000_backfill_2025_album_names.ts
+++ b/packages/frontendmu-adonis/database/migrations/1776800000000_backfill_2025_album_names.ts
@@ -1,0 +1,34 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+const BACKFILL: Array<{ slug: string; albumName: string }> = [
+  { slug: '2025-september', albumName: '2025 September Selected' },
+  { slug: '2025-october', albumName: '2025 October Selected' },
+]
+
+export default class extends BaseSchema {
+  protected tableName = 'events'
+
+  async up() {
+    this.defer(async (db) => {
+      for (const { slug, albumName } of BACKFILL) {
+        await db
+          .from(this.tableName)
+          .where('slug', slug)
+          .whereNull('album_name')
+          .update({ album_name: albumName })
+      }
+    })
+  }
+
+  async down() {
+    this.defer(async (db) => {
+      for (const { slug, albumName } of BACKFILL) {
+        await db
+          .from(this.tableName)
+          .where('slug', slug)
+          .where('album_name', albumName)
+          .update({ album_name: null })
+      }
+    })
+  }
+}

--- a/packages/frontendmu-adonis/inertia/pages/meetups/show.vue
+++ b/packages/frontendmu-adonis/inertia/pages/meetups/show.vue
@@ -198,13 +198,51 @@ function handleScroll() {
   }
 }
 
+// Lightbox
+const lightboxIndex = ref<number | null>(null)
+const photos = computed(() => props.meetup?.photos ?? [])
+const activePhoto = computed(() =>
+  lightboxIndex.value !== null ? photos.value[lightboxIndex.value] : null
+)
+
+function openLightbox(index: number) {
+  lightboxIndex.value = index
+  document.body.style.overflow = 'hidden'
+}
+
+function closeLightbox() {
+  lightboxIndex.value = null
+  document.body.style.overflow = ''
+}
+
+function nextPhoto() {
+  if (lightboxIndex.value === null) return
+  lightboxIndex.value = (lightboxIndex.value + 1) % photos.value.length
+}
+
+function prevPhoto() {
+  if (lightboxIndex.value === null) return
+  lightboxIndex.value =
+    (lightboxIndex.value - 1 + photos.value.length) % photos.value.length
+}
+
+function handleLightboxKey(e: KeyboardEvent) {
+  if (lightboxIndex.value === null) return
+  if (e.key === 'Escape') closeLightbox()
+  else if (e.key === 'ArrowRight') nextPhoto()
+  else if (e.key === 'ArrowLeft') prevPhoto()
+}
+
 onMounted(() => {
   window.addEventListener('scroll', handleScroll, { passive: true })
+  window.addEventListener('keydown', handleLightboxKey)
   highlightChangedSection()
 })
 
 onUnmounted(() => {
   window.removeEventListener('scroll', handleScroll)
+  window.removeEventListener('keydown', handleLightboxKey)
+  document.body.style.overflow = ''
 })
 
 // Highlight a section when arriving via ?changed=<section> from a notification link.
@@ -555,18 +593,20 @@ const calendarUrl = computed(() => {
                 <div class="h-px flex-1 bg-gray-100 dark:bg-verse-900"></div>
               </div>
               <div class="grid grid-cols-2 md:grid-cols-3 gap-3">
-                <div
-                  v-for="photo in meetup.photos"
+                <button
+                  v-for="(photo, index) in meetup.photos"
                   :key="photo.id"
-                  class="relative rounded-lg overflow-hidden aspect-[4/3]"
+                  type="button"
+                  class="relative rounded-lg overflow-hidden aspect-[4/3] group focus:outline-none focus:ring-2 focus:ring-verse-500"
+                  @click="openLightbox(index)"
                 >
                   <img
                     :src="photo.thumbnailUrl"
                     :alt="photo.caption || 'Event photo'"
                     loading="lazy"
-                    class="w-full h-full object-cover"
+                    class="w-full h-full object-cover transition-transform duration-200 group-hover:scale-105"
                   />
-                </div>
+                </button>
               </div>
             </section>
           </div>
@@ -904,6 +944,73 @@ const calendarUrl = computed(() => {
               RSVP
             </button>
           </template>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+
+  <!-- Photo Lightbox -->
+  <Teleport to="body">
+    <Transition
+      enter-active-class="transition-opacity duration-150"
+      leave-active-class="transition-opacity duration-150"
+      enter-from-class="opacity-0"
+      leave-to-class="opacity-0"
+    >
+      <div
+        v-if="activePhoto && meetup"
+        class="fixed inset-0 z-50 bg-black/90 flex items-center justify-center"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Photo viewer"
+        @click.self="closeLightbox"
+      >
+        <button
+          type="button"
+          class="absolute top-4 right-4 w-10 h-10 flex items-center justify-center text-white/80 hover:text-white rounded-full hover:bg-white/10 transition-colors"
+          aria-label="Close"
+          @click="closeLightbox"
+        >
+          <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+
+        <button
+          v-if="meetup.photos.length > 1"
+          type="button"
+          class="absolute left-4 top-1/2 -translate-y-1/2 w-12 h-12 flex items-center justify-center text-white/80 hover:text-white rounded-full bg-black/40 hover:bg-black/60 transition-colors"
+          aria-label="Previous photo"
+          @click="prevPhoto"
+        >
+          <svg class="w-7 h-7" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
+          </svg>
+        </button>
+
+        <button
+          v-if="meetup.photos.length > 1"
+          type="button"
+          class="absolute right-4 top-1/2 -translate-y-1/2 w-12 h-12 flex items-center justify-center text-white/80 hover:text-white rounded-full bg-black/40 hover:bg-black/60 transition-colors"
+          aria-label="Next photo"
+          @click="nextPhoto"
+        >
+          <svg class="w-7 h-7" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+          </svg>
+        </button>
+
+        <img
+          :key="activePhoto.id"
+          :src="activePhoto.photoUrl"
+          :alt="activePhoto.caption || 'Event photo'"
+          class="max-w-[95vw] max-h-[90vh] object-contain select-none"
+        />
+
+        <div
+          class="absolute bottom-4 left-1/2 -translate-x-1/2 px-3 py-1 rounded-full bg-black/50 text-white text-xs font-medium tabular-nums"
+        >
+          {{ (lightboxIndex ?? 0) + 1 }} / {{ meetup.photos.length }}
         </div>
       </div>
     </Transition>

--- a/packages/frontendmu-adonis/inertia/pages/meetups/show.vue
+++ b/packages/frontendmu-adonis/inertia/pages/meetups/show.vue
@@ -556,34 +556,18 @@ const calendarUrl = computed(() => {
               </div>
               <div class="grid grid-cols-2 md:grid-cols-3 gap-3">
                 <div
-                  v-for="photo in meetup.photos.slice(0, 6)"
+                  v-for="photo in meetup.photos"
                   :key="photo.id"
                   class="relative rounded-lg overflow-hidden aspect-[4/3]"
                 >
                   <img
-                    :src="photo.photoUrl"
+                    :src="photo.thumbnailUrl"
                     :alt="photo.caption || 'Event photo'"
+                    loading="lazy"
                     class="w-full h-full object-cover"
                   />
                 </div>
               </div>
-              <a
-                v-if="meetup.album"
-                :href="meetup.album"
-                target="_blank"
-                rel="noopener noreferrer"
-                class="inline-flex items-center gap-2 text-sm font-bold text-verse-500 hover:text-verse-600 transition-colors"
-              >
-                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                    d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
-                  />
-                </svg>
-                View full album
-              </a>
             </section>
           </div>
 


### PR DESCRIPTION
## Summary

- Adds a new \`node ace photos:sync\` command that reads the \`index.json\` from [frontendmu/google-photos-sync](https://github.com/frontendmu/google-photos-sync), matches keys against each event's \`album_name\`, and upserts \`event_photos\` rows. Idempotent — inserts new photos, removes ones that disappeared upstream, and re-orders when the album order shifts.
- Images are served through **jsDelivr** (\`cdn.jsdelivr.net/gh/frontendmu/google-photos-sync@main/…\`) so the VPS never proxies the bytes. Gallery thumbnails go through **images.weserv.nl** at 800px for quick grid loads; the lightbox uses the full-size jsDelivr URL.
- Reworks the meetup page gallery: all photos in the curated album render inline (previously capped at 6), and clicking any thumbnail opens a fullscreen carousel with arrow-key / backdrop-click / Esc controls.
- Drops the stale "View full album" link — \`album_name\` is a text key now, not a URL, so the link was broken.
- Backfill migration adds \`album_name\` to the 2025 September and October meetups that had drifted to null during the Directus → Adonis import, recovering 38 photos.
- CSP \`imgSrc\` now whitelists \`cdn.jsdelivr.net\` and \`images.weserv.nl\` — without these the browser blocks every image.

## Commits

1. Auto-assign UUID when creating EventPhoto
2. Allow jsDelivr and weserv.nl as image sources in CSP
3. Add \`photos:sync\` command to hydrate event galleries from google-photos-sync
4. Render full curated album inline via resized thumbnails
5. Add photo lightbox modal to meetup page
6. Backfill album_name for 2025 September and October meetups

## Deploy hookup

Add \`node ace photos:sync\` to the post-deploy step. A daily cron is optional — the source repo changes rarely.

## Known gap (out of scope here)

8 pre-2020 meetups have photos stored as direct URLs in \`meetups-raw.json\`'s \`images\` array (not in the Google Photos sync). They'll still show empty galleries until we extend \`photos:sync\` to read that legacy field. Can do in a follow-up.

## Test plan

- [ ] Pull the branch, run \`pnpm install\`, \`node ace migration:run\`, \`node ace photos:sync\`
- [ ] Visit \`/meetups\`, pick any event with an album (e.g. \`/meetup/2025-march\`, \`/meetup/2025-september\`, \`/meetup/2025-october\`)
- [ ] Confirm the Gallery section shows the full curated album (not just 6 photos)
- [ ] Click a thumbnail — modal opens with full-resolution image
- [ ] Arrow keys cycle photos, Esc closes, backdrop click closes
- [ ] Visit an event with no album (e.g. a future upcoming meetup) — no Gallery section rendered
- [ ] Re-run \`node ace photos:sync\` — reports \`+0 added, -0 removed\` (idempotent)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added photo lightbox viewer for meetup pages with keyboard navigation (Arrow keys, Escape)
  * Photos display with optimized thumbnails for improved loading performance
  * New photo synchronization capability from external album sources

* **Improvements**
  * Event photos now have reliable automatic ID generation
  * Images load from additional CDN sources for better performance
  * Album data properly configured for 2025 events

<!-- end of auto-generated comment: release notes by coderabbit.ai -->