### PR TITLE
Push to protected production branch via RELEASE_TOKEN PAT

### DIFF
--- a/.github/workflows/release-to-production.yml
+++ b/.github/workflows/release-to-production.yml
@@ -17,13 +17,24 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      actions: write
 
     steps:
+      - name: Validate RELEASE_TOKEN secret
+        env:
+          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        run: |
+          if [ -z "${RELEASE_TOKEN:-}" ]; then
+            echo "::error::RELEASE_TOKEN secret is not set. The production branch is protected, so the default GITHUB_TOKEN cannot push to it. Create a fine-grained PAT with Contents: Read and write on this repo, grant its user bypass permission on the production branch protection rule, and store it as the repository secret RELEASE_TOKEN."
+            exit 1
+          fi
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: production
+          # RELEASE_TOKEN must be able to bypass branch protection on production.
+          # See the workflow comments in the validation step above.
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Configure git
         run: |
@@ -52,16 +63,6 @@ jobs:
           git push origin production
           echo "changed=true" >> "$GITHUB_OUTPUT"
 
-      - name: Trigger Adonis deploy
-        if: steps.merge.outputs.changed == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          # A push signed by GITHUB_TOKEN does not trigger other workflows, so we
-          # explicitly dispatch the deploy workflow against the newly-updated
-          # production ref.
-          gh workflow run deploy-adonis.yml --ref production
-
       - name: Summary
         if: always()
         run: |
@@ -69,7 +70,7 @@ jobs:
             {
               echo "### Released main → production"
               echo ""
-              echo "Adonis deploy workflow dispatched against \`production\`."
+              echo "The push to \`production\` will fire the Deploy AdonisJS workflow if the merge touched \`packages/frontendmu-adonis/**\` or the deploy workflow file itself."
             } >> "$GITHUB_STEP_SUMMARY"
           else
             echo "### No changes to release" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## What broke

Run [24624072987](https://github.com/frontendmu/frontend.mu/actions/runs/24624072987/job/71999843287) from PR #339 failed with:

```
remote: error: GH006: Protected branch update failed for refs/heads/production.
remote: - You're not authorized to push to this branch.
```

`production` has branch protection, and the default `GITHUB_TOKEN` can't bypass it.

## Fix

Switch the push credential to a user-provided PAT stored as the repository secret `RELEASE_TOKEN`. The workflow also fails fast with an actionable error message if the secret is missing, so a misconfigured repo shows the setup instructions in the run output instead of a cryptic git error deep in the job.

## Setup (one-time, before this workflow works)

1. **Create a fine-grained PAT** at [github.com/settings/personal-access-tokens/new](https://github.com/settings/personal-access-tokens/new):
   - Resource owner: `frontendmu`
   - Repository access: only this repo
   - Permissions → Repository → **Contents: Read and write**
2. **Allow that PAT's user to bypass `production` branch protection**:
   - Repo → Settings → Branches → `production` protection rule
   - If using a classic rule: under *Restrict who can push*, add the PAT's user
   - If using rulesets: under *Bypass list*, add the user
3. **Store the PAT as a repo secret** named `RELEASE_TOKEN` (Settings → Secrets and variables → Actions → New repository secret)

## Side effect: explicit deploy trigger is no longer needed

A push signed by a non-`GITHUB_TOKEN` credential triggers downstream workflows normally — so `deploy-adonis.yml` fires off the push event on its own once this is fixed. This PR removes the explicit `gh workflow run deploy-adonis.yml` step that was in the initial version, which also avoids double-deploys when both the push-trigger and the dispatch-trigger would have fired.

(The `workflow_dispatch:` trigger added to `deploy-adonis.yml` in #339 stays — it's still useful as a manual "re-deploy now" button in the Actions UI.)

## Test plan

- [ ] Merge this PR
- [ ] Set up `RELEASE_TOKEN` as described above
- [ ] Run **Release to Production** from the Actions UI; verify:
  - merge commit lands on `production`
  - **Deploy AdonisJS** workflow starts automatically from the resulting push
- [ ] Run **Release to Production** again with no new main commits; verify it no-ops with a notice
- [ ] Temporarily unset the secret and run once; verify the preflight step fails with the setup message