### PR TITLE
Restrict Release to Production to a maintainer allowlist

### DIFF
--- a/.github/workflows/release-to-production.yml
+++ b/.github/workflows/release-to-production.yml
@@ -14,6 +14,11 @@ concurrency:
 
 jobs:
   release:
+    # Only maintainers can trigger a release. Anyone with repo write access can
+    # press the "Run workflow" button, so this is the explicit allowlist for who
+    # is actually permitted to deploy. Extend by appending usernames to the JSON
+    # array below.
+    if: contains(fromJSON('["MrSunshyne"]'), github.actor)
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Why

`workflow_dispatch` is already gated by repo write access, but that's broader than "who should be able to deploy". On a growing project anyone granted `write` for reviewing / triaging could then accidentally press **Run workflow** and ship whatever's on `main`. An explicit allowlist keeps deploy authority narrow without touching collaborator permissions.

## Change

One job-level guard in `.github/workflows/release-to-production.yml`:

```yaml
if: contains(fromJSON('["MrSunshyne"]'), github.actor)
```

If a user outside the allowlist dispatches the workflow, the job is **skipped** (not failed) and nothing runs. No push, no deploy.

## How to add or remove maintainers

Append usernames to the JSON array in the `if:` expression and open a PR:

```yaml
if: contains(fromJSON('["MrSunshyne", "someone-else"]'), github.actor)
```

## Test plan

- [ ] Merge this PR
- [ ] Run **Release to Production** as `MrSunshyne` → job runs as expected
- [ ] Ask a non-allowlisted collaborator to run it (or simulate by temporarily editing the array to exclude yourself) → job is skipped at dispatch, no merge commit, no deploy

## Related

- #340 — independent fix that makes the workflow actually work against the protected `production` branch. Either order of merge is fine; the diffs don't conflict.