### PR TITLE
Add Release to Production workflow

### DIFF
--- a/.github/workflows/deploy-adonis.yml
+++ b/.github/workflows/deploy-adonis.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - packages/frontendmu-adonis/**
       - .github/workflows/deploy-adonis.yml
+  workflow_dispatch:
 
 jobs:
   build-and-push:

--- a/.github/workflows/release-to-production.yml
+++ b/.github/workflows/release-to-production.yml
@@ -1,0 +1,76 @@
+name: Release to Production
+
+on:
+  workflow_dispatch:
+    inputs:
+      note:
+        description: Optional note to include in the release merge commit
+        required: false
+        type: string
+
+concurrency:
+  group: release-to-production
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: production
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Merge main into production
+        id: merge
+        env:
+          NOTE: ${{ inputs.note }}
+        run: |
+          set -euo pipefail
+          git fetch origin main
+
+          if git merge-base --is-ancestor origin/main HEAD; then
+            echo "::notice::production is already up to date with main — nothing to release."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          SUFFIX=""
+          if [ -n "${NOTE:-}" ]; then
+            SUFFIX=" — ${NOTE}"
+          fi
+          git merge --no-ff -m "Release: merge main into production${SUFFIX}" origin/main
+          git push origin production
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Trigger Adonis deploy
+        if: steps.merge.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # A push signed by GITHUB_TOKEN does not trigger other workflows, so we
+          # explicitly dispatch the deploy workflow against the newly-updated
+          # production ref.
+          gh workflow run deploy-adonis.yml --ref production
+
+      - name: Summary
+        if: always()
+        run: |
+          if [ "${{ steps.merge.outputs.changed }}" = "true" ]; then
+            {
+              echo "### Released main → production"
+              echo ""
+              echo "Adonis deploy workflow dispatched against \`production\`."
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "### No changes to release" >> "$GITHUB_STEP_SUMMARY"
+          fi


### PR DESCRIPTION
## Summary

Adds a manual-trigger GitHub Action that merges `main` → `production`, creating a labeled merge commit and explicitly kicking off the Adonis deploy.

## How to use

From the Actions tab → **Release to Production** → **Run workflow**. There's an optional "note" input that gets appended to the merge commit message (useful for "hotfix: X" or release names).

## What the workflow does

1. Checks out `production` with full history
2. Fetches `main`
3. No-ops cleanly if `production` is already up to date with `main` (prints a notice, no merge commit created)
4. Otherwise: creates a `--no-ff` merge commit, pushes to `production`
5. Explicitly dispatches `deploy-adonis.yml` against `production` (see "why explicit dispatch" below)

A `concurrency:` group prevents two releases from racing if someone triggers twice.

## Why explicit dispatch

GitHub intentionally refuses to fan out workflows that were triggered by a `GITHUB_TOKEN`-signed push — it breaks infinite-loop patterns. So if the release job pushes to `production` with the default token, `deploy-adonis.yml` would *not* fire automatically. Two options handle this:

- **A —** use a PAT stored as a secret (cross-repo surface, needs rotation)
- **B —** explicitly dispatch the deploy workflow from the release workflow using `gh workflow run`

This PR uses **B**: it requires one small change to `deploy-adonis.yml` (adding `workflow_dispatch:` alongside the existing `push:` trigger) and no new secrets. The deploy workflow can now also be dispatched manually from the Actions UI, which is a nice side benefit for debugging.

## Test plan

- [ ] Merge this PR to `main`
- [ ] Go to Actions → **Release to Production** → **Run workflow** → optionally add a note, click Run
- [ ] Confirm the `Release: merge main into production` commit appears on the `production` branch
- [ ] Confirm the **Deploy AdonisJS** workflow runs immediately after, against `production`
- [ ] Re-run **Release to Production** with no changes on main; confirm it no-ops with a notice

## Files

- `.github/workflows/release-to-production.yml` (new)
- `.github/workflows/deploy-adonis.yml` (adds `workflow_dispatch:` trigger)