### PR TITLE
Editorial redesign, session kinds, and gallery covers

### DIFF
--- a/packages/frontendmu-adonis/app/controllers/admin/sessions_controller.ts
+++ b/packages/frontendmu-adonis/app/controllers/admin/sessions_controller.ts
@@ -37,13 +37,14 @@ export default class AdminSessionsController {
 
     const data = await request.validateUsing(createSessionValidator)
 
+    const kind = data.kind ?? 'talk'
     const session = await Session.create({
       eventId: event.id,
       title: data.title,
       description: data.description,
       order: data.order,
-      kind: data.kind ?? 'talk',
-      sponsorId: data.sponsorId ?? null,
+      kind,
+      sponsorId: kind === 'sponsored' ? (data.sponsorId ?? null) : null,
       durationMinutes: data.durationMinutes ?? null,
     })
 
@@ -87,12 +88,22 @@ export default class AdminSessionsController {
 
     const data = await request.validateUsing(updateSessionValidator)
 
+    // If the kind changes away from 'sponsored', proactively clear the stale
+    // sponsor link so it can't surface again if kind flips back.
+    const nextKind = data.kind ?? session.kind
+    const sponsorId =
+      nextKind === 'sponsored'
+        ? data.sponsorId !== undefined
+          ? data.sponsorId
+          : session.sponsorId
+        : null
+
     session.merge({
       title: data.title,
       description: data.description,
       order: data.order,
-      ...(data.kind !== undefined ? { kind: data.kind } : {}),
-      ...(data.sponsorId !== undefined ? { sponsorId: data.sponsorId } : {}),
+      kind: nextKind,
+      sponsorId,
       ...(data.durationMinutes !== undefined
         ? { durationMinutes: data.durationMinutes }
         : {}),

--- a/packages/frontendmu-adonis/app/controllers/admin/sessions_controller.ts
+++ b/packages/frontendmu-adonis/app/controllers/admin/sessions_controller.ts
@@ -18,7 +18,7 @@ export default class AdminSessionsController {
     await bouncer.with(SessionPolicy).authorize('create')
 
     await event.load('sessions', (query) => {
-      query.preload('speakers').orderBy('order', 'asc')
+      query.preload('speakers').preload('sponsor').orderBy('order', 'asc')
     })
 
     return response.json({
@@ -42,6 +42,9 @@ export default class AdminSessionsController {
       title: data.title,
       description: data.description,
       order: data.order,
+      kind: data.kind ?? 'talk',
+      sponsorId: data.sponsorId ?? null,
+      durationMinutes: data.durationMinutes ?? null,
     })
 
     if (data.speakerIds && data.speakerIds.length > 0) {
@@ -88,6 +91,11 @@ export default class AdminSessionsController {
       title: data.title,
       description: data.description,
       order: data.order,
+      ...(data.kind !== undefined ? { kind: data.kind } : {}),
+      ...(data.sponsorId !== undefined ? { sponsorId: data.sponsorId } : {}),
+      ...(data.durationMinutes !== undefined
+        ? { durationMinutes: data.durationMinutes }
+        : {}),
     })
 
     await session.save()

--- a/packages/frontendmu-adonis/app/controllers/api/v1/meetups_controller.ts
+++ b/packages/frontendmu-adonis/app/controllers/api/v1/meetups_controller.ts
@@ -13,7 +13,9 @@ export default class PublicMeetupsController {
     const events = await Event.query()
       .where('status', 'published')
       .orderBy('eventDate', 'desc')
-      .preload('sessions', (query) => query.preload('speakers'))
+      .preload('sessions', (query) =>
+        query.preload('speakers').preload('sponsor').orderBy('order', 'asc')
+      )
       .preload('sponsors')
 
     response.header('Cache-Control', CACHE_CONTROL)
@@ -27,7 +29,9 @@ export default class PublicMeetupsController {
     const event = await Event.query()
       .where(column, params.idOrSlug)
       .where('status', 'published')
-      .preload('sessions', (query) => query.preload('speakers'))
+      .preload('sessions', (query) =>
+        query.preload('speakers').preload('sponsor').orderBy('order', 'asc')
+      )
       .preload('sponsors')
       .preload('photos')
       .firstOrFail()
@@ -44,7 +48,9 @@ export default class PublicMeetupsController {
       .where('status', 'published')
       .where('eventDate', '>=', today)
       .orderBy('eventDate', 'asc')
-      .preload('sessions', (query) => query.preload('speakers'))
+      .preload('sessions', (query) =>
+        query.preload('speakers').preload('sponsor').orderBy('order', 'asc')
+      )
       .preload('sponsors')
       .preload('photos')
       .first()

--- a/packages/frontendmu-adonis/app/controllers/api/v1/meetups_controller.ts
+++ b/packages/frontendmu-adonis/app/controllers/api/v1/meetups_controller.ts
@@ -17,6 +17,7 @@ export default class PublicMeetupsController {
         query.preload('speakers').preload('sponsor').orderBy('order', 'asc')
       )
       .preload('sponsors')
+      .preload('photos', (query) => query.orderBy('order', 'asc'))
 
     response.header('Cache-Control', CACHE_CONTROL)
     return response.json(await serialize(EventTransformer.transform(events)))

--- a/packages/frontendmu-adonis/app/controllers/api/v1/meetups_controller.ts
+++ b/packages/frontendmu-adonis/app/controllers/api/v1/meetups_controller.ts
@@ -17,7 +17,7 @@ export default class PublicMeetupsController {
         query.preload('speakers').preload('sponsor').orderBy('order', 'asc')
       )
       .preload('sponsors')
-      .preload('photos', (query) => query.orderBy('order', 'asc'))
+      .preload('photos', (query) => query.orderBy('order', 'asc').groupLimit(1))
 
     response.header('Cache-Control', CACHE_CONTROL)
     return response.json(await serialize(EventTransformer.transform(events)))

--- a/packages/frontendmu-adonis/app/controllers/events_controller.ts
+++ b/packages/frontendmu-adonis/app/controllers/events_controller.ts
@@ -15,6 +15,9 @@ export default class EventsController {
       .preload('sessions', (query) => {
         query.preload('speakers').preload('sponsor').orderBy('order', 'asc')
       })
+      .preload('photos', (query) => {
+        query.orderBy('order', 'asc')
+      })
 
     const meetups = EventTransformer.transform(events)
 

--- a/packages/frontendmu-adonis/app/controllers/events_controller.ts
+++ b/packages/frontendmu-adonis/app/controllers/events_controller.ts
@@ -13,7 +13,7 @@ export default class EventsController {
       .where('status', 'published')
       .orderBy('eventDate', 'desc')
       .preload('sessions', (query) => {
-        query.preload('speakers')
+        query.preload('speakers').preload('sponsor').orderBy('order', 'asc')
       })
 
     const meetups = EventTransformer.transform(events)
@@ -38,7 +38,7 @@ export default class EventsController {
       .where(lookupColumn, params.idOrSlug)
       .where('status', 'published')
       .preload('sessions', (query) => {
-        query.preload('speakers')
+        query.preload('speakers').preload('sponsor').orderBy('order', 'asc')
       })
       .preload('photos')
       .preload('sponsors')

--- a/packages/frontendmu-adonis/app/controllers/events_controller.ts
+++ b/packages/frontendmu-adonis/app/controllers/events_controller.ts
@@ -16,7 +16,9 @@ export default class EventsController {
         query.preload('speakers').preload('sponsor').orderBy('order', 'asc')
       })
       .preload('photos', (query) => {
-        query.orderBy('order', 'asc')
+        // groupLimit keeps one photo per event (the lowest `order`) so we
+        // hydrate a cover thumbnail without fetching the full album for every card.
+        query.orderBy('order', 'asc').groupLimit(1)
       })
 
     const meetups = EventTransformer.transform(events)

--- a/packages/frontendmu-adonis/app/models/session.ts
+++ b/packages/frontendmu-adonis/app/models/session.ts
@@ -3,7 +3,19 @@ import { randomUUID } from 'node:crypto'
 import { BaseModel, column, belongsTo, manyToMany, beforeCreate } from '@adonisjs/lucid/orm'
 import type { BelongsTo, ManyToMany } from '@adonisjs/lucid/types/relations'
 import Event from '#models/event'
+import Sponsor from '#models/sponsor'
 import User from '#models/user'
+
+export const SESSION_KINDS = [
+  'talk',
+  'intro',
+  'sponsored',
+  'break',
+  'photo',
+  'quiz',
+  'other',
+] as const
+export type SessionKind = (typeof SESSION_KINDS)[number]
 
 export default class Session extends BaseModel {
   static selfAssignPrimaryKey = true
@@ -30,6 +42,15 @@ export default class Session extends BaseModel {
   @column()
   declare order: number | null
 
+  @column()
+  declare kind: SessionKind
+
+  @column()
+  declare sponsorId: string | null
+
+  @column()
+  declare durationMinutes: number | null
+
   @column.dateTime({ autoCreate: true })
   declare createdAt: DateTime
 
@@ -39,6 +60,9 @@ export default class Session extends BaseModel {
   // Relationships
   @belongsTo(() => Event)
   declare event: BelongsTo<typeof Event>
+
+  @belongsTo(() => Sponsor)
+  declare sponsor: BelongsTo<typeof Sponsor>
 
   @manyToMany(() => User, {
     pivotTable: 'session_speakers',

--- a/packages/frontendmu-adonis/app/transformers/event_transformer.ts
+++ b/packages/frontendmu-adonis/app/transformers/event_transformer.ts
@@ -55,7 +55,6 @@ export default class EventTransformer extends BaseTransformer<Event> {
       acceptingRsvp: this.resource.acceptingRsvp,
       status: this.resource.status,
       album: this.resource.albumName,
-      photoCount: photos.length,
       coverThumbnailUrl: coverPhoto ? thumbnailFor(coverPhoto.photoUrl, 600) : null,
       updatedAt: this.resource.updatedAt?.toISO() ?? null,
       sessions: SessionTransformer.transform(sessions).depth(2),

--- a/packages/frontendmu-adonis/app/transformers/event_transformer.ts
+++ b/packages/frontendmu-adonis/app/transformers/event_transformer.ts
@@ -24,6 +24,9 @@ export default class EventTransformer extends BaseTransformer<Event> {
     const sponsors = (
       this.resource.$hasRelated('sponsors') ? this.resource.$getRelated('sponsors') : []
     ) as Sponsor[]
+    const photos = (
+      this.resource.$hasRelated('photos') ? this.resource.$getRelated('photos') : []
+    ) as EventPhoto[]
 
     const seen = new Set<string>()
     const speakers: User[] = []
@@ -36,6 +39,8 @@ export default class EventTransformer extends BaseTransformer<Event> {
         speakers.push(speaker)
       }
     }
+
+    const coverPhoto = photos[0] ?? null
 
     return {
       id: this.resource.id,
@@ -50,6 +55,8 @@ export default class EventTransformer extends BaseTransformer<Event> {
       acceptingRsvp: this.resource.acceptingRsvp,
       status: this.resource.status,
       album: this.resource.albumName,
+      photoCount: photos.length,
+      coverThumbnailUrl: coverPhoto ? thumbnailFor(coverPhoto.photoUrl, 600) : null,
       updatedAt: this.resource.updatedAt?.toISO() ?? null,
       sessions: SessionTransformer.transform(sessions).depth(2),
       speakers: SpeakerTransformer.transform(speakers).useVariant('summary'),

--- a/packages/frontendmu-adonis/app/transformers/event_transformer.ts
+++ b/packages/frontendmu-adonis/app/transformers/event_transformer.ts
@@ -3,8 +3,14 @@ import type Event from '#models/event'
 import type EventPhoto from '#models/event_photo'
 import type Session from '#models/session'
 import type Sponsor from '#models/sponsor'
+import type User from '#models/user'
 import SessionTransformer from '#transformers/session_transformer'
+import SpeakerTransformer from '#transformers/speaker_transformer'
 import SponsorTransformer from '#transformers/sponsor_transformer'
+
+// Kinds whose attached users are the actual event speakers. Intro/quiz hosts
+// and sponsored-segment reps don't belong in the canonical speakers list.
+const SPEAKER_SESSION_KINDS = new Set(['talk', 'other'])
 
 function thumbnailFor(url: string, width: number): string {
   return `https://images.weserv.nl/?url=${encodeURIComponent(url)}&w=${width}&output=webp`
@@ -18,6 +24,18 @@ export default class EventTransformer extends BaseTransformer<Event> {
     const sponsors = (
       this.resource.$hasRelated('sponsors') ? this.resource.$getRelated('sponsors') : []
     ) as Sponsor[]
+
+    const seen = new Set<string>()
+    const speakers: User[] = []
+    for (const session of sessions) {
+      if (!SPEAKER_SESSION_KINDS.has(session.kind)) continue
+      if (!session.$hasRelated('speakers')) continue
+      for (const speaker of session.$getRelated('speakers') as User[]) {
+        if (seen.has(speaker.id)) continue
+        seen.add(speaker.id)
+        speakers.push(speaker)
+      }
+    }
 
     return {
       id: this.resource.id,
@@ -34,6 +52,7 @@ export default class EventTransformer extends BaseTransformer<Event> {
       album: this.resource.albumName,
       updatedAt: this.resource.updatedAt?.toISO() ?? null,
       sessions: SessionTransformer.transform(sessions).depth(2),
+      speakers: SpeakerTransformer.transform(speakers).useVariant('summary'),
       sponsors: SponsorTransformer.transform(sponsors).useVariant('summary'),
     }
   }

--- a/packages/frontendmu-adonis/app/transformers/session_transformer.ts
+++ b/packages/frontendmu-adonis/app/transformers/session_transformer.ts
@@ -1,6 +1,7 @@
 import { BaseTransformer } from '@adonisjs/core/transformers'
 import type Session from '#models/session'
 import type Event from '#models/event'
+import type Sponsor from '#models/sponsor'
 import type User from '#models/user'
 import SpeakerTransformer from '#transformers/speaker_transformer'
 
@@ -10,12 +11,27 @@ export default class SessionTransformer extends BaseTransformer<Session> {
       this.resource.$hasRelated('speakers') ? this.resource.$getRelated('speakers') : []
     ) as User[]
 
+    const sponsor = (
+      this.resource.$hasRelated('sponsor') ? this.resource.$getRelated('sponsor') : null
+    ) as Sponsor | null
+
     return {
       id: this.resource.id,
       title: this.resource.title,
       description: this.resource.description,
       order: this.resource.order,
+      kind: this.resource.kind,
+      sponsorId: this.resource.sponsorId,
+      durationMinutes: this.resource.durationMinutes,
       speakers: SpeakerTransformer.transform(speakers).useVariant('summary'),
+      sponsor: sponsor
+        ? {
+            id: sponsor.id,
+            name: sponsor.name,
+            logoUrl: sponsor.logoUrl,
+            logomarkUrl: sponsor.logomarkUrl,
+          }
+        : null,
     }
   }
 

--- a/packages/frontendmu-adonis/app/validators/session_validator.ts
+++ b/packages/frontendmu-adonis/app/validators/session_validator.ts
@@ -1,4 +1,7 @@
 import vine from '@vinejs/vine'
+import { SESSION_KINDS } from '#models/session'
+
+const kindRule = vine.enum([...SESSION_KINDS])
 
 /**
  * Validator for creating a session
@@ -8,6 +11,9 @@ export const createSessionValidator = vine.compile(
     title: vine.string().trim().minLength(3).maxLength(255),
     description: vine.string().trim().nullable().optional(),
     order: vine.number().positive().nullable().optional(),
+    kind: kindRule.optional(),
+    sponsorId: vine.string().uuid().nullable().optional(),
+    durationMinutes: vine.number().positive().max(1440).nullable().optional(),
     speakerIds: vine.array(vine.string().uuid()).optional(),
   })
 )
@@ -20,6 +26,9 @@ export const updateSessionValidator = vine.compile(
     title: vine.string().trim().minLength(3).maxLength(255),
     description: vine.string().trim().nullable().optional(),
     order: vine.number().positive().nullable().optional(),
+    kind: kindRule.optional(),
+    sponsorId: vine.string().uuid().nullable().optional(),
+    durationMinutes: vine.number().positive().max(1440).nullable().optional(),
     speakerIds: vine.array(vine.string().uuid()).optional(),
   })
 )

--- a/packages/frontendmu-adonis/app/validators/session_validator.ts
+++ b/packages/frontendmu-adonis/app/validators/session_validator.ts
@@ -13,7 +13,7 @@ export const createSessionValidator = vine.compile(
     order: vine.number().positive().nullable().optional(),
     kind: kindRule.optional(),
     sponsorId: vine.string().uuid().nullable().optional(),
-    durationMinutes: vine.number().positive().max(1440).nullable().optional(),
+    durationMinutes: vine.number().positive().max(1440).withoutDecimals().nullable().optional(),
     speakerIds: vine.array(vine.string().uuid()).optional(),
   })
 )
@@ -28,7 +28,7 @@ export const updateSessionValidator = vine.compile(
     order: vine.number().positive().nullable().optional(),
     kind: kindRule.optional(),
     sponsorId: vine.string().uuid().nullable().optional(),
-    durationMinutes: vine.number().positive().max(1440).nullable().optional(),
+    durationMinutes: vine.number().positive().max(1440).withoutDecimals().nullable().optional(),
     speakerIds: vine.array(vine.string().uuid()).optional(),
   })
 )

--- a/packages/frontendmu-adonis/database/migrations/1776900000000_add_kind_and_sponsor_to_sessions.ts
+++ b/packages/frontendmu-adonis/database/migrations/1776900000000_add_kind_and_sponsor_to_sessions.ts
@@ -5,7 +5,14 @@ const SESSION_KINDS = ['talk', 'intro', 'sponsored', 'break', 'photo', 'quiz', '
 export default class extends BaseSchema {
   protected tableName = 'sessions'
 
+  /*
+   * Adding a FK column in SQLite triggers a table-recreate. The existing
+   * session_speakers → sessions FK has ON DELETE CASCADE, which would fire
+   * during the recreate and wipe session_speakers. We disable FK enforcement
+   * around the alter to preserve the pivot rows.
+   */
   async up() {
+    this.schema.raw('PRAGMA foreign_keys = OFF')
     this.schema.alterTable(this.tableName, (table) => {
       table
         .string('kind')
@@ -15,13 +22,16 @@ export default class extends BaseSchema {
       table.uuid('sponsor_id').nullable().references('id').inTable('sponsors').onDelete('SET NULL')
       table.integer('duration_minutes').nullable()
     })
+    this.schema.raw('PRAGMA foreign_keys = ON')
   }
 
   async down() {
+    this.schema.raw('PRAGMA foreign_keys = OFF')
     this.schema.alterTable(this.tableName, (table) => {
       table.dropColumn('kind')
       table.dropColumn('sponsor_id')
       table.dropColumn('duration_minutes')
     })
+    this.schema.raw('PRAGMA foreign_keys = ON')
   }
 }

--- a/packages/frontendmu-adonis/database/migrations/1776900000000_add_kind_and_sponsor_to_sessions.ts
+++ b/packages/frontendmu-adonis/database/migrations/1776900000000_add_kind_and_sponsor_to_sessions.ts
@@ -1,0 +1,27 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+const SESSION_KINDS = ['talk', 'intro', 'sponsored', 'break', 'photo', 'quiz', 'other'] as const
+
+export default class extends BaseSchema {
+  protected tableName = 'sessions'
+
+  async up() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table
+        .string('kind')
+        .notNullable()
+        .defaultTo('talk')
+        .checkIn([...SESSION_KINDS])
+      table.uuid('sponsor_id').nullable().references('id').inTable('sponsors').onDelete('SET NULL')
+      table.integer('duration_minutes').nullable()
+    })
+  }
+
+  async down() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table.dropColumn('kind')
+      table.dropColumn('sponsor_id')
+      table.dropColumn('duration_minutes')
+    })
+  }
+}

--- a/packages/frontendmu-adonis/database/migrations/1776900000000_add_kind_and_sponsor_to_sessions.ts
+++ b/packages/frontendmu-adonis/database/migrations/1776900000000_add_kind_and_sponsor_to_sessions.ts
@@ -4,6 +4,11 @@ const SESSION_KINDS = ['talk', 'intro', 'sponsored', 'break', 'photo', 'quiz', '
 
 export default class extends BaseSchema {
   protected tableName = 'sessions'
+  // SQLite silently ignores `PRAGMA foreign_keys` set inside a transaction,
+  // so we opt out of the automatic migration transaction. Without this, the
+  // PRAGMA OFF/ON guards below would be no-ops and the table-recreate that
+  // adds sponsor_id would cascade-wipe session_speakers.
+  static disableTransactions = true
 
   /*
    * Adding a FK column in SQLite triggers a table-recreate. The existing

--- a/packages/frontendmu-adonis/inertia/components/event/EventCard.vue
+++ b/packages/frontendmu-adonis/inertia/components/event/EventCard.vue
@@ -46,29 +46,7 @@ const speakers = computed(() => {
   return props.event.sessions?.flatMap((session) => session.speakers).filter(Boolean) || []
 })
 
-// Deterministic tint pair seeded from the slug/id so cards feel varied but stable
-const TINTS: Array<[string, string]> = [
-  ['oklch(58% 0.14 230)', 'oklch(72% 0.10 200)'],
-  ['oklch(48% 0.12 260)', 'oklch(38% 0.10 280)'],
-  ['oklch(60% 0.13 30)', 'oklch(78% 0.10 55)'],
-  ['oklch(55% 0.12 150)', 'oklch(72% 0.09 130)'],
-  ['oklch(60% 0.14 310)', 'oklch(75% 0.10 290)'],
-  ['oklch(52% 0.13 20)', 'oklch(68% 0.11 40)'],
-  ['oklch(50% 0.13 200)', 'oklch(65% 0.10 180)'],
-  ['oklch(54% 0.14 85)', 'oklch(72% 0.11 70)'],
-  ['oklch(45% 0.10 260)', 'oklch(58% 0.12 240)'],
-  ['oklch(58% 0.13 160)', 'oklch(74% 0.10 140)'],
-]
-
-const tint = computed(() => {
-  const key = props.event.slug || props.event.id
-  let hash = 0
-  for (let i = 0; i < key.length; i += 1) hash = (hash * 31 + key.charCodeAt(i)) | 0
-  return TINTS[Math.abs(hash) % TINTS.length]
-})
-
 const coverThumbnail = computed(() => props.event.coverThumbnailUrl || null)
-const hasGallery = computed(() => !!coverThumbnail.value || !!props.event.album)
 
 function stripHtml(input: string): string {
   return input.replace(/<[^>]*>/g, '').replace(/\s+/g, ' ').trim()
@@ -79,7 +57,11 @@ function stripHtml(input: string): string {
   <article
     class="meetup-card group relative grid rounded-[14px] overflow-hidden border transition-all duration-200 hover:-translate-y-[3px] bg-white dark:bg-verse-950"
     :class="[
-      featured ? 'sm:grid-cols-[1.1fr_1fr] min-h-[280px]' : 'sm:grid-cols-2 min-h-[192px]',
+      coverThumbnail
+        ? featured
+          ? 'sm:grid-cols-[1.1fr_1fr] min-h-[280px]'
+          : 'sm:grid-cols-2 min-h-[192px]'
+        : '',
       status === 'live'
         ? 'border-coral shadow-[0_8px_24px_-8px_color-mix(in_oklch,var(--color-coral)_30%,transparent)]'
         : status === 'upcoming'
@@ -87,7 +69,23 @@ function stripHtml(input: string): string {
           : 'border-gray-200 dark:border-verse-900 hover:border-gray-300 dark:hover:border-verse-800',
     ]"
   >
-    <!-- Body (left) -->
+    <!-- Status tag (floats top-right when no cover to anchor it) -->
+    <span
+      v-if="!coverThumbnail"
+      class="absolute top-4 right-4 z-10 inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full font-mono text-[10px] font-bold uppercase tracking-widest"
+      :class="
+        status === 'live'
+          ? 'bg-coral-strong text-white'
+          : status === 'upcoming'
+            ? 'bg-verse-50 dark:bg-verse-900 text-verse-600 dark:text-verse-300 border border-verse-100 dark:border-verse-800'
+            : 'bg-gray-50 dark:bg-verse-900 text-gray-600 dark:text-gray-400'
+      "
+    >
+      <span v-if="status === 'live'" class="w-1.5 h-1.5 rounded-full bg-white" />
+      {{ isMeetupToday ? 'Today' : isNextMeetup && status === 'upcoming' ? 'Next up' : statusLabel }}
+    </span>
+
+    <!-- Body (left, or full-width when no cover) -->
     <div
       class="flex flex-col justify-between gap-4 min-w-0"
       :class="featured ? 'p-8 md:p-10' : 'p-5 md:p-6'"
@@ -175,70 +173,17 @@ function stripHtml(input: string): string {
       </div>
     </div>
 
-    <!-- Image / Placeholder (right) -->
+    <!-- Cover image (right) — only rendered when we have a synced photo -->
     <div
+      v-if="coverThumbnail"
       class="relative overflow-hidden border-t sm:border-t-0 sm:border-l border-gray-100 dark:border-verse-900 min-h-[180px] sm:min-h-0 order-first sm:order-none"
-      :class="[hasGallery ? '' : 'no-gallery-stripes']"
     >
-      <!-- Cover photo (when we have a synced gallery) -->
       <img
-        v-if="coverThumbnail"
         :src="coverThumbnail"
         :alt="event.title"
         loading="lazy"
         class="absolute inset-0 w-full h-full object-cover transition-transform duration-500 group-hover:scale-[1.04]"
       />
-      <!-- Gradient placeholder (album set but photos not yet synced) -->
-      <div
-        v-else-if="hasGallery"
-        class="absolute inset-0"
-        :style="{ background: `linear-gradient(135deg, ${tint[0]} 0%, ${tint[1]} 100%)` }"
-      >
-        <svg class="absolute inset-0 w-full h-full opacity-[0.35]" viewBox="0 0 200 140" preserveAspectRatio="xMidYMid slice">
-          <defs>
-            <pattern :id="`pat-${event.id}`" width="20" height="20" patternUnits="userSpaceOnUse" patternTransform="rotate(-12)">
-              <circle cx="2" cy="2" r="1" fill="rgba(255,255,255,0.3)" />
-            </pattern>
-          </defs>
-          <rect width="200" height="140" :fill="`url(#pat-${event.id})`" />
-          <rect x="20" y="30" width="70" height="50" rx="4" fill="rgba(255,255,255,0.12)" />
-          <rect x="110" y="40" width="75" height="60" rx="4" fill="rgba(0,0,0,0.18)" />
-          <circle cx="60" cy="110" r="16" fill="rgba(255,255,255,0.15)" />
-        </svg>
-        <div
-          class="absolute inset-0 flex items-center justify-center font-mono text-[10px] tracking-widest uppercase text-white/90"
-        >
-          <span class="bg-black/25 px-2.5 py-1 rounded">{{ event.album || formattedDate.full }}</span>
-        </div>
-      </div>
-
-      <!-- No gallery state -->
-      <div
-        v-else
-        class="absolute inset-0 flex flex-col items-center justify-center gap-2.5 p-6 text-center"
-      >
-        <div
-          class="w-10 h-10 rounded-[10px] bg-white dark:bg-verse-950 border border-dashed border-gray-300 dark:border-verse-800 grid place-items-center text-gray-400 dark:text-gray-500"
-        >
-          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-            <rect x="3" y="5" width="18" height="14" rx="2" />
-            <circle cx="9" cy="11" r="1.5" />
-            <path d="m21 16-4-4-8 8" />
-            <path d="M3 19 21 5" stroke-dasharray="2 2" opacity="0.6" />
-          </svg>
-        </div>
-        <div class="font-mono text-[10.5px] font-semibold uppercase tracking-widest text-gray-500 dark:text-gray-400">
-          {{ status === 'upcoming' ? 'Gallery opens after' : 'No photos yet' }}
-        </div>
-        <div class="font-mono text-[10px] text-gray-400 dark:text-gray-500 max-w-[22ch] leading-snug">
-          {{
-            status === 'upcoming'
-              ? 'Photos will appear here once the event wraps'
-              : 'Recap only — no photos were shared'
-          }}
-        </div>
-      </div>
-
       <!-- Status tag -->
       <span
         class="absolute top-3 right-3 inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full font-mono text-[10px] font-bold uppercase tracking-widest backdrop-blur-md"
@@ -256,7 +201,7 @@ function stripHtml(input: string): string {
 
       <!-- Attendee badge bottom-right -->
       <span
-        v-if="event.attendeeCount && hasGallery"
+        v-if="event.attendeeCount"
         class="absolute bottom-3 right-3 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-white/92 dark:bg-verse-950/92 backdrop-blur-sm font-mono text-[11px] font-bold text-gray-900 dark:text-gray-100 shadow-sm"
       >
         <svg class="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">

--- a/packages/frontendmu-adonis/inertia/components/event/EventCard.vue
+++ b/packages/frontendmu-adonis/inertia/components/event/EventCard.vue
@@ -9,20 +9,22 @@ interface Props {
   event: Data.Event
   isNextMeetup?: boolean
   isMeetupToday?: boolean
+  featured?: boolean
 }
 
 const props = withDefaults(defineProps<Props>(), {
   isNextMeetup: false,
   isMeetupToday: false,
+  featured: false,
 })
 
 const formattedDate = computed(() => {
-  if (!props.event.date) return { day: '', month: '', year: '' }
+  if (!props.event.date) return { day: '', month: '', full: '' }
   const date = new Date(props.event.date)
   return {
     day: date.getDate(),
     month: date.toLocaleString('en-US', { month: 'short' }),
-    year: date.getFullYear(),
+    full: date.toLocaleString('en-US', { day: '2-digit', month: 'short', year: 'numeric' }),
   }
 })
 
@@ -30,88 +32,230 @@ const isUpcoming = computed(() => {
   return props.event.date ? isDateInFuture(new Date(props.event.date)) : false
 })
 
+const status = computed<'live' | 'upcoming' | 'past'>(() => {
+  if (props.isMeetupToday) return 'live'
+  if (isUpcoming.value) return 'upcoming'
+  return 'past'
+})
+
+const statusLabel = computed(() =>
+  status.value === 'live' ? 'Live now' : status.value === 'upcoming' ? 'Upcoming' : 'Past'
+)
+
 const speakers = computed(() => {
   return props.event.sessions?.flatMap((session) => session.speakers).filter(Boolean) || []
 })
+
+// Deterministic tint pair seeded from the slug/id so cards feel varied but stable
+const TINTS: Array<[string, string]> = [
+  ['oklch(58% 0.14 230)', 'oklch(72% 0.10 200)'],
+  ['oklch(48% 0.12 260)', 'oklch(38% 0.10 280)'],
+  ['oklch(60% 0.13 30)', 'oklch(78% 0.10 55)'],
+  ['oklch(55% 0.12 150)', 'oklch(72% 0.09 130)'],
+  ['oklch(60% 0.14 310)', 'oklch(75% 0.10 290)'],
+  ['oklch(52% 0.13 20)', 'oklch(68% 0.11 40)'],
+  ['oklch(50% 0.13 200)', 'oklch(65% 0.10 180)'],
+  ['oklch(54% 0.14 85)', 'oklch(72% 0.11 70)'],
+  ['oklch(45% 0.10 260)', 'oklch(58% 0.12 240)'],
+  ['oklch(58% 0.13 160)', 'oklch(74% 0.10 140)'],
+]
+
+const tint = computed(() => {
+  const key = props.event.slug || props.event.id
+  let hash = 0
+  for (let i = 0; i < key.length; i += 1) hash = (hash * 31 + key.charCodeAt(i)) | 0
+  return TINTS[Math.abs(hash) % TINTS.length]
+})
+
+const hasGallery = computed(() => !!props.event.album)
+
+function stripHtml(input: string): string {
+  return input.replace(/<[^>]*>/g, '').replace(/\s+/g, ' ').trim()
+}
 </script>
 
 <template>
-  <div
-    class="group relative bg-white dark:bg-verse-900 border border-gray-200 dark:border-verse-900 rounded-lg p-4 hover:border-gray-300 dark:hover:border-verse-800 transition-colors"
+  <article
+    class="meetup-card group relative grid rounded-[14px] overflow-hidden border transition-all duration-200 hover:-translate-y-[3px] bg-white dark:bg-verse-950"
+    :class="[
+      featured ? 'sm:grid-cols-[1.1fr_1fr] min-h-[280px]' : 'sm:grid-cols-2 min-h-[192px]',
+      status === 'live'
+        ? 'border-coral shadow-[0_8px_24px_-8px_color-mix(in_oklch,var(--color-coral)_30%,transparent)]'
+        : status === 'upcoming'
+          ? 'border-verse-200 dark:border-verse-800 hover:border-verse-300 dark:hover:border-verse-700'
+          : 'border-gray-200 dark:border-verse-900 hover:border-gray-300 dark:hover:border-verse-800',
+    ]"
   >
-    <div class="flex items-center gap-4">
-      <!-- Minimal Date -->
-      <div
-        class="flex flex-col items-center justify-center w-14 shrink-0 text-gray-400 dark:text-gray-400 group-hover:text-verse-500 transition-colors"
-      >
-        <span class="text-2xl font-black leading-none tracking-tighter">{{
-          formattedDate.day
-        }}</span>
-        <span class="text-xs font-bold uppercase tracking-widest">{{ formattedDate.month }}</span>
+    <!-- Body (left) -->
+    <div
+      class="flex flex-col justify-between gap-4 min-w-0"
+      :class="featured ? 'p-8 md:p-10' : 'p-5 md:p-6'"
+    >
+      <div>
+        <h3
+          :class="
+            featured
+              ? 'font-display text-[32px] md:text-[40px] leading-[1.05] text-gray-900 dark:text-gray-100'
+              : 'font-mono text-[17px] md:text-[19px] font-bold leading-tight tracking-[-0.01em] text-verse-500 dark:text-verse-300 break-words'
+          "
+        >
+          <template v-if="featured">
+            <span>{{ event.title }}</span>
+          </template>
+          <template v-else>
+            {{ event.title }}
+          </template>
+        </h3>
+
+        <p
+          v-if="featured && event.description"
+          class="mt-3 max-w-[52ch] text-[15px] leading-relaxed text-gray-500 dark:text-gray-400 line-clamp-3"
+        >
+          {{ stripHtml(event.description) }}
+        </p>
+
+        <div
+          class="mt-3 flex flex-wrap items-center gap-x-3.5 gap-y-1.5 font-mono text-[12px] text-gray-500 dark:text-gray-400"
+        >
+          <span class="inline-flex items-center gap-1.5">
+            <svg class="w-3.5 h-3.5 text-verse-500/80 dark:text-verse-300/80" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+              <rect x="3" y="5" width="18" height="16" rx="2" />
+              <path d="M3 10h18M8 3v4M16 3v4" />
+            </svg>
+            {{ formattedDate.full }}
+          </span>
+          <span v-if="event.venue" class="inline-flex items-center gap-1.5 truncate max-w-[220px]">
+            <svg class="w-3.5 h-3.5 shrink-0 text-verse-500/80 dark:text-verse-300/80" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 1 1 16 0Z" />
+              <circle cx="12" cy="10" r="3" />
+            </svg>
+            <span class="truncate">{{ event.venue }}</span>
+          </span>
+          <span v-if="event.attendeeCount" class="inline-flex items-center gap-1.5">
+            <svg class="w-3.5 h-3.5 text-verse-500/80 dark:text-verse-300/80" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M17 21v-2a4 4 0 0 0-4-4H7a4 4 0 0 0-4 4v2" />
+              <circle cx="10" cy="7" r="4" />
+              <path d="M21 21v-2a4 4 0 0 0-3-3.87M16 3.13a4 4 0 0 1 0 7.75" />
+            </svg>
+            {{ event.attendeeCount }} attending
+          </span>
+        </div>
       </div>
 
-      <div class="flex-1 min-w-0 space-y-3">
-        <div class="space-y-1">
-          <div class="flex items-center gap-2">
-            <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100 truncate">
-              {{ event.title }}
-            </h3>
-            <div v-if="isMeetupToday || isNextMeetup" class="shrink-0 flex gap-1">
-              <span
-                v-if="isMeetupToday"
-                class="text-[10px] font-bold uppercase tracking-wider bg-red-500 text-white px-2 py-0.5 rounded"
-              >
-                Today
-              </span>
-              <span
-                v-else-if="isNextMeetup"
-                class="text-[10px] font-bold uppercase tracking-wider bg-green-500 text-white px-2 py-0.5 rounded"
-              >
-                Next
-              </span>
-            </div>
-          </div>
-
-          <div
-            class="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs font-mono text-gray-500 dark:text-gray-400"
-          >
-            <div v-if="event.venue" class="flex items-center gap-1">
-              <span class="opacity-50 text-verse-500 dark:text-verse-300">@</span>
-              <span class="truncate max-w-[180px]">{{ event.venue }}</span>
-            </div>
-
-            <div v-if="event.attendeeCount" class="flex items-center gap-1">
-              <span class="opacity-50 text-verse-500 dark:text-verse-300">#</span>
-              {{ event.attendeeCount }} attendees
-            </div>
-          </div>
-        </div>
-
-        <!-- Speakers Prominent Row -->
-        <div v-if="speakers.length > 0" class="flex items-center gap-3 relative z-20">
-          <div class="flex -space-x-2">
+      <!-- Footer: speakers / attendee badge -->
+      <div class="flex items-center justify-between gap-3">
+        <div v-if="speakers.length > 0" class="flex items-center gap-3 min-w-0">
+          <div class="flex -space-x-2 shrink-0">
             <template v-for="speaker in speakers.slice(0, 4)" :key="speaker?.id">
               <SpeakerAvatar
                 size="sm"
                 :name="speaker.name"
                 :github-username="speaker.githubUsername"
                 :avatar-url="speaker.avatarUrl"
-                class="border border-white dark:border-verse-950"
+                class="border-2 border-white dark:border-verse-950"
               />
             </template>
             <div
               v-if="speakers.length > 4"
-              class="w-8 h-8 rounded-lg bg-verse-50 dark:bg-verse-900 border border-white dark:border-verse-950 flex items-center justify-center text-[10px] font-black text-verse-600"
+              class="w-8 h-8 rounded-lg bg-verse-50 dark:bg-verse-900 border-2 border-white dark:border-verse-950 flex items-center justify-center text-[10px] font-black text-verse-600 dark:text-verse-300"
             >
               +{{ speakers.length - 4 }}
             </div>
           </div>
-          <span class="text-xs font-bold text-gray-500 dark:text-gray-400">
+          <span class="font-mono text-[11px] text-gray-500 dark:text-gray-400 truncate">
             {{ speakers[0].name
-            }}<template v-if="speakers.length > 1"> & {{ speakers.length - 1 }} others</template>
+            }}<template v-if="speakers.length > 1"> & {{ speakers.length - 1 }} more</template>
           </span>
         </div>
+        <div v-else-if="event.attendeeCount" class="font-mono text-[11px] text-gray-400 dark:text-gray-500">
+          {{ event.attendeeCount }} attendees
+        </div>
+        <div v-else />
       </div>
+    </div>
+
+    <!-- Image / Placeholder (right) -->
+    <div
+      class="relative overflow-hidden border-t sm:border-t-0 sm:border-l border-gray-100 dark:border-verse-900 min-h-[180px] sm:min-h-0 order-first sm:order-none"
+      :class="[hasGallery ? '' : 'no-gallery-stripes']"
+    >
+      <!-- Gallery placeholder tint -->
+      <div
+        v-if="hasGallery"
+        class="absolute inset-0"
+        :style="{ background: `linear-gradient(135deg, ${tint[0]} 0%, ${tint[1]} 100%)` }"
+      >
+        <svg class="absolute inset-0 w-full h-full opacity-[0.35]" viewBox="0 0 200 140" preserveAspectRatio="xMidYMid slice">
+          <defs>
+            <pattern :id="`pat-${event.id}`" width="20" height="20" patternUnits="userSpaceOnUse" patternTransform="rotate(-12)">
+              <circle cx="2" cy="2" r="1" fill="rgba(255,255,255,0.3)" />
+            </pattern>
+          </defs>
+          <rect width="200" height="140" :fill="`url(#pat-${event.id})`" />
+          <rect x="20" y="30" width="70" height="50" rx="4" fill="rgba(255,255,255,0.12)" />
+          <rect x="110" y="40" width="75" height="60" rx="4" fill="rgba(0,0,0,0.18)" />
+          <circle cx="60" cy="110" r="16" fill="rgba(255,255,255,0.15)" />
+        </svg>
+        <div
+          class="absolute inset-0 flex items-center justify-center font-mono text-[10px] tracking-widest uppercase text-white/90"
+        >
+          <span class="bg-black/25 px-2.5 py-1 rounded">{{ event.album || formattedDate.full }}</span>
+        </div>
+      </div>
+
+      <!-- No gallery state -->
+      <div
+        v-else
+        class="absolute inset-0 flex flex-col items-center justify-center gap-2.5 p-6 text-center"
+      >
+        <div
+          class="w-10 h-10 rounded-[10px] bg-white dark:bg-verse-950 border border-dashed border-gray-300 dark:border-verse-800 grid place-items-center text-gray-400 dark:text-gray-500"
+        >
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+            <rect x="3" y="5" width="18" height="14" rx="2" />
+            <circle cx="9" cy="11" r="1.5" />
+            <path d="m21 16-4-4-8 8" />
+            <path d="M3 19 21 5" stroke-dasharray="2 2" opacity="0.6" />
+          </svg>
+        </div>
+        <div class="font-mono text-[10.5px] font-semibold uppercase tracking-widest text-gray-500 dark:text-gray-400">
+          {{ status === 'upcoming' ? 'Gallery opens after' : 'No photos yet' }}
+        </div>
+        <div class="font-mono text-[10px] text-gray-400 dark:text-gray-500 max-w-[22ch] leading-snug">
+          {{
+            status === 'upcoming'
+              ? 'Photos will appear here once the event wraps'
+              : 'Recap only — no photos were shared'
+          }}
+        </div>
+      </div>
+
+      <!-- Status tag -->
+      <span
+        class="absolute top-3 right-3 inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full font-mono text-[10px] font-bold uppercase tracking-widest backdrop-blur-md"
+        :class="
+          status === 'live'
+            ? 'bg-coral-strong text-white'
+            : status === 'upcoming'
+              ? 'bg-white/90 dark:bg-verse-950/90 text-verse-600 dark:text-verse-300 border border-verse-100 dark:border-verse-800'
+              : 'bg-white/85 dark:bg-verse-950/85 text-gray-700 dark:text-gray-300'
+        "
+      >
+        <span v-if="status === 'live'" class="w-1.5 h-1.5 rounded-full bg-white" />
+        {{ isMeetupToday ? 'Today' : isNextMeetup && status === 'upcoming' ? 'Next up' : statusLabel }}
+      </span>
+
+      <!-- Attendee badge bottom-right -->
+      <span
+        v-if="event.attendeeCount && hasGallery"
+        class="absolute bottom-3 right-3 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-white/92 dark:bg-verse-950/92 backdrop-blur-sm font-mono text-[11px] font-bold text-gray-900 dark:text-gray-100 shadow-sm"
+      >
+        <svg class="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M17 21v-2a4 4 0 0 0-4-4H7a4 4 0 0 0-4 4v2" />
+          <circle cx="10" cy="7" r="4" />
+        </svg>
+        {{ event.attendeeCount }}
+      </span>
     </div>
 
     <Link
@@ -119,5 +263,11 @@ const speakers = computed(() => {
       class="absolute inset-0 z-20"
       aria-label="View event details"
     />
-  </div>
+  </article>
 </template>
+
+<style scoped>
+.meetup-card:hover {
+  box-shadow: 0 24px 48px -12px rgba(13, 20, 51, 0.16), 0 8px 16px -4px rgba(13, 20, 51, 0.08);
+}
+</style>

--- a/packages/frontendmu-adonis/inertia/components/event/EventCard.vue
+++ b/packages/frontendmu-adonis/inertia/components/event/EventCard.vue
@@ -42,9 +42,7 @@ const statusLabel = computed(() =>
   status.value === 'live' ? 'Live now' : status.value === 'upcoming' ? 'Upcoming' : 'Past'
 )
 
-const speakers = computed(() => {
-  return props.event.sessions?.flatMap((session) => session.speakers).filter(Boolean) || []
-})
+const speakers = computed(() => props.event.speakers ?? [])
 
 const coverThumbnail = computed(() => props.event.coverThumbnailUrl || null)
 

--- a/packages/frontendmu-adonis/inertia/components/event/EventCard.vue
+++ b/packages/frontendmu-adonis/inertia/components/event/EventCard.vue
@@ -67,7 +67,8 @@ const tint = computed(() => {
   return TINTS[Math.abs(hash) % TINTS.length]
 })
 
-const hasGallery = computed(() => !!props.event.album)
+const coverThumbnail = computed(() => props.event.coverThumbnailUrl || null)
+const hasGallery = computed(() => !!coverThumbnail.value || !!props.event.album)
 
 function stripHtml(input: string): string {
   return input.replace(/<[^>]*>/g, '').replace(/\s+/g, ' ').trim()
@@ -179,9 +180,17 @@ function stripHtml(input: string): string {
       class="relative overflow-hidden border-t sm:border-t-0 sm:border-l border-gray-100 dark:border-verse-900 min-h-[180px] sm:min-h-0 order-first sm:order-none"
       :class="[hasGallery ? '' : 'no-gallery-stripes']"
     >
-      <!-- Gallery placeholder tint -->
+      <!-- Cover photo (when we have a synced gallery) -->
+      <img
+        v-if="coverThumbnail"
+        :src="coverThumbnail"
+        :alt="event.title"
+        loading="lazy"
+        class="absolute inset-0 w-full h-full object-cover transition-transform duration-500 group-hover:scale-[1.04]"
+      />
+      <!-- Gradient placeholder (album set but photos not yet synced) -->
       <div
-        v-if="hasGallery"
+        v-else-if="hasGallery"
         class="absolute inset-0"
         :style="{ background: `linear-gradient(135deg, ${tint[0]} 0%, ${tint[1]} 100%)` }"
       >

--- a/packages/frontendmu-adonis/inertia/components/layout/Menu.vue
+++ b/packages/frontendmu-adonis/inertia/components/layout/Menu.vue
@@ -556,7 +556,7 @@ onUnmounted(() => {
   >
     <div
       ref="menuInner"
-      class="menu-inner w-[92%] max-w-5xl bg-white/80 dark:bg-verse-950/60 backdrop-blur-xl border border-gray-100 dark:border-verse-800 rounded-2xl squircle px-3 md:px-5 h-16 flex items-center justify-between shadow-sm"
+      class="menu-inner w-[92%] max-w-7xl bg-white/80 dark:bg-verse-950/60 backdrop-blur-xl border border-gray-100 dark:border-verse-800 rounded-2xl squircle px-3 md:px-5 h-16 flex items-center justify-between shadow-sm"
     >
       <!-- Brand -->
       <div class="flex items-center">

--- a/packages/frontendmu-adonis/inertia/css/app.css
+++ b/packages/frontendmu-adonis/inertia/css/app.css
@@ -17,6 +17,19 @@
   --color-verse-800: #0c1a3d;
   --color-verse-900: #060d1f;
   --color-verse-950: #020617;
+
+  /* Coral accent — used sparingly for live/action moments and section labels */
+  --color-coral-soft: oklch(94% 0.04 40);
+  --color-coral: oklch(68% 0.17 35);
+  --color-coral-strong: oklch(62% 0.19 32);
+
+  /* Mono font stack */
+  --font-mono:
+    'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
+
+  /* Sans UI font stack — used for body copy */
+  --font-sans:
+    'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
 }
 
 @utility squircle {
@@ -30,6 +43,13 @@ body,
 #app {
   height: 100%;
   width: 100%;
+}
+
+body {
+  font-family: var(--font-sans);
+  font-feature-settings: 'ss01', 'cv11';
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 /* Dark mode support */
@@ -48,15 +68,23 @@ html.dark {
     sans-serif;
 }
 
-/* Distinctive serif display font for key headings */
+/* Distinctive serif display font for key headings.
+   Fraunces is a variable font with SOFT and WONK axes that give it its
+   distinctive warmth upright and playful, wonky italic at larger sizes. */
 .font-display {
-  font-family: 'Instrument Serif', Georgia, 'Times New Roman', serif;
+  font-family: 'Fraunces', 'Instrument Serif', Georgia, 'Times New Roman', serif;
   font-style: normal;
+  font-weight: 400;
+  font-variation-settings: 'SOFT' 40, 'WONK' 0, 'opsz' 144;
+  letter-spacing: -0.025em;
 }
 
 .font-display-italic {
-  font-family: 'Instrument Serif', Georgia, 'Times New Roman', serif;
+  font-family: 'Fraunces', 'Instrument Serif', Georgia, 'Times New Roman', serif;
   font-style: italic;
+  font-weight: 400;
+  font-variation-settings: 'SOFT' 80, 'WONK' 1, 'opsz' 144;
+  letter-spacing: -0.02em;
 }
 
 /* Animation utilities */
@@ -76,6 +104,61 @@ html.dark {
 /* Custom utilities */
 .contain {
   @apply max-w-7xl mx-auto px-4 sm:px-6 lg:px-8;
+}
+
+/* Editorial section label: uppercase mono with a leading hairline */
+.section-label {
+  @apply inline-flex items-center gap-2.5 text-[11px] font-semibold uppercase;
+  font-family: var(--font-mono);
+  letter-spacing: 0.14em;
+  color: var(--color-coral-strong);
+}
+.section-label::before {
+  content: '';
+  width: 18px;
+  height: 1px;
+  background: currentColor;
+  opacity: 0.6;
+}
+
+/* Breadcrumb / eyebrow trail */
+.mono-eyebrow {
+  @apply inline-flex items-center gap-2.5 text-[11px] font-medium uppercase text-gray-500 dark:text-gray-400;
+  font-family: var(--font-mono);
+  letter-spacing: 0.12em;
+}
+.mono-eyebrow .sep {
+  opacity: 0.4;
+}
+
+/* Diagonal-stripe treatment for "no gallery / no cover" card slots */
+.no-gallery-stripes {
+  background-image: repeating-linear-gradient(
+    135deg,
+    oklch(96% 0.012 82) 0px,
+    oklch(96% 0.012 82) 10px,
+    oklch(93% 0.014 80) 10px,
+    oklch(93% 0.014 80) 20px
+  );
+}
+html.dark .no-gallery-stripes {
+  background-image: repeating-linear-gradient(
+    135deg,
+    var(--color-verse-900) 0px,
+    var(--color-verse-900) 10px,
+    var(--color-verse-800) 10px,
+    var(--color-verse-800) 20px
+  );
+}
+
+/* Pulse indicator for live state */
+@keyframes coral-pulse {
+  0% { box-shadow: 0 0 0 0 color-mix(in oklch, var(--color-coral) 60%, transparent); }
+  70% { box-shadow: 0 0 0 10px transparent; }
+  100% { box-shadow: 0 0 0 0 transparent; }
+}
+.coral-pulse {
+  animation: coral-pulse 2s infinite;
 }
 
 /* Native dialog styling */

--- a/packages/frontendmu-adonis/inertia/css/app.css
+++ b/packages/frontendmu-adonis/inertia/css/app.css
@@ -108,14 +108,14 @@ html.dark {
 
 /* Editorial section label: uppercase mono with a leading hairline */
 .section-label {
-  @apply inline-flex items-center gap-2.5 text-[11px] font-semibold uppercase;
+  @apply inline-flex items-center gap-3 text-[13px] font-semibold uppercase;
   font-family: var(--font-mono);
   letter-spacing: 0.14em;
   color: var(--color-coral-strong);
 }
 .section-label::before {
   content: '';
-  width: 18px;
+  width: 24px;
   height: 1px;
   background: currentColor;
   opacity: 0.6;

--- a/packages/frontendmu-adonis/inertia/css/app.css
+++ b/packages/frontendmu-adonis/inertia/css/app.css
@@ -160,6 +160,11 @@ html.dark .no-gallery-stripes {
 .coral-pulse {
   animation: coral-pulse 2s infinite;
 }
+@media (prefers-reduced-motion: reduce) {
+  .coral-pulse {
+    animation: none;
+  }
+}
 
 /* Native dialog styling */
 dialog {

--- a/packages/frontendmu-adonis/inertia/pages/admin/events/edit.vue
+++ b/packages/frontendmu-adonis/inertia/pages/admin/events/edit.vue
@@ -1044,7 +1044,10 @@ async function removeSponsor(sponsorId: string) {
                     >
                       {{ session.description }}
                     </p>
-                    <div class="flex items-center gap-2 text-sm text-verse-500 dark:text-verse-400">
+                    <div
+                      v-if="session.speakers?.length"
+                      class="flex items-center gap-2 text-sm text-verse-500 dark:text-verse-400"
+                    >
                       <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path
                           stroke-linecap="round"

--- a/packages/frontendmu-adonis/inertia/pages/admin/events/edit.vue
+++ b/packages/frontendmu-adonis/inertia/pages/admin/events/edit.vue
@@ -45,15 +45,36 @@ onUnmounted(() => {
 })
 
 // Session form state
+type SessionKind = 'talk' | 'intro' | 'sponsored' | 'break' | 'photo' | 'quiz' | 'other'
+
+const SESSION_KIND_OPTIONS: Array<{ value: SessionKind; label: string; hint: string }> = [
+  { value: 'talk', label: 'Talk', hint: 'Speaker-led session' },
+  { value: 'intro', label: 'Intro', hint: 'Welcome / MC segment' },
+  { value: 'sponsored', label: 'Sponsored', hint: 'Sponsor spotlight' },
+  { value: 'break', label: 'Break', hint: 'Lunch, coffee, etc.' },
+  { value: 'photo', label: 'Group photo', hint: 'Everyone on stage' },
+  { value: 'quiz', label: 'Quiz', hint: 'Hosted quiz segment' },
+  { value: 'other', label: 'Other', hint: 'Custom segment' },
+]
+
+const KINDS_WITH_SPEAKERS: SessionKind[] = ['talk', 'intro', 'quiz', 'other']
+const KINDS_WITH_SPONSOR: SessionKind[] = ['sponsored']
+
 const editingSession = ref<Data.Session | null>(null)
 const sessionForm = ref({
   title: '',
   description: '',
+  kind: 'talk' as SessionKind,
+  sponsorId: null as string | null,
+  durationMinutes: null as number | null,
   speakerIds: [] as string[],
 })
 const sessionFormErrors = ref<Record<string, string>>({})
 const sessionFormProcessing = ref(false)
 const speakerSearch = ref('')
+
+const showSpeakers = computed(() => KINDS_WITH_SPEAKERS.includes(sessionForm.value.kind))
+const showSponsor = computed(() => KINDS_WITH_SPONSOR.includes(sessionForm.value.kind))
 
 // Form state for event
 const formEventDate = computed(() => {
@@ -107,11 +128,23 @@ const draggedSession = ref<Data.Session | null>(null)
 const dragOverIndex = ref<number | null>(null)
 
 // Session management functions
-function openNewSessionForm() {
+const QUICK_ADD_PRESETS: Record<string, { kind: SessionKind; title: string }> = {
+  intro: { kind: 'intro', title: 'Welcome & intro' },
+  break: { kind: 'break', title: 'Lunch' },
+  photo: { kind: 'photo', title: 'Group photo' },
+  quiz: { kind: 'quiz', title: 'Quiz' },
+  sponsored: { kind: 'sponsored', title: 'Sponsor spotlight' },
+}
+
+function openNewSessionForm(presetKey?: keyof typeof QUICK_ADD_PRESETS) {
+  const preset = presetKey ? QUICK_ADD_PRESETS[presetKey] : null
   editingSession.value = null
   sessionForm.value = {
-    title: '',
+    title: preset?.title ?? '',
     description: '',
+    kind: preset?.kind ?? 'talk',
+    sponsorId: null,
+    durationMinutes: null,
     speakerIds: [],
   }
   sessionFormErrors.value = {}
@@ -126,6 +159,9 @@ function openEditSessionForm(session: Data.Session) {
   sessionForm.value = {
     title: session.title,
     description: session.description || '',
+    kind: ((session as { kind?: SessionKind }).kind ?? 'talk') as SessionKind,
+    sponsorId: (session as { sponsorId?: string | null }).sponsorId ?? null,
+    durationMinutes: (session as { durationMinutes?: number | null }).durationMinutes ?? null,
     speakerIds: session.speakers?.map((s) => s.id) || [],
   }
   sessionFormErrors.value = {}
@@ -142,6 +178,9 @@ function closeSessionForm() {
   sessionForm.value = {
     title: '',
     description: '',
+    kind: 'talk',
+    sponsorId: null,
+    durationMinutes: null,
     speakerIds: [],
   }
   sessionFormErrors.value = {}
@@ -221,8 +260,14 @@ async function saveSession() {
 
     const method = editingSession.value ? 'PUT' : 'POST'
 
+    const kind = sessionForm.value.kind
     const payload = {
-      ...sessionForm.value,
+      title: sessionForm.value.title,
+      description: sessionForm.value.description,
+      kind,
+      durationMinutes: sessionForm.value.durationMinutes,
+      sponsorId: KINDS_WITH_SPONSOR.includes(kind) ? sessionForm.value.sponsorId : null,
+      speakerIds: KINDS_WITH_SPEAKERS.includes(kind) ? sessionForm.value.speakerIds : [],
       order: editingSession.value?.order ?? sessions.value.length + 1,
     }
 
@@ -475,8 +520,72 @@ async function removeSponsor(sponsorId: string) {
               />
             </div>
 
+            <!-- Type + Duration -->
+            <div class="grid grid-cols-[1fr_140px] gap-3">
+              <div>
+                <label
+                  for="sessionKind"
+                  class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-2"
+                >
+                  Type
+                </label>
+                <select
+                  id="sessionKind"
+                  v-model="sessionForm.kind"
+                  class="w-full px-4 py-2 border border-verse-300 dark:border-verse-600 squircle rounded-lg bg-white dark:bg-verse-700 text-verse-900 dark:text-verse-100 focus:ring-2 focus:ring-verse-500 focus:border-transparent"
+                >
+                  <option v-for="opt in SESSION_KIND_OPTIONS" :key="opt.value" :value="opt.value">
+                    {{ opt.label }} — {{ opt.hint }}
+                  </option>
+                </select>
+              </div>
+              <div>
+                <label
+                  for="sessionDuration"
+                  class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-2"
+                >
+                  Duration (min)
+                </label>
+                <input
+                  id="sessionDuration"
+                  v-model.number="sessionForm.durationMinutes"
+                  type="number"
+                  min="1"
+                  max="1440"
+                  placeholder="—"
+                  class="w-full px-4 py-2 border border-verse-300 dark:border-verse-600 squircle rounded-lg bg-white dark:bg-verse-700 text-verse-900 dark:text-verse-100 focus:ring-2 focus:ring-verse-500 focus:border-transparent"
+                />
+              </div>
+            </div>
+
+            <!-- Sponsor (sponsored kind only) -->
+            <div v-if="showSponsor">
+              <label
+                for="sessionSponsor"
+                class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-2"
+              >
+                Sponsor *
+              </label>
+              <select
+                id="sessionSponsor"
+                v-model="sessionForm.sponsorId"
+                class="w-full px-4 py-2 border border-verse-300 dark:border-verse-600 squircle rounded-lg bg-white dark:bg-verse-700 text-verse-900 dark:text-verse-100 focus:ring-2 focus:ring-verse-500 focus:border-transparent"
+              >
+                <option :value="null">— Pick a sponsor —</option>
+                <option v-for="sp in sponsors" :key="sp.id" :value="sp.id">
+                  {{ sp.name }}
+                </option>
+              </select>
+              <p
+                v-if="sponsors.length === 0"
+                class="mt-2 text-xs text-verse-500 dark:text-verse-400"
+              >
+                Attach sponsors to this event first (below the Sessions section).
+              </p>
+            </div>
+
             <!-- Speakers -->
-            <div>
+            <div v-if="showSpeakers">
               <label class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-2">
                 Speakers
               </label>
@@ -847,10 +956,32 @@ async function removeSponsor(sponsorId: string) {
             <h3 class="text-lg font-medium text-verse-900 dark:text-verse-100">Sessions</h3>
             <button
               type="button"
-              @click="openNewSessionForm"
+              @click="() => openNewSessionForm()"
               class="px-4 py-2 bg-verse-600 hover:bg-verse-700 text-white text-sm font-medium squircle rounded-lg transition-colors"
             >
               Add Session
+            </button>
+          </div>
+
+          <!-- Quick-add presets -->
+          <div class="flex flex-wrap items-center gap-2 mb-4 pb-4 border-b border-verse-200 dark:border-verse-700">
+            <span class="text-xs font-medium text-verse-500 dark:text-verse-400 uppercase tracking-wide">
+              Quick add
+            </span>
+            <button
+              v-for="preset in [
+                { key: 'intro', label: '+ Intro' },
+                { key: 'break', label: '+ Lunch break' },
+                { key: 'photo', label: '+ Group photo' },
+                { key: 'quiz', label: '+ Quiz' },
+                { key: 'sponsored', label: '+ Sponsored' },
+              ]"
+              :key="preset.key"
+              type="button"
+              @click="openNewSessionForm(preset.key as 'intro' | 'break' | 'photo' | 'quiz' | 'sponsored')"
+              class="px-2.5 py-1 text-xs font-medium text-verse-700 dark:text-verse-300 bg-white dark:bg-verse-700 border border-verse-300 dark:border-verse-600 hover:border-verse-500 hover:text-verse-900 dark:hover:text-verse-100 squircle rounded-md transition-colors"
+            >
+              {{ preset.label }}
             </button>
           </div>
 
@@ -885,15 +1016,27 @@ async function removeSponsor(sponsorId: string) {
                     </svg>
                   </div>
                   <div class="flex-1 min-w-0">
-                    <div class="flex items-center gap-2 mb-1">
+                    <div class="flex items-center gap-2 mb-1 flex-wrap">
                       <span
                         class="px-2 py-0.5 bg-verse-200 dark:bg-verse-600 text-verse-700 dark:text-verse-200 text-xs font-medium rounded"
                       >
                         #{{ index + 1 }}
                       </span>
+                      <span
+                        v-if="session.kind && session.kind !== 'talk'"
+                        class="px-2 py-0.5 bg-coral-soft text-coral-strong text-[10.5px] font-mono font-semibold uppercase tracking-wider rounded"
+                      >
+                        {{ session.kind }}
+                      </span>
                       <h4 class="font-medium text-verse-900 dark:text-verse-100 truncate">
                         {{ session.title }}
                       </h4>
+                      <span
+                        v-if="session.durationMinutes"
+                        class="text-xs font-mono text-verse-500 dark:text-verse-400"
+                      >
+                        · {{ session.durationMinutes }}m
+                      </span>
                     </div>
                     <p
                       v-if="session.description"

--- a/packages/frontendmu-adonis/inertia/pages/admin/events/edit.vue
+++ b/packages/frontendmu-adonis/inertia/pages/admin/events/edit.vue
@@ -159,9 +159,9 @@ function openEditSessionForm(session: Data.Session) {
   sessionForm.value = {
     title: session.title,
     description: session.description || '',
-    kind: ((session as { kind?: SessionKind }).kind ?? 'talk') as SessionKind,
-    sponsorId: (session as { sponsorId?: string | null }).sponsorId ?? null,
-    durationMinutes: (session as { durationMinutes?: number | null }).durationMinutes ?? null,
+    kind: (session.kind ?? 'talk') as SessionKind,
+    sponsorId: session.sponsorId ?? null,
+    durationMinutes: session.durationMinutes ?? null,
     speakerIds: session.speakers?.map((s) => s.id) || [],
   }
   sessionFormErrors.value = {}

--- a/packages/frontendmu-adonis/inertia/pages/meetups/index.vue
+++ b/packages/frontendmu-adonis/inertia/pages/meetups/index.vue
@@ -4,7 +4,7 @@ import { Head } from '@inertiajs/vue3'
 import { Link } from '@inertiajs/vue3'
 import type { Data } from '@generated/data'
 import EventCard from '~/components/event/EventCard.vue'
-import { isDateInFuture, isDateToday } from '~/utils/date'
+import { isDateInFuture, isDateInPast, isDateToday } from '~/utils/date'
 
 interface Props {
   meetups: Data.Event[]
@@ -35,12 +35,14 @@ const nextMeetup = computed(() => {
 
 const nextMeetupId = computed(() => nextMeetup.value?.id)
 
-// Apply search + status filter
+// Apply search + status filter. "Upcoming" includes same-day meetups; they're
+// only moved to "Past" the day after.
 const filteredMeetups = computed(() => {
   const q = query.value.trim().toLowerCase()
   return props.meetups.filter((m) => {
     if (statusFilter.value !== 'all') {
-      const isUpcoming = m.date ? isDateInFuture(new Date(m.date)) : false
+      const d = m.date ? new Date(m.date) : null
+      const isUpcoming = d ? !isDateInPast(d) : false
       if (statusFilter.value === 'upcoming' && !isUpcoming) return false
       if (statusFilter.value === 'past' && isUpcoming) return false
     }

--- a/packages/frontendmu-adonis/inertia/pages/meetups/index.vue
+++ b/packages/frontendmu-adonis/inertia/pages/meetups/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import { Head } from '@inertiajs/vue3'
 import { Link } from '@inertiajs/vue3'
 import type { Data } from '@generated/data'
@@ -13,66 +13,101 @@ interface Props {
 
 const props = defineProps<Props>()
 
-// Group meetups by year
+// Filter state
+type StatusFilter = 'all' | 'upcoming' | 'past'
+const query = ref('')
+const statusFilter = ref<StatusFilter>('all')
+
+const upcomingMeetups = computed(() =>
+  props.meetups.filter((m) => (m.date ? isDateInFuture(new Date(m.date)) : false))
+)
+
+const todaysMeetups = computed(() =>
+  props.meetups.filter((m) => (m.date ? isDateToday(new Date(m.date)) : false))
+)
+
+const nextMeetup = computed(() => {
+  const sorted = [...upcomingMeetups.value].sort(
+    (a, b) => new Date(a.date!).getTime() - new Date(b.date!).getTime()
+  )
+  return sorted[0]
+})
+
+const nextMeetupId = computed(() => nextMeetup.value?.id)
+
+// Apply search + status filter
+const filteredMeetups = computed(() => {
+  const q = query.value.trim().toLowerCase()
+  return props.meetups.filter((m) => {
+    if (statusFilter.value !== 'all') {
+      const isUpcoming = m.date ? isDateInFuture(new Date(m.date)) : false
+      if (statusFilter.value === 'upcoming' && !isUpcoming) return false
+      if (statusFilter.value === 'past' && isUpcoming) return false
+    }
+    if (!q) return true
+    return (
+      m.title.toLowerCase().includes(q) ||
+      (m.venue ?? '').toLowerCase().includes(q) ||
+      (m.date ?? '').toLowerCase().includes(q)
+    )
+  })
+})
+
+// Group filtered meetups by year
 const meetupsGroupedByYear = computed(() => {
-  return props.meetups.reduce((acc: Record<number, Data.Event[]>, event) => {
+  return filteredMeetups.value.reduce((acc: Record<number, Data.Event[]>, event) => {
     if (!event.date) return acc
     const year = new Date(event.date).getFullYear()
-    if (!acc[year]) {
-      acc[year] = []
-    }
+    if (!acc[year]) acc[year] = []
     acc[year].push(event)
     return acc
   }, {})
 })
 
-// Get years in descending order
 const years = computed(() =>
   Object.keys(meetupsGroupedByYear.value)
     .map(Number)
     .sort((a, b) => b - a)
 )
 
-// Get upcoming meetups
-const upcomingMeetups = computed(() =>
-  props.meetups.filter((meetup) => {
-    return meetup.date ? isDateInFuture(new Date(meetup.date)) : false
-  })
+const totalAttendees = computed(() =>
+  props.meetups.reduce((sum, m) => sum + (m.attendeeCount ?? 0), 0)
 )
 
-// Get next meetup
-const nextMeetup = computed(() => {
-  const sorted = [...upcomingMeetups.value].sort((a, b) => {
-    return new Date(a.date!).getTime() - new Date(b.date!).getTime()
-  })
-  return sorted[0]
-})
+function clearFilters() {
+  query.value = ''
+  statusFilter.value = 'all'
+}
 
-// Get today's meetups
-const todaysMeetups = computed(() =>
-  props.meetups.filter((meetup) => {
-    return meetup.date ? isDateToday(new Date(meetup.date)) : false
-  })
-)
+function yearAttendees(year: number) {
+  return (meetupsGroupedByYear.value[year] || []).reduce(
+    (sum, m) => sum + (m.attendeeCount ?? 0),
+    0
+  )
+}
 
-const nextMeetupId = computed(() => nextMeetup.value?.id)
+// Promote the upcoming meetup (or latest past meetup of its year) as "featured" within its own year
+function featuredForYear(year: number): Data.Event | undefined {
+  const items = meetupsGroupedByYear.value[year] || []
+  if (nextMeetup.value && new Date(nextMeetup.value.date!).getFullYear() === year) {
+    return items.find((m) => m.id === nextMeetup.value!.id)
+  }
+  return undefined
+}
 </script>
 
 <template>
   <Head title="All Meetups" />
-  <main class="relative min-h-screen pt-40 pb-32">
-    <div class="contain relative z-10 max-w-5xl">
+  <main class="relative min-h-screen pt-32 pb-24">
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 relative z-10">
       <!-- Page Header -->
-      <div class="mb-16 space-y-4">
-        <div class="flex flex-col md:flex-row md:items-baseline justify-between gap-4">
-          <div>
-            <h1
-              class="text-3xl md:text-4xl font-display tracking-tight text-gray-900 dark:text-white leading-none"
-            >
-              Meetup Archive
-            </h1>
-          </div>
-
+      <header class="mb-10 max-w-3xl space-y-4">
+        <div class="flex items-center justify-between flex-wrap gap-3">
+          <p class="mono-eyebrow">
+            <span>CODERS.MU</span>
+            <span class="sep">/</span>
+            <span>MEETUPS</span>
+          </p>
           <Link
             v-if="canCreate"
             href="/admin/events/create"
@@ -81,57 +116,145 @@ const nextMeetupId = computed(() => nextMeetup.value?.id)
             + Create Event
           </Link>
         </div>
+
+        <h1
+          class="font-display text-[clamp(48px,6vw,88px)] leading-[0.98] text-gray-900 dark:text-white text-balance"
+        >
+          Every meetup, <span class="font-display-italic text-verse-500 dark:text-verse-300">every year</span>
+        </h1>
+
+        <p class="text-[18px] leading-[1.55] text-gray-500 dark:text-gray-400 max-w-[58ch]">
+          Over the years, we've organized {{ meetups.length }}+ meetups around the island — from beachside hacks to
+          late-night terminal talks<template v-if="totalAttendees">. {{ totalAttendees.toLocaleString() }}+ builders
+          have shown up</template>. Here's all of them.
+        </p>
+      </header>
+
+      <!-- Filter row -->
+      <div
+        class="filter-row flex flex-wrap items-center gap-3 py-4 mb-6 border-y border-gray-200 dark:border-verse-900"
+      >
+        <label
+          class="search-input flex items-center gap-2.5 flex-1 min-w-[220px] px-3.5 py-2.5 rounded-lg bg-white dark:bg-verse-950 border border-gray-200 dark:border-verse-800 focus-within:border-verse-500 transition-colors"
+        >
+          <svg class="w-4 h-4 text-gray-400 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="11" cy="11" r="7" />
+            <path d="m20 20-3.5-3.5" />
+          </svg>
+          <input
+            v-model="query"
+            type="text"
+            placeholder="Search by title, venue, year…"
+            class="flex-1 bg-transparent border-none outline-none text-sm text-gray-900 dark:text-gray-100 placeholder:text-gray-400"
+          />
+        </label>
+
+        <div
+          class="pill-filter inline-flex p-1 rounded-full bg-gray-50 dark:bg-verse-900 border border-gray-200 dark:border-verse-800"
+        >
+          <button
+            v-for="option in [
+              { k: 'all', label: 'All' },
+              { k: 'upcoming', label: 'Upcoming' },
+              { k: 'past', label: 'Past' },
+            ]"
+            :key="option.k"
+            type="button"
+            class="px-3.5 py-1.5 rounded-full font-mono text-[11px] font-semibold uppercase tracking-widest transition-colors"
+            :class="
+              statusFilter === option.k
+                ? 'bg-gray-900 dark:bg-white text-white dark:text-gray-900'
+                : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'
+            "
+            @click="statusFilter = option.k as StatusFilter"
+          >
+            {{ option.label }}
+          </button>
+        </div>
+
+        <div
+          class="filter-count font-mono text-[11px] uppercase tracking-wider text-gray-400 dark:text-gray-500 sm:ml-auto"
+        >
+          Showing
+          <strong class="text-gray-900 dark:text-gray-100 font-bold">{{ filteredMeetups.length }}</strong>
+          of {{ meetups.length }}
+        </div>
+      </div>
+
+      <!-- Empty state (after filter) -->
+      <div
+        v-if="meetups.length && !filteredMeetups.length"
+        class="py-20 text-center font-mono text-sm text-gray-500 dark:text-gray-400"
+      >
+        No meetups match <strong class="text-gray-900 dark:text-gray-100">&ldquo;{{ query }}&rdquo;</strong>.
+        <div class="mt-4">
+          <button
+            type="button"
+            class="inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-gray-200 dark:border-verse-800 text-xs font-semibold text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-verse-900"
+            @click="clearFilters"
+          >
+            Clear filters
+          </button>
+        </div>
       </div>
 
       <!-- Timeline Grid -->
       <div class="space-y-16">
         <template v-for="year in years" :key="year">
-          <div class="relative group/year">
-            <div class="flex flex-col md:flex-row gap-8">
-              <!-- Year Header -->
-              <div class="md:w-24 shrink-0">
-                <div class="sticky top-24">
-                  <span class="text-3xl font-display text-gray-300 dark:text-gray-600 select-none">
-                    {{ year }}
-                  </span>
-                </div>
-              </div>
-
-              <!-- Events Grid -->
-              <div class="flex-1 grid grid-cols-1 md:grid-cols-2 gap-4">
-                <EventCard
-                  v-for="event in meetupsGroupedByYear[year]"
-                  :key="event.id"
-                  :event="event"
-                  :is-next-meetup="event.id === nextMeetupId"
-                  :is-meetup-today="todaysMeetups.some((meetup) => meetup.id === event.id)"
-                />
-              </div>
+          <section class="year-section relative">
+            <!-- Giant vertical year label -->
+            <div
+              aria-hidden="true"
+              class="year-label absolute left-[-8px] top-[160px] font-display font-normal pointer-events-none select-none hidden md:block text-gray-200/90 dark:text-verse-900"
+              :style="{
+                fontSize: 'clamp(80px, 12vw, 180px)',
+                lineHeight: '0.8',
+                letterSpacing: '-0.04em',
+                writingMode: 'vertical-rl',
+                transform: 'rotate(180deg)',
+                zIndex: 0,
+              }"
+            >
+              {{ year }}
             </div>
 
-            <!-- Year Divider -->
-            <div class="mt-16 h-px w-full bg-gray-100 dark:bg-verse-900"></div>
-          </div>
+            <!-- Year header -->
+            <div class="relative z-10 flex items-baseline gap-5 mb-7 md:pl-20">
+              <h2 class="font-display text-[32px] md:text-[38px] leading-none tracking-tight text-gray-900 dark:text-gray-100">
+                {{ year }}
+              </h2>
+              <span class="font-mono text-[11px] uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                {{ meetupsGroupedByYear[year].length }} meetup<template v-if="meetupsGroupedByYear[year].length !== 1">s</template>
+                <template v-if="yearAttendees(year)"> · {{ yearAttendees(year) }} attendees</template>
+              </span>
+            </div>
+
+            <!-- Events Grid -->
+            <div class="relative z-10 md:pl-20 grid grid-cols-1 md:grid-cols-2 gap-5">
+              <template v-for="event in meetupsGroupedByYear[year]" :key="event.id">
+                <div
+                  :class="event.id === featuredForYear(year)?.id ? 'md:col-span-2' : ''"
+                >
+                  <EventCard
+                    :event="event"
+                    :is-next-meetup="event.id === nextMeetupId"
+                    :is-meetup-today="todaysMeetups.some((m) => m.id === event.id)"
+                    :featured="event.id === featuredForYear(year)?.id"
+                  />
+                </div>
+              </template>
+            </div>
+          </section>
         </template>
       </div>
 
-      <!-- Empty state -->
+      <!-- Empty state (no meetups at all) -->
       <div v-if="!meetups.length" class="text-center py-32 space-y-6">
         <div
           class="w-16 h-16 bg-gray-50 dark:bg-verse-900 rounded-lg flex items-center justify-center mx-auto"
         >
-          <svg
-            class="w-8 h-8 text-gray-400 dark:text-gray-500"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
-            />
+          <svg class="w-8 h-8 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
           </svg>
         </div>
         <p class="text-2xl font-bold text-gray-400">No meetups found in the archives.</p>
@@ -141,33 +264,11 @@ const nextMeetupId = computed(() => nextMeetup.value?.id)
 </template>
 
 <style scoped>
-@keyframes list-item-scroll-effect {
-  0% {
-    opacity: 0;
-    transform: scale(0.95);
-  }
-
-  20%,
-  80% {
-    opacity: 1;
-    transform: scale(1);
-  }
-
-  100% {
-    opacity: 0;
-    transform: scale(0.95);
-  }
+.year-section + .year-section {
+  border-top: 1px dashed var(--color-gray-200, #e5e7eb);
+  padding-top: 4rem;
 }
-
-@supports (animation-timeline: view()) {
-  .card-entrance {
-    view-timeline-name: --list-item-timeline;
-    animation-timeline: --list-item-timeline;
-    animation-range-start: entry 20%;
-    animation-range-end: cover 95%;
-    animation-fill-mode: both;
-    animation-name: list-item-scroll-effect;
-    transform-origin: center center;
-  }
+:global(html.dark) .year-section + .year-section {
+  border-top-color: var(--color-verse-900);
 }
 </style>

--- a/packages/frontendmu-adonis/inertia/pages/meetups/show.vue
+++ b/packages/frontendmu-adonis/inertia/pages/meetups/show.vue
@@ -446,7 +446,8 @@ const calendarUrl = computed(() => {
                 <li
                   v-for="session in meetup.sessions"
                   :key="session.id"
-                  class="agenda-session flex items-start gap-4 py-5"
+                  class="agenda-session flex gap-4 py-5"
+                  :class="session.kind === 'talk' || session.kind === 'other' ? 'items-start' : 'items-center'"
                 >
                   <!-- Left medallion: avatar (talk) OR sponsor logo OR icon -->
                   <div class="shrink-0">
@@ -529,17 +530,12 @@ const calendarUrl = computed(() => {
                       </span>
                     </p>
 
-                    <!-- Talk / intro / quiz / sponsored / other: title row -->
-                    <template v-else>
+                    <!-- Talk / other: title + speakers stacked -->
+                    <template v-else-if="session.kind === 'talk' || session.kind === 'other'">
                       <div class="flex items-baseline gap-3 flex-wrap">
-                        <component
-                          :is="session.kind === 'sponsored' && session.sponsor ? 'Link' : 'h3'"
-                          :href="session.kind === 'sponsored' && session.sponsor ? `/sponsor/${session.sponsor.id}` : undefined"
-                          class="font-display text-[22px] md:text-[24px] leading-[1.2] text-gray-900 dark:text-gray-100"
-                          :class="session.kind === 'sponsored' && session.sponsor ? 'hover:text-verse-500 transition-colors' : ''"
-                        >
+                        <h3 class="font-display text-[22px] md:text-[24px] leading-[1.2] text-gray-900 dark:text-gray-100">
                           {{ session.title }}
-                        </component>
+                        </h3>
                         <span
                           v-if="session.durationMinutes"
                           class="font-mono text-[11.5px] text-gray-400 dark:text-gray-500"
@@ -547,10 +543,8 @@ const calendarUrl = computed(() => {
                           {{ session.durationMinutes }} min
                         </span>
                       </div>
-
-                      <!-- Speakers subtitle: only for talks; "Hosted by" for quiz -->
                       <div
-                        v-if="session.speakers?.length && (session.kind === 'talk' || session.kind === 'other')"
+                        v-if="session.speakers?.length"
                         class="mt-1.5 flex flex-wrap gap-x-3 gap-y-1 text-[14px] text-gray-500 dark:text-gray-400"
                       >
                         <Link
@@ -562,19 +556,61 @@ const calendarUrl = computed(() => {
                           {{ speaker.name }}<template v-if="i < session.speakers.length - 1">,</template>
                         </Link>
                       </div>
-                      <p
-                        v-else-if="session.kind === 'quiz' && session.speakers?.length"
-                        class="mt-1.5 text-[14px] text-gray-500 dark:text-gray-400"
+                    </template>
+
+                    <!-- Intro / quiz / sponsored: title + related entity inline -->
+                    <div v-else class="flex items-baseline gap-x-3 gap-y-1 flex-wrap">
+                      <component
+                        :is="session.kind === 'sponsored' && session.sponsor ? 'Link' : 'h3'"
+                        :href="session.kind === 'sponsored' && session.sponsor ? `/sponsor/${session.sponsor.id}` : undefined"
+                        class="font-display text-[22px] md:text-[24px] leading-[1.2] text-gray-900 dark:text-gray-100"
+                        :class="session.kind === 'sponsored' && session.sponsor ? 'hover:text-verse-500 transition-colors' : ''"
                       >
-                        Hosted by
+                        {{ session.title }}
+                      </component>
+                      <span
+                        v-if="session.kind === 'sponsored' && session.sponsor"
+                        class="text-[14px] text-gray-500 dark:text-gray-400"
+                      >
+                        ·
+                        <Link
+                          :href="`/sponsor/${session.sponsor.id}`"
+                          class="hover:text-verse-500 transition-colors"
+                        >
+                          {{ session.sponsor.name }}
+                        </Link>
+                      </span>
+                      <span
+                        v-else-if="session.kind === 'quiz' && session.speakers?.length"
+                        class="text-[14px] text-gray-500 dark:text-gray-400"
+                      >
+                        · Hosted by
                         <Link
                           v-for="(speaker, i) in session.speakers"
                           :key="speaker.id"
                           :href="`/speaker/${speaker.id}`"
                           class="hover:text-verse-500 dark:hover:text-verse-400 transition-colors"
                         >{{ speaker.name }}<template v-if="i < session.speakers.length - 1">,</template></Link>
-                      </p>
-                    </template>
+                      </span>
+                      <span
+                        v-else-if="session.speakers?.length"
+                        class="text-[14px] text-gray-500 dark:text-gray-400"
+                      >
+                        ·
+                        <Link
+                          v-for="(speaker, i) in session.speakers"
+                          :key="speaker.id"
+                          :href="`/speaker/${speaker.id}`"
+                          class="hover:text-verse-500 dark:hover:text-verse-400 transition-colors"
+                        >{{ speaker.name }}<template v-if="i < session.speakers.length - 1">,</template></Link>
+                      </span>
+                      <span
+                        v-if="session.durationMinutes"
+                        class="font-mono text-[11.5px] text-gray-400 dark:text-gray-500"
+                      >
+                        {{ session.durationMinutes }} min
+                      </span>
+                    </div>
                   </div>
                 </li>
               </ol>

--- a/packages/frontendmu-adonis/inertia/pages/meetups/show.vue
+++ b/packages/frontendmu-adonis/inertia/pages/meetups/show.vue
@@ -432,90 +432,143 @@ const calendarUrl = computed(() => {
             <!-- About -->
             <section v-if="meetup.description" class="pb-12 border-b border-gray-200 dark:border-verse-900">
               <span class="section-label">About this meetup</span>
-              <h2 class="font-display text-[clamp(28px,3.8vw,36px)] leading-[1.05] text-gray-900 dark:text-gray-100 mt-3">
-                What to expect when you <span class="font-display-italic text-verse-500 dark:text-verse-300">join us</span>
-              </h2>
               <div
-                class="prose prose-lg dark:prose-invert max-w-[68ch] mt-5 leading-[1.7] text-gray-700 dark:text-gray-400"
+                class="prose prose-lg dark:prose-invert max-w-[68ch] mt-6 text-[19px] leading-[1.75] text-gray-700 dark:text-gray-400"
                 v-html="sanitizeHtml(meetup.description)"
               />
             </section>
 
-            <!-- Agenda (timeline) -->
+            <!-- Agenda -->
             <section v-if="meetup.sessions.length" class="py-12 border-b border-gray-200 dark:border-verse-900">
               <span class="section-label">Agenda</span>
-              <h2 class="font-display text-[clamp(28px,3.8vw,36px)] leading-[1.05] text-gray-900 dark:text-gray-100 mt-3">
-                {{ meetup.sessions.length }} session<template v-if="meetup.sessions.length !== 1">s</template>,
-                <span class="font-display-italic text-verse-500 dark:text-verse-300">one day</span>
-              </h2>
 
-              <div class="mt-8">
-                <article
-                  v-for="(session, index) in meetup.sessions"
-                  :key="session.id"
-                  class="agenda-session grid grid-cols-[90px_1fr] md:grid-cols-[110px_1fr] gap-6 md:gap-7 py-6 border-b border-dashed border-gray-200 dark:border-verse-900 last:border-b-0 relative"
-                >
-                  <div class="font-mono text-[13px] font-semibold text-verse-600 dark:text-verse-300 relative pt-1">
-                    <span>{{ session.startTime || '—' }}</span>
-                    <!-- timeline dot -->
+              <div class="mt-7">
+                <template v-for="session in meetup.sessions" :key="session.id">
+                  <!-- Minimal row: break / photo -->
+                  <article
+                    v-if="session.kind === 'break' || session.kind === 'photo'"
+                    class="agenda-session flex items-center gap-4 py-5 border-b border-dashed border-gray-200 dark:border-verse-900 last:border-b-0"
+                  >
                     <span
-                      class="hidden md:block absolute right-[-20px] top-[8px] w-[9px] h-[9px] rounded-full bg-white dark:bg-verse-950 border-2 border-verse-600 dark:border-verse-300"
-                    />
-                  </div>
-                  <div class="md:pl-5 border-l border-gray-200 dark:border-verse-900">
-                    <div class="flex flex-wrap items-center gap-2 mb-2">
-                      <span v-if="session.kind" class="font-mono text-[10.5px] uppercase tracking-[0.05em] font-medium px-1.5 py-0.5 rounded bg-verse-50 dark:bg-verse-900 text-verse-600 dark:text-verse-300">
-                        {{ session.kind }}
-                      </span>
-                      <span v-if="session.duration" class="font-mono text-[11.5px] text-gray-400 dark:text-gray-500">
-                        {{ session.duration }}
+                      class="w-9 h-9 rounded-[10px] bg-gray-50 dark:bg-verse-900/60 text-gray-500 dark:text-gray-400 grid place-items-center shrink-0"
+                    >
+                      <svg v-if="session.kind === 'break'" class="w-[18px] h-[18px]" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M17 8h1a4 4 0 0 1 0 8h-1" />
+                        <path d="M3 8h14v9a4 4 0 0 1-4 4H7a4 4 0 0 1-4-4z" />
+                        <path d="M6 2v3M10 2v3M14 2v3" />
+                      </svg>
+                      <svg v-else class="w-[18px] h-[18px]" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z" />
+                        <circle cx="12" cy="13" r="4" />
+                      </svg>
+                    </span>
+                    <p class="flex-1 text-[17px] text-gray-700 dark:text-gray-300">
+                      {{ session.title }}
+                    </p>
+                    <span
+                      v-if="session.durationMinutes"
+                      class="font-mono text-[12px] text-gray-400 dark:text-gray-500"
+                    >
+                      {{ session.durationMinutes }} min
+                    </span>
+                  </article>
+
+                  <!-- Sponsored row -->
+                  <article
+                    v-else-if="session.kind === 'sponsored' && session.sponsor"
+                    class="agenda-session py-6 border-b border-dashed border-gray-200 dark:border-verse-900 last:border-b-0"
+                  >
+                    <span class="font-mono text-[10.5px] uppercase tracking-[0.14em] text-coral-strong font-semibold">
+                      Sponsor spotlight
+                    </span>
+                    <div class="mt-2 flex items-center gap-4 flex-wrap">
+                      <Link
+                        :href="`/sponsor/${session.sponsor.id}`"
+                        class="flex items-center gap-4 group/sponsor"
+                      >
+                        <img
+                          v-if="session.sponsor.logoUrl || session.sponsor.logomarkUrl"
+                          :src="(session.sponsor.logoUrl || session.sponsor.logomarkUrl) as string"
+                          :alt="session.sponsor.name"
+                          class="h-10 w-auto object-contain opacity-90 group-hover/sponsor:opacity-100 transition-opacity"
+                        />
+                        <div class="leading-tight">
+                          <h3 class="font-display text-[24px] md:text-[26px] leading-[1.15] text-gray-900 dark:text-gray-100">
+                            {{ session.title }}
+                          </h3>
+                          <p class="mt-1 text-[14px] text-gray-500 dark:text-gray-400 group-hover/sponsor:text-verse-500 transition-colors">
+                            by {{ session.sponsor.name }}
+                          </p>
+                        </div>
+                      </Link>
+                      <span
+                        v-if="session.durationMinutes"
+                        class="font-mono text-[12px] text-gray-400 dark:text-gray-500 ml-auto"
+                      >
+                        {{ session.durationMinutes }} min
                       </span>
                     </div>
-                    <h3 class="font-display text-[20px] md:text-[22px] leading-tight text-gray-900 dark:text-gray-100">
+                  </article>
+
+                  <!-- Talk / intro / quiz / other: full card with speakers -->
+                  <article
+                    v-else
+                    class="agenda-session py-8 border-b border-dashed border-gray-200 dark:border-verse-900 last:border-b-0"
+                  >
+                    <div class="flex items-center gap-3 mb-2 flex-wrap">
+                      <span
+                        v-if="session.kind && session.kind !== 'talk'"
+                        class="px-2 py-0.5 bg-verse-50 dark:bg-verse-900 text-verse-600 dark:text-verse-300 text-[10.5px] font-mono font-semibold uppercase tracking-[0.12em] rounded"
+                      >
+                        {{ session.kind }}
+                      </span>
+                      <span
+                        v-if="session.durationMinutes"
+                        class="font-mono text-[12px] text-gray-400 dark:text-gray-500"
+                      >
+                        {{ session.durationMinutes }} min
+                      </span>
+                    </div>
+                    <h3 class="font-display text-[26px] md:text-[30px] leading-[1.1] text-gray-900 dark:text-gray-100">
                       {{ session.title }}
                     </h3>
-                    <div v-if="session.speakers?.length" class="mt-3 flex flex-wrap gap-4">
+                    <div v-if="session.speakers?.length" class="mt-4 flex flex-wrap gap-x-6 gap-y-4">
                       <Link
                         v-for="speaker in session.speakers"
                         :key="speaker.id"
                         :href="`/speaker/${speaker.id}`"
-                        class="flex items-center gap-2.5 group/speaker"
+                        class="flex items-center gap-3 group/speaker"
                       >
                         <SpeakerAvatar
-                          size="sm"
+                          size="md"
                           :name="speaker.name"
                           :github-username="speaker.githubUsername"
                           class="ring-2 ring-gray-100 dark:ring-verse-900 group-hover/speaker:ring-verse-500 transition-all"
                         />
                         <div class="leading-tight">
-                          <p class="text-sm font-semibold text-gray-900 dark:text-gray-200 group-hover/speaker:text-verse-500 transition-colors">
+                          <p class="text-[15px] font-semibold text-gray-900 dark:text-gray-200 group-hover/speaker:text-verse-500 transition-colors">
                             {{ speaker.name }}
                           </p>
-                          <p v-if="speaker.githubUsername" class="text-[11px] text-gray-400 mt-0.5 font-mono">
+                          <p v-if="speaker.githubUsername" class="text-[12px] text-gray-400 mt-1 font-mono">
                             @{{ speaker.githubUsername }}
                           </p>
                         </div>
                       </Link>
                     </div>
-                  </div>
-                </article>
+                  </article>
+                </template>
               </div>
             </section>
 
             <!-- Speakers (dedicated card grid when we have them) -->
             <section v-if="allSpeakers.length" class="py-12 border-b border-gray-200 dark:border-verse-900">
               <span class="section-label">Speakers</span>
-              <h2 class="font-display text-[clamp(28px,3.8vw,36px)] leading-[1.05] text-gray-900 dark:text-gray-100 mt-3">
-                {{ allSpeakers.length }}
-                builder<template v-if="allSpeakers.length !== 1">s</template>,
-                <span class="font-display-italic text-verse-500 dark:text-verse-300">one lineup</span>
-              </h2>
               <div class="mt-6 grid grid-cols-1 sm:grid-cols-2 gap-4">
                 <Link
                   v-for="sp in allSpeakers"
                   :key="sp.id"
                   :href="`/speaker/${sp.id}`"
-                  class="flex items-start gap-4 p-4 rounded-xl border border-gray-200 dark:border-verse-900 hover:border-verse-300 dark:hover:border-verse-700 bg-white dark:bg-verse-950 transition-colors"
+                  class="flex items-start gap-4 p-5 rounded-xl border border-gray-200 dark:border-verse-900 hover:border-verse-300 dark:hover:border-verse-700 bg-white dark:bg-verse-950 transition-colors"
                 >
                   <SpeakerAvatar
                     size="md"
@@ -525,10 +578,10 @@ const calendarUrl = computed(() => {
                     class="shrink-0"
                   />
                   <div class="min-w-0">
-                    <p class="font-display text-[18px] text-gray-900 dark:text-gray-100 leading-tight">
+                    <p class="font-display text-[22px] text-gray-900 dark:text-gray-100 leading-[1.15]">
                       {{ sp.name }}
                     </p>
-                    <p v-if="sp.githubUsername" class="font-mono text-[11px] uppercase tracking-[0.08em] text-verse-600 dark:text-verse-400 mt-1.5">
+                    <p v-if="sp.githubUsername" class="font-mono text-[12px] uppercase tracking-[0.08em] text-verse-600 dark:text-verse-400 mt-2">
                       @{{ sp.githubUsername }}
                     </p>
                   </div>
@@ -538,12 +591,7 @@ const calendarUrl = computed(() => {
 
             <!-- Attendees -->
             <section v-if="attendees.length > 0" class="py-12 border-b border-gray-200 dark:border-verse-900">
-              <span class="section-label">Who's coming</span>
-              <h2 class="font-display text-[clamp(28px,3.8vw,36px)] leading-[1.05] text-gray-900 dark:text-gray-100 mt-3">
-                <span class="font-display-italic text-verse-500 dark:text-verse-300">{{ rsvpCount }} builder<template v-if="rsvpCount !== 1">s</template></span>
-                <template v-if="isPast"> showed up</template>
-                <template v-else> already in</template>
-              </h2>
+              <span class="section-label">{{ isPast ? 'Who came' : "Who's coming" }}</span>
               <div class="mt-6 flex items-center gap-4 flex-wrap">
                 <div class="flex -space-x-2.5">
                   <template v-for="attendee in attendees.slice(0, 8)" :key="attendee.id">
@@ -562,7 +610,7 @@ const calendarUrl = computed(() => {
                     +{{ attendees.length - 8 }}
                   </div>
                 </div>
-                <p class="font-mono text-[13px] text-gray-500 dark:text-gray-400">
+                <p class="font-mono text-[14px] text-gray-500 dark:text-gray-400">
                   <strong class="text-gray-900 dark:text-gray-100 font-bold">{{ rsvpCount }} attending</strong>
                   <template v-if="spotsRemaining !== null && !isPast"> · {{ spotsRemaining }} spots left</template>
                 </p>
@@ -571,13 +619,8 @@ const calendarUrl = computed(() => {
 
             <!-- Photo Gallery (past only) -->
             <section v-if="meetup.photos.length" class="py-12 border-b border-gray-200 dark:border-verse-900">
-              <div class="flex items-end justify-between gap-4 flex-wrap">
-                <div>
-                  <span class="section-label">Event Recap</span>
-                  <h2 class="font-display text-[clamp(28px,3.8vw,36px)] leading-[1.05] text-gray-900 dark:text-gray-100 mt-3">
-                    A look <span class="font-display-italic text-verse-500 dark:text-verse-300">back</span>
-                  </h2>
-                </div>
+              <div class="flex items-center justify-between gap-4 flex-wrap">
+                <span class="section-label">Photos</span>
                 <span class="font-mono text-[11px] uppercase tracking-[0.08em] text-gray-400 dark:text-gray-500">
                   {{ meetup.photos.length }} photos · tap to expand
                 </span>
@@ -603,9 +646,6 @@ const calendarUrl = computed(() => {
             <!-- Sponsors -->
             <section v-if="meetup.sponsors.length" class="py-12 border-b border-gray-200 dark:border-verse-900">
               <span class="section-label">Sponsors</span>
-              <h2 class="font-display text-[clamp(28px,3.8vw,36px)] leading-[1.05] text-gray-900 dark:text-gray-100 mt-3">
-                Made possible by <span class="font-display-italic text-verse-500 dark:text-verse-300">local support</span>
-              </h2>
               <div
                 class="mt-6 flex flex-wrap gap-x-10 gap-y-4 items-center px-7 py-6 rounded-xl border border-dashed border-gray-300 dark:border-verse-800 bg-white dark:bg-verse-950"
               >

--- a/packages/frontendmu-adonis/inertia/pages/meetups/show.vue
+++ b/packages/frontendmu-adonis/inertia/pages/meetups/show.vue
@@ -63,11 +63,13 @@ const spotsRemaining = computed(() => {
   return Math.max(0, props.meetup.seatsAvailable - props.rsvpCount)
 })
 
-// All speakers deduplicated across sessions
+// Speakers dedup'd across talk sessions only — hosts of intros/quizzes
+// are not speakers, they're emcees for those segments.
 const allSpeakers = computed(() => {
   if (!props.meetup?.sessions) return []
   const seen = new Set<string>()
   return props.meetup.sessions
+    .filter((s) => s.kind === 'talk' || s.kind === 'other')
     .flatMap((s) => s.speakers)
     .filter((speaker) => {
       if (!speaker || seen.has(speaker.id)) return false

--- a/packages/frontendmu-adonis/inertia/pages/meetups/show.vue
+++ b/packages/frontendmu-adonis/inertia/pages/meetups/show.vue
@@ -63,20 +63,8 @@ const spotsRemaining = computed(() => {
   return Math.max(0, props.meetup.seatsAvailable - props.rsvpCount)
 })
 
-// Speakers dedup'd across talk sessions only — hosts of intros/quizzes
-// are not speakers, they're emcees for those segments.
-const allSpeakers = computed(() => {
-  if (!props.meetup?.sessions) return []
-  const seen = new Set<string>()
-  return props.meetup.sessions
-    .filter((s) => s.kind === 'talk' || s.kind === 'other')
-    .flatMap((s) => s.speakers)
-    .filter((speaker) => {
-      if (!speaker || seen.has(speaker.id)) return false
-      seen.add(speaker.id)
-      return true
-    })
-})
+// Canonical speakers, derived by the API from talk/other sessions only.
+const allSpeakers = computed(() => props.meetup?.speakers ?? [])
 
 // RSVP handlers
 async function handleRsvp() {

--- a/packages/frontendmu-adonis/inertia/pages/meetups/show.vue
+++ b/packages/frontendmu-adonis/inertia/pages/meetups/show.vue
@@ -475,8 +475,7 @@ const calendarUrl = computed(() => {
                       class="w-10 h-10 rounded-full grid place-items-center"
                       :class="{
                         'bg-verse-50 dark:bg-verse-900/60 text-verse-600 dark:text-verse-300':
-                          session.kind === 'intro' || session.kind === 'quiz' || session.kind === 'talk',
-                        'bg-coral-soft text-coral-strong': session.kind === 'sponsored',
+                          session.kind === 'intro' || session.kind === 'quiz' || session.kind === 'talk' || session.kind === 'sponsored',
                         'bg-gray-50 dark:bg-verse-900/60 text-gray-500 dark:text-gray-400':
                           session.kind === 'break' || session.kind === 'photo' || session.kind === 'other',
                       }"
@@ -516,71 +515,66 @@ const calendarUrl = computed(() => {
 
                   <!-- Content -->
                   <div class="flex-1 min-w-0">
-                    <!-- Eyebrow: kind label + duration -->
-                    <div
-                      v-if="(session.kind && session.kind !== 'talk') || session.durationMinutes"
-                      class="flex items-center gap-2.5 mb-1 flex-wrap font-mono text-[10.5px] uppercase tracking-[0.12em]"
+                    <!-- Break / photo: small italic single line -->
+                    <p
+                      v-if="session.kind === 'break' || session.kind === 'photo'"
+                      class="text-[15px] italic text-gray-500 dark:text-gray-400 flex items-center gap-3 flex-wrap"
                     >
+                      <span>{{ session.title }}</span>
                       <span
-                        v-if="session.kind === 'sponsored'"
-                        class="font-semibold text-coral-strong"
+                        v-if="session.durationMinutes"
+                        class="font-mono text-[11.5px] not-italic text-gray-400 dark:text-gray-500"
                       >
-                        Sponsor spotlight
-                      </span>
-                      <span
-                        v-else-if="session.kind && session.kind !== 'talk'"
-                        class="font-semibold text-verse-600 dark:text-verse-300"
-                      >
-                        {{ session.kind }}
-                      </span>
-                      <span v-if="session.durationMinutes" class="text-gray-400 dark:text-gray-500 normal-case tracking-normal text-[11.5px]">
                         {{ session.durationMinutes }} min
                       </span>
-                    </div>
-
-                    <!-- Title: big for talk/intro/quiz/sponsored/other; compact italic for break/photo -->
-                    <component
-                      :is="session.kind === 'sponsored' && session.sponsor ? 'Link' : 'h3'"
-                      :href="session.kind === 'sponsored' && session.sponsor ? `/sponsor/${session.sponsor.id}` : undefined"
-                      v-if="session.kind !== 'break' && session.kind !== 'photo'"
-                      class="font-display text-[22px] md:text-[24px] leading-[1.2] text-gray-900 dark:text-gray-100"
-                      :class="session.kind === 'sponsored' && session.sponsor ? 'hover:text-verse-500 transition-colors' : ''"
-                    >
-                      {{ session.title }}
-                    </component>
-                    <p
-                      v-else
-                      class="text-[15px] italic text-gray-500 dark:text-gray-400"
-                    >
-                      {{ session.title }}
                     </p>
 
-                    <!-- Subtitle: speakers (for talk/intro/quiz/other) or sponsor attribution -->
-                    <div
-                      v-if="session.speakers?.length && session.kind !== 'sponsored' && session.kind !== 'break' && session.kind !== 'photo'"
-                      class="mt-1.5 flex flex-wrap gap-x-3 gap-y-1 text-[14px] text-gray-500 dark:text-gray-400"
-                    >
-                      <Link
-                        v-for="(speaker, i) in session.speakers"
-                        :key="speaker.id"
-                        :href="`/speaker/${speaker.id}`"
-                        class="hover:text-verse-500 dark:hover:text-verse-400 transition-colors"
+                    <!-- Talk / intro / quiz / sponsored / other: title row -->
+                    <template v-else>
+                      <div class="flex items-baseline gap-3 flex-wrap">
+                        <component
+                          :is="session.kind === 'sponsored' && session.sponsor ? 'Link' : 'h3'"
+                          :href="session.kind === 'sponsored' && session.sponsor ? `/sponsor/${session.sponsor.id}` : undefined"
+                          class="font-display text-[22px] md:text-[24px] leading-[1.2] text-gray-900 dark:text-gray-100"
+                          :class="session.kind === 'sponsored' && session.sponsor ? 'hover:text-verse-500 transition-colors' : ''"
+                        >
+                          {{ session.title }}
+                        </component>
+                        <span
+                          v-if="session.durationMinutes"
+                          class="font-mono text-[11.5px] text-gray-400 dark:text-gray-500"
+                        >
+                          {{ session.durationMinutes }} min
+                        </span>
+                      </div>
+
+                      <!-- Speakers subtitle: only for talks; "Hosted by" for quiz -->
+                      <div
+                        v-if="session.speakers?.length && (session.kind === 'talk' || session.kind === 'other')"
+                        class="mt-1.5 flex flex-wrap gap-x-3 gap-y-1 text-[14px] text-gray-500 dark:text-gray-400"
                       >
-                        {{ speaker.name }}<template v-if="i < session.speakers.length - 1">,</template>
-                      </Link>
-                    </div>
-                    <p
-                      v-else-if="session.kind === 'sponsored' && session.sponsor"
-                      class="mt-1 text-[13.5px] text-gray-500 dark:text-gray-400"
-                    >
-                      by
-                      <Link
-                        :href="`/sponsor/${session.sponsor.id}`"
-                        class="hover:text-verse-500 transition-colors"
+                        <Link
+                          v-for="(speaker, i) in session.speakers"
+                          :key="speaker.id"
+                          :href="`/speaker/${speaker.id}`"
+                          class="hover:text-verse-500 dark:hover:text-verse-400 transition-colors"
+                        >
+                          {{ speaker.name }}<template v-if="i < session.speakers.length - 1">,</template>
+                        </Link>
+                      </div>
+                      <p
+                        v-else-if="session.kind === 'quiz' && session.speakers?.length"
+                        class="mt-1.5 text-[14px] text-gray-500 dark:text-gray-400"
                       >
-                        {{ session.sponsor.name }}
-                      </Link>
-                    </p>
+                        Hosted by
+                        <Link
+                          v-for="(speaker, i) in session.speakers"
+                          :key="speaker.id"
+                          :href="`/speaker/${speaker.id}`"
+                          class="hover:text-verse-500 dark:hover:text-verse-400 transition-colors"
+                        >{{ speaker.name }}<template v-if="i < session.speakers.length - 1">,</template></Link>
+                      </p>
+                    </template>
                   </div>
                 </li>
               </ol>

--- a/packages/frontendmu-adonis/inertia/pages/meetups/show.vue
+++ b/packages/frontendmu-adonis/inertia/pages/meetups/show.vue
@@ -443,120 +443,146 @@ const calendarUrl = computed(() => {
               <span class="section-label">Agenda</span>
 
               <ol class="mt-6 divide-y divide-dashed divide-gray-200 dark:divide-verse-900">
-                <template v-for="session in meetup.sessions" :key="session.id">
-                  <!-- Minimal row: break / photo -->
-                  <li
-                    v-if="session.kind === 'break' || session.kind === 'photo'"
-                    class="agenda-session flex items-center gap-3 py-3 text-gray-500 dark:text-gray-400"
-                  >
-                    <span
-                      class="w-7 h-7 rounded-md bg-gray-50 dark:bg-verse-900/60 grid place-items-center shrink-0"
+                <li
+                  v-for="session in meetup.sessions"
+                  :key="session.id"
+                  class="agenda-session flex items-start gap-4 py-5"
+                >
+                  <!-- Left medallion: avatar (talk) OR sponsor logo OR icon -->
+                  <div class="shrink-0">
+                    <!-- Talks: first speaker's avatar -->
+                    <SpeakerAvatar
+                      v-if="session.kind === 'talk' && session.speakers?.[0]"
+                      size="md"
+                      :name="session.speakers[0].name"
+                      :github-username="session.speakers[0].githubUsername"
+                      class="ring-2 ring-gray-100 dark:ring-verse-900"
+                    />
+                    <!-- Sponsored: sponsor logo if present, else icon -->
+                    <div
+                      v-else-if="session.kind === 'sponsored' && session.sponsor && (session.sponsor.logoUrl || session.sponsor.logomarkUrl)"
+                      class="w-10 h-10 rounded-full bg-white dark:bg-verse-900 border border-gray-200 dark:border-verse-800 grid place-items-center overflow-hidden"
                     >
-                      <svg v-if="session.kind === 'break'" class="w-[15px] h-[15px]" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+                      <img
+                        :src="(session.sponsor.logomarkUrl || session.sponsor.logoUrl) as string"
+                        :alt="session.sponsor.name"
+                        class="w-7 h-7 object-contain"
+                      />
+                    </div>
+                    <!-- Everything else: a coloured icon tile -->
+                    <div
+                      v-else
+                      class="w-10 h-10 rounded-full grid place-items-center"
+                      :class="{
+                        'bg-verse-50 dark:bg-verse-900/60 text-verse-600 dark:text-verse-300':
+                          session.kind === 'intro' || session.kind === 'quiz' || session.kind === 'talk',
+                        'bg-coral-soft text-coral-strong': session.kind === 'sponsored',
+                        'bg-gray-50 dark:bg-verse-900/60 text-gray-500 dark:text-gray-400':
+                          session.kind === 'break' || session.kind === 'photo' || session.kind === 'other',
+                      }"
+                    >
+                      <!-- intro: mic -->
+                      <svg v-if="session.kind === 'intro'" class="w-[18px] h-[18px]" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+                        <rect x="9" y="2" width="6" height="12" rx="3" />
+                        <path d="M5 10v2a7 7 0 0 0 14 0v-2M12 19v3M8 22h8" />
+                      </svg>
+                      <!-- quiz: sparkle / lightbulb -->
+                      <svg v-else-if="session.kind === 'quiz'" class="w-[18px] h-[18px]" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M9 18h6M10 22h4M12 2a7 7 0 0 0-4 12.7c.7.7 1 1.7 1 2.3v1h6v-1c0-.6.3-1.6 1-2.3A7 7 0 0 0 12 2z" />
+                      </svg>
+                      <!-- sponsored (no logo): tag -->
+                      <svg v-else-if="session.kind === 'sponsored'" class="w-[18px] h-[18px]" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M20.59 13.41 13.42 20.58a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z" />
+                        <circle cx="7" cy="7" r="1.5" />
+                      </svg>
+                      <!-- break: cup -->
+                      <svg v-else-if="session.kind === 'break'" class="w-[18px] h-[18px]" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
                         <path d="M17 8h1a4 4 0 0 1 0 8h-1" />
                         <path d="M3 8h14v9a4 4 0 0 1-4 4H7a4 4 0 0 1-4-4z" />
                         <path d="M6 2v3M10 2v3M14 2v3" />
                       </svg>
-                      <svg v-else class="w-[15px] h-[15px]" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+                      <!-- photo: camera -->
+                      <svg v-else-if="session.kind === 'photo'" class="w-[18px] h-[18px]" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
                         <path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z" />
                         <circle cx="12" cy="13" r="4" />
                       </svg>
-                    </span>
-                    <p class="flex-1 text-[15px] italic">{{ session.title }}</p>
-                    <span
-                      v-if="session.durationMinutes"
-                      class="font-mono text-[11.5px] text-gray-400 dark:text-gray-500"
-                    >
-                      {{ session.durationMinutes }} min
-                    </span>
-                  </li>
-
-                  <!-- Sponsored row -->
-                  <li
-                    v-else-if="session.kind === 'sponsored'"
-                    class="agenda-session py-4 flex items-center gap-4 flex-wrap"
-                  >
-                    <component
-                      :is="session.sponsor ? 'Link' : 'div'"
-                      :href="session.sponsor ? `/sponsor/${session.sponsor.id}` : undefined"
-                      class="flex items-center gap-3.5 min-w-0 flex-1 group/sponsor"
-                    >
-                      <img
-                        v-if="session.sponsor && (session.sponsor.logoUrl || session.sponsor.logomarkUrl)"
-                        :src="(session.sponsor.logoUrl || session.sponsor.logomarkUrl) as string"
-                        :alt="session.sponsor.name"
-                        class="h-8 w-auto object-contain opacity-90 group-hover/sponsor:opacity-100 transition-opacity shrink-0"
-                      />
-                      <div class="min-w-0 leading-tight">
-                        <span class="font-mono text-[10.5px] uppercase tracking-[0.12em] text-coral-strong font-semibold">
-                          Sponsor spotlight
-                        </span>
-                        <p class="mt-1 font-display text-[20px] md:text-[22px] leading-[1.15] text-gray-900 dark:text-gray-100 truncate">
-                          {{ session.title }}
-                        </p>
-                        <p
-                          v-if="session.sponsor"
-                          class="mt-0.5 text-[13px] text-gray-500 dark:text-gray-400 group-hover/sponsor:text-verse-500 transition-colors"
-                        >
-                          by {{ session.sponsor.name }}
-                        </p>
-                      </div>
-                    </component>
-                    <span
-                      v-if="session.durationMinutes"
-                      class="font-mono text-[11.5px] text-gray-400 dark:text-gray-500"
-                    >
-                      {{ session.durationMinutes }} min
-                    </span>
-                  </li>
-
-                  <!-- Talk / intro / quiz / other -->
-                  <li
-                    v-else
-                    class="agenda-session py-5 flex items-start gap-5 flex-wrap md:flex-nowrap"
-                  >
-                    <div class="min-w-0 flex-1">
-                      <div v-if="session.kind && session.kind !== 'talk' || session.durationMinutes" class="flex items-center gap-2.5 mb-1.5 flex-wrap">
-                        <span
-                          v-if="session.kind && session.kind !== 'talk'"
-                          class="font-mono text-[10.5px] uppercase tracking-[0.12em] font-semibold text-verse-600 dark:text-verse-300"
-                        >
-                          {{ session.kind }}
-                        </span>
-                        <span
-                          v-if="session.durationMinutes"
-                          class="font-mono text-[11.5px] text-gray-400 dark:text-gray-500"
-                        >
-                          {{ session.durationMinutes }} min
-                        </span>
-                      </div>
-                      <h3 class="font-display text-[22px] md:text-[24px] leading-[1.2] text-gray-900 dark:text-gray-100">
-                        {{ session.title }}
-                      </h3>
+                      <!-- fallback (talk without speaker, other): document -->
+                      <svg v-else class="w-[18px] h-[18px]" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+                        <path d="M14 2v6h6M9 13h6M9 17h4" />
+                      </svg>
                     </div>
+                  </div>
+
+                  <!-- Content -->
+                  <div class="flex-1 min-w-0">
+                    <!-- Eyebrow: kind label + duration -->
                     <div
-                      v-if="session.speakers?.length"
-                      class="flex flex-wrap gap-x-5 gap-y-2 md:justify-end md:min-w-[220px] md:pt-1"
+                      v-if="(session.kind && session.kind !== 'talk') || session.durationMinutes"
+                      class="flex items-center gap-2.5 mb-1 flex-wrap font-mono text-[10.5px] uppercase tracking-[0.12em]"
+                    >
+                      <span
+                        v-if="session.kind === 'sponsored'"
+                        class="font-semibold text-coral-strong"
+                      >
+                        Sponsor spotlight
+                      </span>
+                      <span
+                        v-else-if="session.kind && session.kind !== 'talk'"
+                        class="font-semibold text-verse-600 dark:text-verse-300"
+                      >
+                        {{ session.kind }}
+                      </span>
+                      <span v-if="session.durationMinutes" class="text-gray-400 dark:text-gray-500 normal-case tracking-normal text-[11.5px]">
+                        {{ session.durationMinutes }} min
+                      </span>
+                    </div>
+
+                    <!-- Title: big for talk/intro/quiz/sponsored/other; compact italic for break/photo -->
+                    <component
+                      :is="session.kind === 'sponsored' && session.sponsor ? 'Link' : 'h3'"
+                      :href="session.kind === 'sponsored' && session.sponsor ? `/sponsor/${session.sponsor.id}` : undefined"
+                      v-if="session.kind !== 'break' && session.kind !== 'photo'"
+                      class="font-display text-[22px] md:text-[24px] leading-[1.2] text-gray-900 dark:text-gray-100"
+                      :class="session.kind === 'sponsored' && session.sponsor ? 'hover:text-verse-500 transition-colors' : ''"
+                    >
+                      {{ session.title }}
+                    </component>
+                    <p
+                      v-else
+                      class="text-[15px] italic text-gray-500 dark:text-gray-400"
+                    >
+                      {{ session.title }}
+                    </p>
+
+                    <!-- Subtitle: speakers (for talk/intro/quiz/other) or sponsor attribution -->
+                    <div
+                      v-if="session.speakers?.length && session.kind !== 'sponsored' && session.kind !== 'break' && session.kind !== 'photo'"
+                      class="mt-1.5 flex flex-wrap gap-x-3 gap-y-1 text-[14px] text-gray-500 dark:text-gray-400"
                     >
                       <Link
-                        v-for="speaker in session.speakers"
+                        v-for="(speaker, i) in session.speakers"
                         :key="speaker.id"
                         :href="`/speaker/${speaker.id}`"
-                        class="flex items-center gap-2.5 group/speaker"
+                        class="hover:text-verse-500 dark:hover:text-verse-400 transition-colors"
                       >
-                        <SpeakerAvatar
-                          size="sm"
-                          :name="speaker.name"
-                          :github-username="speaker.githubUsername"
-                          class="ring-2 ring-gray-100 dark:ring-verse-900 group-hover/speaker:ring-verse-500 transition-all"
-                        />
-                        <span class="text-[14px] font-semibold text-gray-900 dark:text-gray-200 group-hover/speaker:text-verse-500 transition-colors">
-                          {{ speaker.name }}
-                        </span>
+                        {{ speaker.name }}<template v-if="i < session.speakers.length - 1">,</template>
                       </Link>
                     </div>
-                  </li>
-                </template>
+                    <p
+                      v-else-if="session.kind === 'sponsored' && session.sponsor"
+                      class="mt-1 text-[13.5px] text-gray-500 dark:text-gray-400"
+                    >
+                      by
+                      <Link
+                        :href="`/sponsor/${session.sponsor.id}`"
+                        class="hover:text-verse-500 transition-colors"
+                      >
+                        {{ session.sponsor.name }}
+                      </Link>
+                    </p>
+                  </div>
+                </li>
               </ol>
             </section>
 

--- a/packages/frontendmu-adonis/inertia/pages/meetups/show.vue
+++ b/packages/frontendmu-adonis/inertia/pages/meetups/show.vue
@@ -122,7 +122,7 @@ async function handleCancelRsvp() {
   }
 }
 
-// Share event via Web Share API
+// Share event via Web Share API (used by the mobile RSVP bar share button)
 async function shareEvent() {
   if (!props.meetup) return
   const shareData = {
@@ -137,6 +137,31 @@ async function shareEvent() {
     rsvpSuccess.value = 'Link copied to clipboard'
     setTimeout(() => (rsvpSuccess.value = null), 2000)
   }
+}
+
+function shareText() {
+  return props.meetup ? `${props.meetup.title} — Coders.mu` : 'Coders.mu meetup'
+}
+
+function shareToTwitter() {
+  const url = encodeURIComponent(window.location.href)
+  const text = encodeURIComponent(shareText())
+  window.open(`https://x.com/intent/tweet?url=${url}&text=${text}`, '_blank', 'noopener')
+}
+
+function shareToLinkedIn() {
+  const url = encodeURIComponent(window.location.href)
+  window.open(
+    `https://www.linkedin.com/sharing/share-offsite/?url=${url}`,
+    '_blank',
+    'noopener'
+  )
+}
+
+async function copyEventLink() {
+  await navigator.clipboard.writeText(window.location.href)
+  rsvpSuccess.value = 'Link copied to clipboard'
+  setTimeout(() => (rsvpSuccess.value = null), 2000)
 }
 
 const eventDate = computed(() => {
@@ -444,6 +469,7 @@ const calendarUrl = computed(() => {
                       size="md"
                       :name="session.speakers[0].name"
                       :github-username="session.speakers[0].githubUsername"
+                      :avatar-url="session.speakers[0].avatarUrl"
                       class="ring-2 ring-gray-100 dark:ring-verse-900"
                     />
                     <!-- Sponsored: sponsor logo if present, else icon -->
@@ -547,14 +573,19 @@ const calendarUrl = computed(() => {
 
                     <!-- Intro / quiz / sponsored: title + related entity inline -->
                     <div v-else class="flex items-baseline gap-x-3 gap-y-1 flex-wrap">
-                      <component
-                        :is="session.kind === 'sponsored' && session.sponsor ? 'Link' : 'h3'"
-                        :href="session.kind === 'sponsored' && session.sponsor ? `/sponsor/${session.sponsor.id}` : undefined"
-                        class="font-display text-[22px] md:text-[24px] leading-[1.2] text-gray-900 dark:text-gray-100"
-                        :class="session.kind === 'sponsored' && session.sponsor ? 'hover:text-verse-500 transition-colors' : ''"
+                      <Link
+                        v-if="session.kind === 'sponsored' && session.sponsor"
+                        :href="`/sponsor/${session.sponsor.id}`"
+                        class="font-display text-[22px] md:text-[24px] leading-[1.2] text-gray-900 dark:text-gray-100 hover:text-verse-500 transition-colors"
                       >
                         {{ session.title }}
-                      </component>
+                      </Link>
+                      <h3
+                        v-else
+                        class="font-display text-[22px] md:text-[24px] leading-[1.2] text-gray-900 dark:text-gray-100"
+                      >
+                        {{ session.title }}
+                      </h3>
                       <span
                         v-if="session.kind === 'sponsored' && session.sponsor"
                         class="text-[14px] text-gray-500 dark:text-gray-400"
@@ -719,16 +750,16 @@ const calendarUrl = computed(() => {
               <button
                 type="button"
                 class="share-btn w-9 h-9 rounded-full border border-gray-200 dark:border-verse-800 grid place-items-center text-gray-500 dark:text-gray-400 hover:border-verse-400 hover:text-verse-500 transition-colors"
-                aria-label="Share via Twitter"
-                @click="shareEvent"
+                aria-label="Share on X / Twitter"
+                @click="shareToTwitter"
               >
                 <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor"><path d="M18 2h3l-7 8 8 12h-6l-5-7-6 7H2l7-9L2 2h6l4 6 6-6z" /></svg>
               </button>
               <button
                 type="button"
                 class="share-btn w-9 h-9 rounded-full border border-gray-200 dark:border-verse-800 grid place-items-center text-gray-500 dark:text-gray-400 hover:border-verse-400 hover:text-verse-500 transition-colors"
-                aria-label="Share via LinkedIn"
-                @click="shareEvent"
+                aria-label="Share on LinkedIn"
+                @click="shareToLinkedIn"
               >
                 <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor"><path d="M4 4h4v4H4zM4 10h4v10H4zM10 10h4v1.5c.8-1.1 2.2-2 4-2 3 0 4 2 4 5V20h-4v-5c0-1.5-.5-2.5-2-2.5s-2 1-2 2.5V20h-4V10z" /></svg>
               </button>
@@ -736,7 +767,7 @@ const calendarUrl = computed(() => {
                 type="button"
                 class="share-btn w-9 h-9 rounded-full border border-gray-200 dark:border-verse-800 grid place-items-center text-gray-500 dark:text-gray-400 hover:border-verse-400 hover:text-verse-500 transition-colors"
                 aria-label="Copy link"
-                @click="shareEvent"
+                @click="copyEventLink"
               >
                 <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
                   <path d="M10 13a5 5 0 0 0 7.07 0l3-3a5 5 0 0 0-7.07-7.07l-1 1" />

--- a/packages/frontendmu-adonis/inertia/pages/meetups/show.vue
+++ b/packages/frontendmu-adonis/inertia/pages/meetups/show.vue
@@ -181,6 +181,33 @@ const statusLabel = computed(() => {
 
 const formattedDate = computed(() => eventDate.value?.toFormat('EEEE, MMMM d, yyyy') ?? '')
 
+// Split the title into a "plain" lead and an italicized tail for editorial emphasis.
+// Italicizes the last word — unless the title is a single word, in which case it's all italic.
+const titleParts = computed(() => {
+  const title = props.meetup?.title ?? ''
+  const words = title.trim().split(/\s+/)
+  if (words.length <= 1) return { plain: '', italic: title }
+  return {
+    plain: words.slice(0, -1).join(' '),
+    italic: words[words.length - 1],
+  }
+})
+
+// First sentence of the description, with HTML stripped — used as an editorial subtitle
+// beneath the hero title.
+const heroSubtitle = computed(() => {
+  const raw = props.meetup?.description
+  if (!raw) return null
+  const text = raw
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+  if (!text) return null
+  const firstStop = text.search(/[.!?]\s/)
+  const sentence = firstStop > 0 ? text.slice(0, firstStop + 1) : text
+  return sentence.length > 220 ? sentence.slice(0, 200).trim() + '…' : sentence
+})
+
 const formattedDateShort = computed(() => eventDate.value?.toFormat('EEE, MMM d') ?? '')
 
 const daysUntil = computed(() => {
@@ -278,224 +305,118 @@ const calendarUrl = computed(() => {
 
 <template>
   <Head :title="meetup?.title || 'Meetup'" />
-  <main class="relative min-h-screen pt-32 pb-32">
-    <div class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 relative z-10">
+  <main class="relative min-h-screen pt-24 pb-24">
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 relative z-10">
       <template v-if="meetup">
         <!-- ===== HERO ZONE ===== -->
-        <section id="rsvp-section" class="pb-12">
-          <div class="flex flex-col lg:flex-row lg:items-start lg:justify-between gap-10">
-            <!-- Left: Main hero content -->
-            <div class="flex-1 space-y-8 min-w-0">
-              <!-- Status Badge -->
-              <div class="flex items-center gap-3">
-                <span
-                  class="inline-flex items-center gap-2 px-3 py-1 rounded-md text-xs font-medium border"
-                  :class="
-                    isToday
-                      ? 'bg-red-50 dark:bg-red-950/30 border-red-200 dark:border-red-900 text-red-600 dark:text-red-400'
-                      : isUpcoming
-                        ? 'bg-verse-50 dark:bg-verse-900 border-verse-200 dark:border-verse-800 text-verse-600 dark:text-verse-400'
-                        : 'bg-gray-50 border-gray-200 text-gray-500 dark:bg-verse-900 dark:border-verse-800 dark:text-gray-400'
-                  "
-                >
-                  <span v-if="isToday" class="relative flex h-2 w-2">
-                    <span
-                      class="animate-ping absolute inline-flex h-full w-full rounded-full bg-current opacity-75"
-                    ></span>
-                    <span class="relative inline-flex rounded-full h-2 w-2 bg-current"></span>
-                  </span>
-                  {{ statusLabel }}
-                </span>
-                <Link
-                  v-if="canEdit"
-                  :href="`/admin/events/${meetup.id}/edit`"
-                  class="inline-flex items-center gap-1.5 px-3 py-1 rounded-md text-xs font-medium border border-gray-200 dark:border-verse-800 text-gray-500 dark:text-gray-400 hover:border-verse-500 hover:text-verse-500 dark:hover:text-verse-400 transition-colors"
-                >
-                  <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
-                    />
-                  </svg>
-                  Edit
-                </Link>
-              </div>
+        <section id="rsvp-section" class="pb-10 border-b border-gray-200 dark:border-verse-900">
+          <!-- Breadcrumb + Edit -->
+          <div class="flex items-center justify-between flex-wrap gap-3 mb-5">
+            <p class="mono-eyebrow">
+              <Link href="/meetups">MEETUPS</Link>
+              <span v-if="eventDate" class="sep">/</span>
+              <span v-if="eventDate">{{ eventDate.toFormat('yyyy') }}</span>
+              <span v-if="eventDate" class="sep">/</span>
+              <span v-if="eventDate">{{ eventDate.toFormat('MMMM').toUpperCase() }}</span>
+            </p>
+            <Link
+              v-if="canEdit"
+              :href="`/admin/events/${meetup.id}/edit`"
+              class="inline-flex items-center gap-1.5 px-3 py-1 rounded-md text-xs font-medium border border-gray-200 dark:border-verse-800 text-gray-500 dark:text-gray-400 hover:border-verse-500 hover:text-verse-500 dark:hover:text-verse-400 transition-colors"
+            >
+              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+              </svg>
+              Edit
+            </Link>
+          </div>
 
-              <!-- Title -->
-              <h1
-                class="text-3xl md:text-4xl font-display tracking-tight text-gray-900 dark:text-gray-100 leading-tight"
-              >
-                {{ meetup.title }}
-              </h1>
+          <!-- Status pill -->
+          <div class="mb-4 flex items-center gap-3 flex-wrap">
+            <span
+              class="inline-flex items-center gap-2 px-3 py-1.5 rounded-full font-mono text-[11px] font-semibold uppercase tracking-widest border"
+              :class="
+                isToday
+                  ? 'border-coral/30 bg-coral-soft text-coral-strong'
+                  : isUpcoming
+                    ? 'bg-verse-50 dark:bg-verse-900 border-verse-200 dark:border-verse-800 text-verse-600 dark:text-verse-400'
+                    : 'bg-gray-50 border-gray-200 text-gray-500 dark:bg-verse-900 dark:border-verse-800 dark:text-gray-400'
+              "
+            >
+              <span v-if="isToday" class="w-2 h-2 rounded-full bg-coral coral-pulse" />
+              {{ statusLabel }}
+            </span>
+          </div>
 
-              <!-- Meta Row: Date + Time + Venue -->
+          <!-- Title — editorial serif with italic tail -->
+          <h1
+            class="font-display text-[clamp(44px,6.5vw,84px)] leading-[0.98] text-gray-900 dark:text-gray-100 text-balance max-w-[16ch] mb-6"
+          >
+            <template v-if="titleParts.plain">{{ titleParts.plain }}&nbsp;</template><span class="font-display-italic text-verse-500 dark:text-verse-300">{{ titleParts.italic }}</span>
+          </h1>
+
+          <!-- Subtitle (first sentence of description, muted) -->
+          <p
+            v-if="heroSubtitle"
+            class="text-[18px] leading-[1.55] text-gray-500 dark:text-gray-400 max-w-[56ch] mb-8"
+          >
+            {{ heroSubtitle }}
+          </p>
+
+          <!-- Meta row: icon-tiled Date / Time / Venue -->
+          <div class="flex flex-wrap gap-x-9 gap-y-5 pt-2">
+            <div v-if="eventDate" class="flex items-start gap-3">
               <div
-                class="flex flex-wrap items-center gap-x-6 gap-y-3 text-gray-500 dark:text-gray-400 font-medium text-sm"
+                class="w-9 h-9 rounded-[10px] bg-verse-50 dark:bg-verse-900/60 text-verse-600 dark:text-verse-300 grid place-items-center shrink-0"
               >
-                <div v-if="eventDate" class="flex items-center gap-2">
-                  <svg
-                    class="w-4 h-4 text-verse-500 shrink-0"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
-                    />
-                  </svg>
-                  {{ formattedDate }}
-                </div>
-                <div v-if="meetup.startTime" class="flex items-center gap-2">
-                  <svg
-                    class="w-4 h-4 text-verse-500 shrink-0"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
-                    />
-                  </svg>
-                  {{ meetup.startTime }}{{ meetup.endTime ? ` – ${meetup.endTime}` : '' }}
-                </div>
-                <div v-if="meetup.venue" class="flex items-center gap-2">
-                  <svg
-                    class="w-4 h-4 text-verse-500 shrink-0"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"
-                    />
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"
-                    />
-                  </svg>
-                  {{ meetup.venue }}
-                </div>
+                <svg class="w-[18px] h-[18px]" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+                  <rect x="3" y="5" width="18" height="16" rx="2" />
+                  <path d="M3 10h18M8 3v4M16 3v4" />
+                </svg>
               </div>
-
-              <!-- CTA + Spots Remaining -->
-              <div v-if="canRsvp" class="flex flex-wrap items-center gap-4">
-                <template v-if="!isAuthenticated">
-                  <Link
-                    href="/login"
-                    class="px-5 py-2.5 text-sm font-medium bg-verse-600 text-white rounded-md hover:bg-verse-700 transition-colors"
-                  >
-                    Login to RSVP
-                  </Link>
-                </template>
-                <template v-else>
-                  <button
-                    v-if="hasRsvp"
-                    @click="handleCancelRsvp"
-                    :disabled="isRsvpLoading"
-                    class="px-5 py-2.5 text-sm font-medium border border-red-300 dark:border-red-800 text-red-600 dark:text-red-400 rounded-md hover:bg-red-50 dark:hover:bg-red-950/30 transition-colors disabled:opacity-50"
-                  >
-                    {{ isRsvpLoading ? 'Cancelling...' : 'Cancel RSVP' }}
-                  </button>
-                  <button
-                    v-else
-                    @click="handleRsvp"
-                    :disabled="isRsvpLoading"
-                    class="px-5 py-2.5 text-sm font-medium bg-verse-600 text-white rounded-md hover:bg-verse-700 transition-colors disabled:opacity-50"
-                  >
-                    {{ isRsvpLoading ? 'Submitting...' : isFull ? 'Join Waitlist' : 'RSVP Now' }}
-                  </button>
-                </template>
-                <span
-                  v-if="spotsRemaining !== null"
-                  class="text-sm font-semibold"
-                  :class="spotsRemaining <= 5 ? 'text-red-500' : 'text-gray-400 dark:text-gray-500'"
-                >
-                  {{
-                    spotsRemaining === 0
-                      ? 'No spots left'
-                      : `${spotsRemaining} spot${spotsRemaining !== 1 ? 's' : ''} remaining`
-                  }}
-                </span>
-              </div>
-
-              <!-- RSVP feedback -->
-              <p v-if="rsvpError" class="text-sm text-red-500 font-medium">{{ rsvpError }}</p>
-              <p v-if="rsvpSuccess" class="text-sm text-green-600 dark:text-green-400 font-medium">
-                {{ rsvpSuccess }}
-              </p>
-
-              <!-- Speaker Preview Strip -->
-              <div v-if="allSpeakers.length" class="flex items-center gap-4 pt-2">
-                <div class="flex -space-x-3">
-                  <template v-for="speaker in allSpeakers.slice(0, 5)" :key="speaker.id">
-                    <Link :href="`/speaker/${speaker.id}`" class="relative hover:z-10">
-                      <SpeakerAvatar
-                        size="sm"
-                        :name="speaker.name"
-                        :github-username="speaker.githubUsername"
-                        :avatar-url="speaker.avatarUrl"
-                        class="border-2 border-white dark:border-verse-950"
-                      />
-                    </Link>
-                  </template>
-                  <div
-                    v-if="allSpeakers.length > 5"
-                    class="w-8 h-8 rounded-full bg-verse-100 dark:bg-verse-900 border-2 border-white dark:border-verse-950 flex items-center justify-center text-[10px] font-bold text-verse-600 dark:text-verse-400"
-                  >
-                    +{{ allSpeakers.length - 5 }}
-                  </div>
-                </div>
-                <p class="text-xs text-gray-400 dark:text-gray-500 font-medium">
-                  {{ allSpeakers.length }} speaker{{ allSpeakers.length !== 1 ? 's' : '' }}
-                </p>
+              <div>
+                <div class="font-mono text-[10.5px] uppercase tracking-[0.12em] text-gray-400 dark:text-gray-500 mb-0.5">Date</div>
+                <div class="text-[15px] font-semibold text-gray-900 dark:text-gray-100">{{ formattedDate }}</div>
               </div>
             </div>
 
-            <!-- Right: Sponsors -->
-            <div v-if="meetup.sponsors.length" class="lg:w-64 shrink-0 space-y-4 lg:pt-[9.5rem]">
-              <p class="text-xs font-medium text-gray-400">Sponsored by</p>
-              <div class="flex flex-wrap lg:flex-col gap-3">
-                <Link
-                  v-for="sponsor in meetup.sponsors"
-                  :key="sponsor.id"
-                  :href="`/sponsor/${sponsor.id}`"
-                  class="flex items-center justify-center px-4 py-3 rounded-lg border hover:border-gray-300 dark:hover:border-verse-700 transition-colors group/sponsor"
-                  :class="
-                    sponsor.logoBg
-                      ? 'border-verse-800'
-                      : 'border-gray-100 dark:border-verse-800 bg-white dark:bg-white'
-                  "
-                  :style="sponsor.logoBg ? { backgroundColor: sponsor.logoBg } : {}"
-                >
-                  <img
-                    v-if="sponsor.logoUrl"
-                    :src="sponsor.logoUrl"
-                    :alt="sponsor.name"
-                    class="h-14 w-auto object-contain"
-                  />
-                  <span v-else class="text-sm font-bold text-gray-700 dark:text-gray-300">{{
-                    sponsor.name
-                  }}</span>
-                </Link>
+            <div v-if="meetup.startTime" class="flex items-start gap-3">
+              <div
+                class="w-9 h-9 rounded-[10px] bg-verse-50 dark:bg-verse-900/60 text-verse-600 dark:text-verse-300 grid place-items-center shrink-0"
+              >
+                <svg class="w-[18px] h-[18px]" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+                  <circle cx="12" cy="12" r="9" />
+                  <path d="M12 7v5l3 2" />
+                </svg>
+              </div>
+              <div>
+                <div class="font-mono text-[10.5px] uppercase tracking-[0.12em] text-gray-400 dark:text-gray-500 mb-0.5">Time</div>
+                <div class="text-[15px] font-semibold text-gray-900 dark:text-gray-100">
+                  {{ meetup.startTime }}<template v-if="meetup.endTime"> – {{ meetup.endTime }}</template>
+                </div>
+              </div>
+            </div>
+
+            <div v-if="meetup.venue" class="flex items-start gap-3">
+              <div
+                class="w-9 h-9 rounded-[10px] bg-verse-50 dark:bg-verse-900/60 text-verse-600 dark:text-verse-300 grid place-items-center shrink-0"
+              >
+                <svg class="w-[18px] h-[18px]" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+                  <path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 1 1 16 0Z" />
+                  <circle cx="12" cy="10" r="3" />
+                </svg>
+              </div>
+              <div>
+                <div class="font-mono text-[10.5px] uppercase tracking-[0.12em] text-gray-400 dark:text-gray-500 mb-0.5">Venue</div>
+                <div class="text-[15px] font-semibold text-gray-900 dark:text-gray-100">
+                  {{ meetup.venue }}<template v-if="meetup.location"> · {{ meetup.location }}</template>
+                </div>
               </div>
             </div>
           </div>
 
-          <!-- Cover Image -->
-          <div v-if="meetup.coverImageUrl" class="rounded-lg overflow-hidden mt-8">
+          <!-- Cover image (optional) -->
+          <div v-if="meetup.coverImageUrl" class="rounded-[var(--r-lg,16px)] overflow-hidden mt-10">
             <img
               :src="meetup.coverImageUrl"
               :alt="meetup.title"
@@ -504,366 +425,443 @@ const calendarUrl = computed(() => {
           </div>
         </section>
 
-        <!-- Separator -->
-        <div class="border-t border-gray-100 dark:border-verse-800 mb-12"></div>
-
         <!-- ===== TWO-COLUMN GRID ===== -->
-        <div class="grid grid-cols-1 lg:grid-cols-12 gap-12 lg:gap-16">
+        <div class="grid grid-cols-1 lg:grid-cols-[1fr_380px] gap-10 lg:gap-14 mt-12 items-start">
           <!-- Left Column: Content -->
-          <div class="lg:col-span-7 space-y-14">
-            <!-- Description -->
-            <section v-if="meetup.description" class="space-y-5">
-              <div class="flex items-center gap-2">
-                <span class="text-sm font-semibold text-verse-500 dark:text-verse-400">About</span>
-                <div class="h-px flex-1 bg-gray-100 dark:bg-verse-900"></div>
-              </div>
+          <div class="min-w-0">
+            <!-- About -->
+            <section v-if="meetup.description" class="pb-12 border-b border-gray-200 dark:border-verse-900">
+              <span class="section-label">About this meetup</span>
+              <h2 class="font-display text-[clamp(28px,3.8vw,36px)] leading-[1.05] text-gray-900 dark:text-gray-100 mt-3">
+                What to expect when you <span class="font-display-italic text-verse-500 dark:text-verse-300">join us</span>
+              </h2>
               <div
-                class="prose prose-lg dark:prose-invert max-w-none font-medium leading-relaxed text-gray-600 dark:text-gray-400"
+                class="prose prose-lg dark:prose-invert max-w-[68ch] mt-5 leading-[1.7] text-gray-700 dark:text-gray-400"
                 v-html="sanitizeHtml(meetup.description)"
               />
             </section>
 
-            <!-- Sessions/Agenda -->
-            <section v-if="meetup.sessions.length" class="space-y-8">
-              <div class="flex items-center gap-2">
-                <span class="text-sm font-semibold text-verse-500 dark:text-verse-400">Agenda</span>
-                <div class="h-px flex-1 bg-gray-100 dark:bg-verse-900"></div>
-              </div>
+            <!-- Agenda (timeline) -->
+            <section v-if="meetup.sessions.length" class="py-12 border-b border-gray-200 dark:border-verse-900">
+              <span class="section-label">Agenda</span>
+              <h2 class="font-display text-[clamp(28px,3.8vw,36px)] leading-[1.05] text-gray-900 dark:text-gray-100 mt-3">
+                {{ meetup.sessions.length }} session<template v-if="meetup.sessions.length !== 1">s</template>,
+                <span class="font-display-italic text-verse-500 dark:text-verse-300">one day</span>
+              </h2>
 
-              <div class="space-y-10">
+              <div class="mt-8">
                 <article
                   v-for="(session, index) in meetup.sessions"
                   :key="session.id"
-                  class="relative group"
+                  class="agenda-session grid grid-cols-[90px_1fr] md:grid-cols-[110px_1fr] gap-6 md:gap-7 py-6 border-b border-dashed border-gray-200 dark:border-verse-900 last:border-b-0 relative"
                 >
-                  <div class="flex gap-5">
-                    <!-- Timeline dot -->
-                    <div class="relative shrink-0 flex flex-col items-center pt-2">
-                      <div class="relative z-10 w-2.5 h-2.5 rounded-full bg-verse-500"></div>
-                      <div
-                        v-if="index !== meetup.sessions.length - 1"
-                        class="absolute top-[1.125rem] bottom-[-2.5rem] w-px bg-gray-200 dark:bg-verse-800"
-                      ></div>
+                  <div class="font-mono text-[13px] font-semibold text-verse-600 dark:text-verse-300 relative pt-1">
+                    <span>{{ session.startTime || '—' }}</span>
+                    <!-- timeline dot -->
+                    <span
+                      class="hidden md:block absolute right-[-20px] top-[8px] w-[9px] h-[9px] rounded-full bg-white dark:bg-verse-950 border-2 border-verse-600 dark:border-verse-300"
+                    />
+                  </div>
+                  <div class="md:pl-5 border-l border-gray-200 dark:border-verse-900">
+                    <div class="flex flex-wrap items-center gap-2 mb-2">
+                      <span v-if="session.kind" class="font-mono text-[10.5px] uppercase tracking-[0.05em] font-medium px-1.5 py-0.5 rounded bg-verse-50 dark:bg-verse-900 text-verse-600 dark:text-verse-300">
+                        {{ session.kind }}
+                      </span>
+                      <span v-if="session.duration" class="font-mono text-[11.5px] text-gray-400 dark:text-gray-500">
+                        {{ session.duration }}
+                      </span>
                     </div>
-
-                    <div class="flex-1 space-y-4">
-                      <h3
-                        class="text-xl md:text-2xl font-display tracking-tight text-gray-900 dark:text-gray-100 leading-tight"
+                    <h3 class="font-display text-[20px] md:text-[22px] leading-tight text-gray-900 dark:text-gray-100">
+                      {{ session.title }}
+                    </h3>
+                    <div v-if="session.speakers?.length" class="mt-3 flex flex-wrap gap-4">
+                      <Link
+                        v-for="speaker in session.speakers"
+                        :key="speaker.id"
+                        :href="`/speaker/${speaker.id}`"
+                        class="flex items-center gap-2.5 group/speaker"
                       >
-                        {{ session.title }}
-                      </h3>
-
-                      <div v-if="session.speakers?.length" class="flex flex-wrap gap-4">
-                        <Link
-                          v-for="speaker in session.speakers"
-                          :key="speaker.id"
-                          :href="`/speaker/${speaker.id}`"
-                          class="flex items-center gap-2.5 group/speaker transition-all"
-                        >
-                          <SpeakerAvatar
-                            size="sm"
-                            :name="speaker.name"
-                            :github-username="speaker.githubUsername"
-                            class="ring-2 ring-gray-100 dark:ring-verse-900 group-hover/speaker:ring-verse-500 transition-all"
-                          />
-                          <div class="leading-tight">
-                            <p
-                              class="text-sm font-bold text-gray-900 dark:text-gray-200 group-hover/speaker:text-verse-500 transition-colors"
-                            >
-                              {{ speaker.name }}
-                            </p>
-                            <p v-if="speaker.githubUsername" class="text-xs text-gray-400 mt-0.5">
-                              @{{ speaker.githubUsername }}
-                            </p>
-                          </div>
-                        </Link>
-                      </div>
+                        <SpeakerAvatar
+                          size="sm"
+                          :name="speaker.name"
+                          :github-username="speaker.githubUsername"
+                          class="ring-2 ring-gray-100 dark:ring-verse-900 group-hover/speaker:ring-verse-500 transition-all"
+                        />
+                        <div class="leading-tight">
+                          <p class="text-sm font-semibold text-gray-900 dark:text-gray-200 group-hover/speaker:text-verse-500 transition-colors">
+                            {{ speaker.name }}
+                          </p>
+                          <p v-if="speaker.githubUsername" class="text-[11px] text-gray-400 mt-0.5 font-mono">
+                            @{{ speaker.githubUsername }}
+                          </p>
+                        </div>
+                      </Link>
                     </div>
                   </div>
                 </article>
               </div>
             </section>
 
-            <!-- Photo Gallery -->
-            <section v-if="meetup.photos.length" class="space-y-5">
-              <div class="flex items-center gap-2">
-                <span class="text-sm font-semibold text-verse-500 dark:text-verse-400"
-                  >Gallery</span
+            <!-- Speakers (dedicated card grid when we have them) -->
+            <section v-if="allSpeakers.length" class="py-12 border-b border-gray-200 dark:border-verse-900">
+              <span class="section-label">Speakers</span>
+              <h2 class="font-display text-[clamp(28px,3.8vw,36px)] leading-[1.05] text-gray-900 dark:text-gray-100 mt-3">
+                {{ allSpeakers.length }}
+                builder<template v-if="allSpeakers.length !== 1">s</template>,
+                <span class="font-display-italic text-verse-500 dark:text-verse-300">one lineup</span>
+              </h2>
+              <div class="mt-6 grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <Link
+                  v-for="sp in allSpeakers"
+                  :key="sp.id"
+                  :href="`/speaker/${sp.id}`"
+                  class="flex items-start gap-4 p-4 rounded-xl border border-gray-200 dark:border-verse-900 hover:border-verse-300 dark:hover:border-verse-700 bg-white dark:bg-verse-950 transition-colors"
                 >
-                <div class="h-px flex-1 bg-gray-100 dark:bg-verse-900"></div>
+                  <SpeakerAvatar
+                    size="md"
+                    :name="sp.name"
+                    :github-username="sp.githubUsername"
+                    :avatar-url="sp.avatarUrl"
+                    class="shrink-0"
+                  />
+                  <div class="min-w-0">
+                    <p class="font-display text-[18px] text-gray-900 dark:text-gray-100 leading-tight">
+                      {{ sp.name }}
+                    </p>
+                    <p v-if="sp.githubUsername" class="font-mono text-[11px] uppercase tracking-[0.08em] text-verse-600 dark:text-verse-400 mt-1.5">
+                      @{{ sp.githubUsername }}
+                    </p>
+                  </div>
+                </Link>
               </div>
-              <div class="grid grid-cols-2 md:grid-cols-3 gap-3">
+            </section>
+
+            <!-- Attendees -->
+            <section v-if="attendees.length > 0" class="py-12 border-b border-gray-200 dark:border-verse-900">
+              <span class="section-label">Who's coming</span>
+              <h2 class="font-display text-[clamp(28px,3.8vw,36px)] leading-[1.05] text-gray-900 dark:text-gray-100 mt-3">
+                <span class="font-display-italic text-verse-500 dark:text-verse-300">{{ rsvpCount }} builder<template v-if="rsvpCount !== 1">s</template></span>
+                <template v-if="isPast"> showed up</template>
+                <template v-else> already in</template>
+              </h2>
+              <div class="mt-6 flex items-center gap-4 flex-wrap">
+                <div class="flex -space-x-2.5">
+                  <template v-for="attendee in attendees.slice(0, 8)" :key="attendee.id">
+                    <SpeakerAvatar
+                      size="md"
+                      :name="attendee.name"
+                      :github-username="attendee.githubUsername"
+                      :avatar-url="attendee.avatarUrl"
+                      class="border-2 border-white dark:border-verse-950"
+                    />
+                  </template>
+                  <div
+                    v-if="attendees.length > 8"
+                    class="w-10 h-10 rounded-full bg-gray-100 dark:bg-verse-900 border-2 border-white dark:border-verse-950 flex items-center justify-center text-[11px] font-bold text-gray-600 dark:text-gray-300"
+                  >
+                    +{{ attendees.length - 8 }}
+                  </div>
+                </div>
+                <p class="font-mono text-[13px] text-gray-500 dark:text-gray-400">
+                  <strong class="text-gray-900 dark:text-gray-100 font-bold">{{ rsvpCount }} attending</strong>
+                  <template v-if="spotsRemaining !== null && !isPast"> · {{ spotsRemaining }} spots left</template>
+                </p>
+              </div>
+            </section>
+
+            <!-- Photo Gallery (past only) -->
+            <section v-if="meetup.photos.length" class="py-12 border-b border-gray-200 dark:border-verse-900">
+              <div class="flex items-end justify-between gap-4 flex-wrap">
+                <div>
+                  <span class="section-label">Event Recap</span>
+                  <h2 class="font-display text-[clamp(28px,3.8vw,36px)] leading-[1.05] text-gray-900 dark:text-gray-100 mt-3">
+                    A look <span class="font-display-italic text-verse-500 dark:text-verse-300">back</span>
+                  </h2>
+                </div>
+                <span class="font-mono text-[11px] uppercase tracking-[0.08em] text-gray-400 dark:text-gray-500">
+                  {{ meetup.photos.length }} photos · tap to expand
+                </span>
+              </div>
+              <div class="mt-6 grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3">
                 <button
                   v-for="(photo, index) in meetup.photos"
                   :key="photo.id"
                   type="button"
-                  class="relative rounded-lg overflow-hidden aspect-[4/3] group focus:outline-none focus:ring-2 focus:ring-verse-500"
+                  class="relative rounded-md overflow-hidden aspect-square group focus:outline-none focus:ring-2 focus:ring-verse-500"
                   @click="openLightbox(index)"
                 >
                   <img
                     :src="photo.thumbnailUrl"
                     :alt="photo.caption || 'Event photo'"
                     loading="lazy"
-                    class="w-full h-full object-cover transition-transform duration-200 group-hover:scale-105"
+                    class="w-full h-full object-cover transition-transform duration-300 group-hover:scale-[1.04]"
                   />
                 </button>
               </div>
             </section>
+
+            <!-- Sponsors -->
+            <section v-if="meetup.sponsors.length" class="py-12 border-b border-gray-200 dark:border-verse-900">
+              <span class="section-label">Sponsors</span>
+              <h2 class="font-display text-[clamp(28px,3.8vw,36px)] leading-[1.05] text-gray-900 dark:text-gray-100 mt-3">
+                Made possible by <span class="font-display-italic text-verse-500 dark:text-verse-300">local support</span>
+              </h2>
+              <div
+                class="mt-6 flex flex-wrap gap-x-10 gap-y-4 items-center px-7 py-6 rounded-xl border border-dashed border-gray-300 dark:border-verse-800 bg-white dark:bg-verse-950"
+              >
+                <Link
+                  v-for="sponsor in meetup.sponsors"
+                  :key="sponsor.id"
+                  :href="`/sponsor/${sponsor.id}`"
+                  class="flex items-center gap-3 text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 transition-colors"
+                >
+                  <img
+                    v-if="sponsor.logoUrl"
+                    :src="sponsor.logoUrl"
+                    :alt="sponsor.name"
+                    class="h-9 w-auto object-contain"
+                  />
+                  <span v-else class="font-display text-[17px]">{{ sponsor.name }}</span>
+                </Link>
+              </div>
+            </section>
+
+            <!-- Share bar -->
+            <div
+              class="flex items-center gap-3 flex-wrap py-6 border-b border-gray-200 dark:border-verse-900"
+            >
+              <span class="font-mono text-[11px] uppercase tracking-[0.12em] text-gray-400 dark:text-gray-500">
+                Share this meetup
+              </span>
+              <button
+                type="button"
+                class="share-btn w-9 h-9 rounded-full border border-gray-200 dark:border-verse-800 grid place-items-center text-gray-500 dark:text-gray-400 hover:border-verse-400 hover:text-verse-500 transition-colors"
+                aria-label="Share via Twitter"
+                @click="shareEvent"
+              >
+                <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor"><path d="M18 2h3l-7 8 8 12h-6l-5-7-6 7H2l7-9L2 2h6l4 6 6-6z" /></svg>
+              </button>
+              <button
+                type="button"
+                class="share-btn w-9 h-9 rounded-full border border-gray-200 dark:border-verse-800 grid place-items-center text-gray-500 dark:text-gray-400 hover:border-verse-400 hover:text-verse-500 transition-colors"
+                aria-label="Share via LinkedIn"
+                @click="shareEvent"
+              >
+                <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor"><path d="M4 4h4v4H4zM4 10h4v10H4zM10 10h4v1.5c.8-1.1 2.2-2 4-2 3 0 4 2 4 5V20h-4v-5c0-1.5-.5-2.5-2-2.5s-2 1-2 2.5V20h-4V10z" /></svg>
+              </button>
+              <button
+                type="button"
+                class="share-btn w-9 h-9 rounded-full border border-gray-200 dark:border-verse-800 grid place-items-center text-gray-500 dark:text-gray-400 hover:border-verse-400 hover:text-verse-500 transition-colors"
+                aria-label="Copy link"
+                @click="shareEvent"
+              >
+                <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+                  <path d="M10 13a5 5 0 0 0 7.07 0l3-3a5 5 0 0 0-7.07-7.07l-1 1" />
+                  <path d="M14 11a5 5 0 0 0-7.07 0l-3 3a5 5 0 0 0 7.07 7.07l1-1" />
+                </svg>
+              </button>
+              <span class="ml-auto font-mono text-[11px] text-gray-400 dark:text-gray-500 truncate max-w-[260px]">
+                coders.mu/meetup/{{ meetup.slug || meetup.id }}
+              </span>
+            </div>
+
+            <!-- Code of Conduct callout -->
+            <div
+              class="mt-8 flex items-start gap-4 p-5 rounded-xl border bg-[oklch(95%_0.03_155)] border-[color-mix(in_oklch,oklch(72%_0.10_155)_25%,transparent)] dark:bg-verse-900/40 dark:border-verse-800"
+            >
+              <div class="w-9 h-9 rounded-[10px] bg-white dark:bg-verse-950 grid place-items-center text-[oklch(45%_0.1_155)] shrink-0">
+                <svg class="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+                  <path d="M12 2 3 6v6c0 5 4 9 9 10 5-1 9-5 9-10V6l-9-4Z" />
+                  <path d="m9 12 2 2 4-4" />
+                </svg>
+              </div>
+              <div>
+                <h4 class="font-display text-[17px] text-[oklch(28%_0.08_155)] dark:text-gray-100 mb-0.5">
+                  A welcoming space for everyone
+                </h4>
+                <p class="text-[13.5px] leading-[1.55] text-[oklch(32%_0.05_155)] dark:text-gray-400">
+                  Coders.mu meetups follow a simple code of conduct: be kind, be curious, no harassment.
+                  First time attending? Come say hi — we'll introduce you around.
+                  <Link href="/code-of-conduct" class="underline underline-offset-[3px] font-semibold text-[oklch(38%_0.12_155)] dark:text-verse-300">
+                    Read the full code of conduct →
+                  </Link>
+                </p>
+              </div>
+            </div>
           </div>
 
-          <!-- Right Column: Sidebar -->
-          <aside class="lg:col-span-5">
-            <div class="sticky top-24 space-y-8">
-              <!-- Event Details Card -->
+          <!-- Right Column: Sticky RSVP Card -->
+          <aside class="lg:row-start-1 lg:col-start-2">
+            <div class="sticky top-24">
               <div
-                class="bg-white dark:bg-verse-950 border border-gray-200 dark:border-verse-900 rounded-lg overflow-hidden"
+                class="bg-white dark:bg-verse-950 border border-gray-200 dark:border-verse-900 rounded-2xl overflow-hidden shadow-[0_4px_16px_-4px_rgba(13,20,51,0.08),0_2px_6px_-2px_rgba(13,20,51,0.05)]"
               >
-                <div
-                  class="px-6 py-4 bg-gray-50 dark:bg-verse-900 border-b border-gray-200 dark:border-verse-900"
-                >
-                  <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-200">
-                    Event Details
-                  </h3>
+                <!-- Header -->
+                <div class="flex items-center justify-between px-6 pt-5 pb-4 border-b border-gray-100 dark:border-verse-900">
+                  <div class="font-display text-[18px] text-gray-900 dark:text-gray-100">
+                    <template v-if="isToday">Happening now</template>
+                    <template v-else-if="isUpcoming">Reserve your spot</template>
+                    <template v-else>Event details</template>
+                  </div>
+                  <span
+                    v-if="isToday"
+                    class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full font-mono text-[10px] font-semibold uppercase tracking-[0.1em] text-coral-strong bg-coral-soft border border-coral/30"
+                  >
+                    <span class="w-1.5 h-1.5 rounded-full bg-coral coral-pulse" />
+                    Live
+                  </span>
                 </div>
-                <div class="p-6 space-y-5">
-                  <div class="space-y-4">
-                    <div
-                      data-change="schedule"
-                      :data-changed-active="activeChange === 'schedule' ? '' : null"
-                      class="space-y-4"
-                    >
-                      <div class="flex items-baseline justify-between">
-                        <p class="text-xs font-medium text-gray-500 dark:text-gray-400">Date</p>
-                        <p class="text-sm font-bold text-gray-900 dark:text-gray-100">
-                          {{ eventDate?.toFormat('dd MMM yyyy') }}
-                        </p>
-                      </div>
-                      <div class="flex items-baseline justify-between">
-                        <p class="text-xs font-medium text-gray-500 dark:text-gray-400">Time</p>
-                        <p class="text-sm font-bold text-gray-900 dark:text-gray-100">
-                          {{ meetup.startTime || 'TBA' }}
-                        </p>
-                      </div>
+
+                <!-- Body -->
+                <div class="px-6 pt-5 pb-2">
+                  <div
+                    data-change="schedule"
+                    :data-changed-active="activeChange === 'schedule' ? '' : null"
+                    class="space-y-0"
+                  >
+                    <div class="flex items-baseline justify-between py-2.5">
+                      <span class="font-mono text-[11px] uppercase tracking-[0.08em] text-gray-400 dark:text-gray-500">Date</span>
+                      <span class="text-[15px] font-semibold text-gray-900 dark:text-gray-100">{{ eventDate?.toFormat('dd MMM yyyy') || 'TBA' }}</span>
                     </div>
-                    <div
-                      data-change="seats"
-                      :data-changed-active="activeChange === 'seats' ? '' : null"
-                      class="space-y-4"
-                    >
-                      <div class="flex items-baseline justify-between">
-                        <p class="text-xs font-medium text-gray-500 dark:text-gray-400">Capacity</p>
-                        <p class="text-sm font-bold text-gray-900 dark:text-gray-100">
-                          {{ rsvpCount }} / {{ meetup.seatsAvailable || '∞' }}
-                        </p>
-                      </div>
-                      <!-- Capacity progress bar -->
-                      <div v-if="meetup.seatsAvailable" class="space-y-1">
-                        <div
-                          class="w-full h-1.5 rounded-full bg-gray-100 dark:bg-verse-800 overflow-hidden"
-                        >
-                          <div
-                            class="h-full rounded-full transition-all duration-500"
-                            :class="
-                              capacityPercent >= 90
-                                ? 'bg-red-500'
-                                : capacityPercent >= 70
-                                  ? 'bg-amber-500'
-                                  : 'bg-verse-500'
-                            "
-                            :style="{ width: `${capacityPercent}%` }"
-                          ></div>
-                        </div>
-                        <p class="text-[10px] text-gray-400 text-right">
-                          {{ capacityPercent }}% full
-                        </p>
-                      </div>
+                    <div class="flex items-baseline justify-between py-2.5 border-t border-dashed border-gray-200 dark:border-verse-800">
+                      <span class="font-mono text-[11px] uppercase tracking-[0.08em] text-gray-400 dark:text-gray-500">Time</span>
+                      <span class="text-[15px] font-semibold text-gray-900 dark:text-gray-100">{{ meetup.startTime || 'TBA' }}</span>
+                    </div>
+                    <div class="flex items-baseline justify-between py-2.5 border-t border-dashed border-gray-200 dark:border-verse-800">
+                      <span class="font-mono text-[11px] uppercase tracking-[0.08em] text-gray-400 dark:text-gray-500">Price</span>
+                      <span class="text-[15px] font-semibold text-[oklch(45%_0.1_155)] dark:text-emerald-400">Free</span>
                     </div>
                   </div>
 
+                  <!-- Capacity -->
+                  <div
+                    v-if="meetup.seatsAvailable"
+                    data-change="seats"
+                    :data-changed-active="activeChange === 'seats' ? '' : null"
+                    class="mt-4"
+                  >
+                    <div class="flex items-baseline justify-between">
+                      <span class="font-mono text-[11px] uppercase tracking-[0.08em] text-gray-400 dark:text-gray-500">Capacity</span>
+                      <span class="text-[14px] font-semibold">
+                        <span :class="capacityPercent >= 80 ? 'text-coral-strong' : 'text-gray-900 dark:text-gray-100'">{{ rsvpCount }}</span>
+                        <span class="text-gray-400 dark:text-gray-500"> / {{ meetup.seatsAvailable }}</span>
+                      </span>
+                    </div>
+                    <div class="mt-2 h-1.5 rounded-full bg-gray-100 dark:bg-verse-900 overflow-hidden">
+                      <div
+                        class="h-full rounded-full transition-all duration-500"
+                        :class="
+                          capacityPercent >= 80
+                            ? 'bg-gradient-to-r from-coral-strong to-amber-400'
+                            : 'bg-gradient-to-r from-verse-500 to-verse-400'
+                        "
+                        :style="{ width: `${capacityPercent}%` }"
+                      />
+                    </div>
+                    <p v-if="spotsRemaining !== null && spotsRemaining <= 10 && spotsRemaining > 0" class="mt-1.5 font-mono text-[11.5px] text-coral-strong">
+                      Only {{ spotsRemaining }} spot<template v-if="spotsRemaining !== 1">s</template> left
+                    </p>
+                  </div>
+
+                  <!-- Venue block -->
                   <div
                     v-if="meetup.venue"
                     data-change="location"
                     :data-changed-active="activeChange === 'location' ? '' : null"
-                    class="pt-4 border-t border-gray-100 dark:border-verse-800 space-y-1"
+                    class="mt-5"
                   >
-                    <p class="text-xs font-medium text-gray-500 dark:text-gray-400">Venue</p>
-                    <p class="text-sm font-bold text-gray-900 dark:text-gray-100 leading-snug">
-                      {{ meetup.venue }}
-                    </p>
-                    <p v-if="meetup.location" class="text-xs text-gray-400 font-medium">
-                      {{ meetup.location }}
-                    </p>
-                    <div class="flex flex-wrap gap-2 pt-2">
+                    <span class="font-mono text-[10.5px] uppercase tracking-[0.12em] text-gray-400 dark:text-gray-500">Venue</span>
+                    <div class="text-[15px] font-semibold text-gray-900 dark:text-gray-100 mt-1.5 leading-snug">{{ meetup.venue }}</div>
+                    <div v-if="meetup.location" class="text-[13.5px] text-gray-500 dark:text-gray-400 leading-snug">{{ meetup.location }}</div>
+                    <div v-if="meetup.mapUrl || meetup.parkingLocation" class="mt-3 flex flex-wrap gap-x-4 gap-y-1.5">
                       <a
                         v-if="meetup.mapUrl"
                         :href="meetup.mapUrl"
                         target="_blank"
                         rel="noopener noreferrer"
-                        class="inline-flex items-center gap-1.5 text-xs font-semibold text-verse-500 hover:text-verse-600 transition-colors"
+                        class="inline-flex items-center gap-1.5 font-mono text-[11.5px] font-semibold text-verse-600 dark:text-verse-400 hover:text-verse-700"
                       >
-                        <svg
-                          class="w-3.5 h-3.5"
-                          fill="none"
-                          stroke="currentColor"
-                          viewBox="0 0 24 24"
-                        >
-                          <path
-                            stroke-linecap="round"
-                            stroke-linejoin="round"
-                            stroke-width="2"
-                            d="M9 20l-5.447-2.724A1 1 0 013 16.382V5.618a1 1 0 011.447-.894L9 7m0 13l6-3m-6 3V7m6 10l4.553 2.276A1 1 0 0021 18.382V7.618a1 1 0 00-.553-.894L15 4m0 13V4m0 0L9 7"
-                          />
+                        <svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+                          <path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 1 1 16 0Z" />
+                          <circle cx="12" cy="10" r="3" />
                         </svg>
-                        View map
+                        Directions
                       </a>
-                      <span
-                        v-if="meetup.parkingLocation"
-                        class="inline-flex items-center gap-1.5 text-xs text-gray-400"
-                      >
-                        <svg
-                          class="w-3.5 h-3.5"
-                          fill="none"
-                          stroke="currentColor"
-                          viewBox="0 0 24 24"
-                        >
-                          <path
-                            stroke-linecap="round"
-                            stroke-linejoin="round"
-                            stroke-width="2"
-                            d="M5 10l7-7m0 0l7 7m-7-7v18"
-                          />
-                        </svg>
-                        {{ meetup.parkingLocation }}
+                      <span v-if="meetup.parkingLocation" class="inline-flex items-center gap-1.5 font-mono text-[11.5px] text-gray-400 dark:text-gray-500">
+                        Parking: {{ meetup.parkingLocation }}
                       </span>
                     </div>
                   </div>
-
-                  <!-- Sidebar RSVP -->
-                  <div
-                    data-change="rsvp"
-                    :data-changed-active="activeChange === 'rsvp' ? '' : null"
-                    class="pt-4 border-t border-gray-100 dark:border-verse-800 space-y-3"
-                  >
-                    <div
-                      v-if="
-                        isUpcoming ||
-                        isToday ||
-                        (featureFlags.rsvpPastEvents && isPast && meetup.acceptingRsvp)
-                      "
-                    >
-                      <template v-if="!isAuthenticated && canRsvp">
-                        <Link
-                          href="/login"
-                          class="block w-full py-2.5 text-center text-sm font-medium bg-verse-600 text-white rounded-md hover:bg-verse-700 transition-colors"
-                        >
-                          Login to RSVP
-                        </Link>
-                      </template>
-                      <template v-else-if="isAuthenticated && canRsvp">
-                        <button
-                          v-if="hasRsvp"
-                          @click="handleCancelRsvp"
-                          :disabled="isRsvpLoading"
-                          class="w-full py-2.5 text-sm font-medium border border-red-300 dark:border-red-800 text-red-600 dark:text-red-400 rounded-md hover:bg-red-50 dark:hover:bg-red-950/30 transition-colors disabled:opacity-50"
-                        >
-                          {{ isRsvpLoading ? 'Cancelling...' : 'Cancel RSVP' }}
-                        </button>
-                        <button
-                          v-else
-                          @click="handleRsvp"
-                          :disabled="isRsvpLoading"
-                          class="w-full py-2.5 text-sm font-medium bg-verse-600 text-white rounded-md hover:bg-verse-700 transition-colors disabled:opacity-50"
-                        >
-                          {{
-                            isRsvpLoading ? 'Submitting...' : isFull ? 'Join Waitlist' : 'RSVP Now'
-                          }}
-                        </button>
-                      </template>
-                      <div
-                        v-else
-                        class="text-center p-3 bg-gray-50 dark:bg-verse-900 rounded-md text-xs font-medium text-gray-500 dark:text-gray-400 border border-gray-200 dark:border-verse-900"
-                      >
-                        RSVPs Closed
-                      </div>
-                    </div>
-
-                    <div class="flex gap-2">
-                      <a
-                        v-if="calendarUrl"
-                        :href="calendarUrl"
-                        target="_blank"
-                        class="flex-1 flex items-center justify-center gap-2 py-2.5 border border-gray-200 dark:border-verse-800 rounded-md text-xs font-medium text-gray-500 hover:text-verse-500 dark:text-gray-400 dark:hover:text-verse-400 transition-colors"
-                      >
-                        <svg
-                          class="w-3.5 h-3.5"
-                          fill="none"
-                          stroke="currentColor"
-                          viewBox="0 0 24 24"
-                        >
-                          <path
-                            stroke-linecap="round"
-                            stroke-linejoin="round"
-                            stroke-width="2"
-                            d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
-                          />
-                        </svg>
-                        Add to Calendar
-                      </a>
-                      <button
-                        @click="shareEvent"
-                        class="p-2.5 border border-gray-200 dark:border-verse-800 rounded-md text-gray-400 hover:text-verse-500 transition-colors"
-                        aria-label="Share event"
-                      >
-                        <svg
-                          class="w-3.5 h-3.5"
-                          fill="none"
-                          stroke="currentColor"
-                          viewBox="0 0 24 24"
-                        >
-                          <path
-                            stroke-linecap="round"
-                            stroke-linejoin="round"
-                            stroke-width="2"
-                            d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z"
-                          />
-                        </svg>
-                      </button>
-                    </div>
-                  </div>
                 </div>
+
+                <!-- Footer CTA -->
+                <div
+                  data-change="rsvp"
+                  :data-changed-active="activeChange === 'rsvp' ? '' : null"
+                  class="px-6 py-5 border-t border-gray-100 dark:border-verse-900 flex gap-2.5"
+                >
+                  <template v-if="isUpcoming || isToday || (featureFlags.rsvpPastEvents && isPast && meetup.acceptingRsvp)">
+                    <template v-if="!isAuthenticated && canRsvp">
+                      <Link
+                        href="/login"
+                        class="flex-1 py-3 text-center text-sm font-semibold bg-verse-600 text-white rounded-lg hover:bg-verse-700 transition-colors"
+                      >
+                        Login to RSVP
+                      </Link>
+                    </template>
+                    <template v-else-if="isAuthenticated && canRsvp">
+                      <button
+                        v-if="hasRsvp"
+                        :disabled="isRsvpLoading"
+                        class="flex-1 py-3 text-sm font-semibold border border-gray-200 dark:border-verse-800 bg-[oklch(95%_0.03_155)] text-[oklch(38%_0.08_155)] rounded-lg transition-colors disabled:opacity-50"
+                        @click="handleCancelRsvp"
+                      >
+                        <span v-if="isRsvpLoading">Cancelling…</span>
+                        <span v-else>✓ You're in — tap to cancel</span>
+                      </button>
+                      <button
+                        v-else
+                        :disabled="isRsvpLoading"
+                        class="flex-1 py-3 text-sm font-semibold bg-verse-600 text-white rounded-lg hover:bg-verse-700 transition-colors disabled:opacity-50"
+                        @click="handleRsvp"
+                      >
+                        {{ isRsvpLoading ? 'Submitting…' : isFull ? 'Join waitlist' : 'RSVP — claim your spot' }}
+                      </button>
+                    </template>
+                    <div
+                      v-else
+                      class="flex-1 py-3 text-center rounded-lg border border-gray-200 dark:border-verse-800 text-xs font-medium text-gray-500 dark:text-gray-400"
+                    >
+                      RSVPs Closed
+                    </div>
+                  </template>
+                  <a
+                    v-else-if="calendarUrl"
+                    :href="calendarUrl"
+                    target="_blank"
+                    class="flex-1 py-3 text-center text-sm font-semibold border border-gray-200 dark:border-verse-800 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-verse-900 transition-colors"
+                  >
+                    Add to Calendar
+                  </a>
+                  <button
+                    type="button"
+                    class="w-11 h-11 rounded-lg border border-gray-200 dark:border-verse-800 grid place-items-center text-gray-500 dark:text-gray-400 hover:text-verse-500 transition-colors"
+                    aria-label="Share"
+                    @click="shareEvent"
+                  >
+                    <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+                      <circle cx="18" cy="5" r="3" /><circle cx="6" cy="12" r="3" /><circle cx="18" cy="19" r="3" />
+                      <path d="m8.59 13.51 6.83 3.98M15.41 6.51l-6.82 3.98" />
+                    </svg>
+                  </button>
+                </div>
+
+                <p v-if="rsvpError" class="px-6 pb-5 text-[13px] text-red-500 font-medium">{{ rsvpError }}</p>
+                <p v-if="rsvpSuccess" class="px-6 pb-5 text-[13px] text-emerald-600 dark:text-emerald-400 font-medium">{{ rsvpSuccess }}</p>
               </div>
             </div>
           </aside>
         </div>
-
-        <!-- ===== ATTENDEES (full-width) ===== -->
-        <section v-if="attendees.length > 0" class="mt-16 space-y-8">
-          <div class="flex items-center gap-2">
-            <span class="text-sm font-semibold text-verse-500 dark:text-verse-400">Attendees</span>
-            <div class="h-px flex-1 bg-gray-100 dark:bg-verse-900"></div>
-            <span class="text-xs font-bold text-gray-400">{{ rsvpCount }} RSVP'd</span>
-          </div>
-
-          <div class="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8 gap-4">
-            <div
-              v-for="attendee in attendees"
-              :key="attendee.id"
-              class="flex flex-col items-center gap-2 group"
-            >
-              <SpeakerAvatar
-                size="md"
-                :name="attendee.name"
-                :github-username="attendee.githubUsername"
-                :avatar-url="attendee.avatarUrl"
-              />
-              <p
-                class="text-[11px] font-medium text-gray-500 dark:text-gray-400 text-center leading-tight truncate w-full group-hover:text-verse-500 transition-colors"
-              >
-                {{ attendee.name }}
-              </p>
-            </div>
-          </div>
-        </section>
       </template>
 
       <!-- Not Found -->

--- a/packages/frontendmu-adonis/inertia/pages/meetups/show.vue
+++ b/packages/frontendmu-adonis/inertia/pages/meetups/show.vue
@@ -305,13 +305,13 @@ const calendarUrl = computed(() => {
 
 <template>
   <Head :title="meetup?.title || 'Meetup'" />
-  <main class="relative min-h-screen pt-24 pb-24">
+  <main class="relative min-h-screen pt-36 md:pt-44 pb-24">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 relative z-10">
       <template v-if="meetup">
         <!-- ===== HERO ZONE ===== -->
-        <section id="rsvp-section" class="pb-10 border-b border-gray-200 dark:border-verse-900">
+        <section id="rsvp-section" class="pb-16 border-b border-gray-200 dark:border-verse-900">
           <!-- Breadcrumb + Edit -->
-          <div class="flex items-center justify-between flex-wrap gap-3 mb-5">
+          <div class="flex items-center justify-between flex-wrap gap-3 mb-7">
             <p class="mono-eyebrow">
               <Link href="/meetups">MEETUPS</Link>
               <span v-if="eventDate" class="sep">/</span>
@@ -332,7 +332,7 @@ const calendarUrl = computed(() => {
           </div>
 
           <!-- Status pill -->
-          <div class="mb-4 flex items-center gap-3 flex-wrap">
+          <div class="mb-8 flex items-center gap-3 flex-wrap">
             <span
               class="inline-flex items-center gap-2 px-3 py-1.5 rounded-full font-mono text-[11px] font-semibold uppercase tracking-widest border"
               :class="
@@ -350,7 +350,7 @@ const calendarUrl = computed(() => {
 
           <!-- Title — editorial serif with italic tail -->
           <h1
-            class="font-display text-[clamp(44px,6.5vw,84px)] leading-[0.98] text-gray-900 dark:text-gray-100 text-balance max-w-[16ch] mb-6"
+            class="font-display text-[clamp(44px,6.5vw,84px)] leading-[0.98] text-gray-900 dark:text-gray-100 text-balance max-w-[16ch] mb-8"
           >
             <template v-if="titleParts.plain">{{ titleParts.plain }}&nbsp;</template><span class="font-display-italic text-verse-500 dark:text-verse-300">{{ titleParts.italic }}</span>
           </h1>
@@ -358,13 +358,13 @@ const calendarUrl = computed(() => {
           <!-- Subtitle (first sentence of description, muted) -->
           <p
             v-if="heroSubtitle"
-            class="text-[18px] leading-[1.55] text-gray-500 dark:text-gray-400 max-w-[56ch] mb-8"
+            class="text-[18px] leading-[1.55] text-gray-500 dark:text-gray-400 max-w-[56ch] mb-12"
           >
             {{ heroSubtitle }}
           </p>
 
           <!-- Meta row: icon-tiled Date / Time / Venue -->
-          <div class="flex flex-wrap gap-x-9 gap-y-5 pt-2">
+          <div class="flex flex-wrap gap-x-10 gap-y-5 pt-4">
             <div v-if="eventDate" class="flex items-start gap-3">
               <div
                 class="w-9 h-9 rounded-[10px] bg-verse-50 dark:bg-verse-900/60 text-verse-600 dark:text-verse-300 grid place-items-center shrink-0"

--- a/packages/frontendmu-adonis/inertia/pages/meetups/show.vue
+++ b/packages/frontendmu-adonis/inertia/pages/meetups/show.vue
@@ -429,7 +429,7 @@ const calendarUrl = computed(() => {
             </section>
 
             <!-- Agenda -->
-            <section v-if="meetup.sessions.length" class="py-12 border-b border-gray-200 dark:border-verse-900">
+            <section v-if="meetup.sessions.length" class="pb-12 border-b border-gray-200 dark:border-verse-900">
               <span class="section-label">Agenda</span>
 
               <ol class="mt-6 divide-y divide-dashed divide-gray-200 dark:divide-verse-900">
@@ -606,6 +606,32 @@ const calendarUrl = computed(() => {
               </ol>
             </section>
 
+            <!-- Photo Gallery (past only) -->
+            <section v-if="meetup.photos.length" class="py-12 border-b border-gray-200 dark:border-verse-900">
+              <div class="flex items-center justify-between gap-4 flex-wrap">
+                <span class="section-label">Photos</span>
+                <span class="font-mono text-[11px] uppercase tracking-[0.08em] text-gray-400 dark:text-gray-500">
+                  {{ meetup.photos.length }} photos · tap to expand
+                </span>
+              </div>
+              <div class="mt-6 grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3">
+                <button
+                  v-for="(photo, index) in meetup.photos"
+                  :key="photo.id"
+                  type="button"
+                  class="relative rounded-md overflow-hidden aspect-square group focus:outline-none focus:ring-2 focus:ring-verse-500"
+                  @click="openLightbox(index)"
+                >
+                  <img
+                    :src="photo.thumbnailUrl"
+                    :alt="photo.caption || 'Event photo'"
+                    loading="lazy"
+                    class="w-full h-full object-cover transition-transform duration-300 group-hover:scale-[1.04]"
+                  />
+                </button>
+              </div>
+            </section>
+
             <!-- Speakers (dedicated card grid when we have them) -->
             <section v-if="allSpeakers.length" class="py-12 border-b border-gray-200 dark:border-verse-900">
               <span class="section-label">Speakers</span>
@@ -660,32 +686,6 @@ const calendarUrl = computed(() => {
                   <strong class="text-gray-900 dark:text-gray-100 font-bold">{{ rsvpCount }} attending</strong>
                   <template v-if="spotsRemaining !== null && !isPast"> · {{ spotsRemaining }} spots left</template>
                 </p>
-              </div>
-            </section>
-
-            <!-- Photo Gallery (past only) -->
-            <section v-if="meetup.photos.length" class="py-12 border-b border-gray-200 dark:border-verse-900">
-              <div class="flex items-center justify-between gap-4 flex-wrap">
-                <span class="section-label">Photos</span>
-                <span class="font-mono text-[11px] uppercase tracking-[0.08em] text-gray-400 dark:text-gray-500">
-                  {{ meetup.photos.length }} photos · tap to expand
-                </span>
-              </div>
-              <div class="mt-6 grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3">
-                <button
-                  v-for="(photo, index) in meetup.photos"
-                  :key="photo.id"
-                  type="button"
-                  class="relative rounded-md overflow-hidden aspect-square group focus:outline-none focus:ring-2 focus:ring-verse-500"
-                  @click="openLightbox(index)"
-                >
-                  <img
-                    :src="photo.thumbnailUrl"
-                    :alt="photo.caption || 'Event photo'"
-                    loading="lazy"
-                    class="w-full h-full object-cover transition-transform duration-300 group-hover:scale-[1.04]"
-                  />
-                </button>
               </div>
             </section>
 

--- a/packages/frontendmu-adonis/inertia/pages/meetups/show.vue
+++ b/packages/frontendmu-adonis/inertia/pages/meetups/show.vue
@@ -31,7 +31,6 @@ const showMobileRsvp = ref(false)
 
 // Check if user has an active RSVP
 const hasRsvp = computed(() => !!props.userRsvp)
-const rsvpStatus = computed(() => props.userRsvp?.status)
 
 // Check if event is accepting RSVPs
 const canRsvp = computed(() => {
@@ -197,8 +196,6 @@ const heroSubtitle = computed(() => {
   const sentence = firstStop > 0 ? text.slice(0, firstStop + 1) : text
   return sentence.length > 220 ? sentence.slice(0, 200).trim() + '…' : sentence
 })
-
-const formattedDateShort = computed(() => eventDate.value?.toFormat('EEE, MMM d') ?? '')
 
 const daysUntil = computed(() => {
   if (!eventDate.value || !isUpcoming.value) return null
@@ -429,7 +426,7 @@ const calendarUrl = computed(() => {
             </section>
 
             <!-- Agenda -->
-            <section v-if="meetup.sessions.length" class="pb-12 border-b border-gray-200 dark:border-verse-900">
+            <section v-if="meetup.sessions?.length" class="pb-12 border-b border-gray-200 dark:border-verse-900">
               <span class="section-label">Agenda</span>
 
               <ol class="mt-6 divide-y divide-dashed divide-gray-200 dark:divide-verse-900">
@@ -586,7 +583,7 @@ const calendarUrl = computed(() => {
                         v-else-if="session.speakers?.length"
                         class="text-[14px] text-gray-500 dark:text-gray-400"
                       >
-                        ·
+                        · by
                         <Link
                           v-for="(speaker, i) in session.speakers"
                           :key="speaker.id"
@@ -607,7 +604,7 @@ const calendarUrl = computed(() => {
             </section>
 
             <!-- Photo Gallery (past only) -->
-            <section v-if="meetup.photos.length" class="py-12 border-b border-gray-200 dark:border-verse-900">
+            <section v-if="meetup.photos?.length" class="py-12 border-b border-gray-200 dark:border-verse-900">
               <div class="flex items-center justify-between gap-4 flex-wrap">
                 <span class="section-label">Photos</span>
                 <span class="font-mono text-[11px] uppercase tracking-[0.08em] text-gray-400 dark:text-gray-500">
@@ -690,7 +687,7 @@ const calendarUrl = computed(() => {
             </section>
 
             <!-- Sponsors -->
-            <section v-if="meetup.sponsors.length" class="py-12 border-b border-gray-200 dark:border-verse-900">
+            <section v-if="meetup.sponsors?.length" class="py-12 border-b border-gray-200 dark:border-verse-900">
               <span class="section-label">Sponsors</span>
               <div
                 class="mt-6 flex flex-wrap gap-x-10 gap-y-4 items-center px-7 py-6 rounded-xl border border-dashed border-gray-300 dark:border-verse-800 bg-white dark:bg-verse-950"

--- a/packages/frontendmu-adonis/inertia/pages/meetups/show.vue
+++ b/packages/frontendmu-adonis/inertia/pages/meetups/show.vue
@@ -442,122 +442,122 @@ const calendarUrl = computed(() => {
             <section v-if="meetup.sessions.length" class="py-12 border-b border-gray-200 dark:border-verse-900">
               <span class="section-label">Agenda</span>
 
-              <div class="mt-7">
+              <ol class="mt-6 divide-y divide-dashed divide-gray-200 dark:divide-verse-900">
                 <template v-for="session in meetup.sessions" :key="session.id">
                   <!-- Minimal row: break / photo -->
-                  <article
+                  <li
                     v-if="session.kind === 'break' || session.kind === 'photo'"
-                    class="agenda-session flex items-center gap-4 py-5 border-b border-dashed border-gray-200 dark:border-verse-900 last:border-b-0"
+                    class="agenda-session flex items-center gap-3 py-3 text-gray-500 dark:text-gray-400"
                   >
                     <span
-                      class="w-9 h-9 rounded-[10px] bg-gray-50 dark:bg-verse-900/60 text-gray-500 dark:text-gray-400 grid place-items-center shrink-0"
+                      class="w-7 h-7 rounded-md bg-gray-50 dark:bg-verse-900/60 grid place-items-center shrink-0"
                     >
-                      <svg v-if="session.kind === 'break'" class="w-[18px] h-[18px]" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+                      <svg v-if="session.kind === 'break'" class="w-[15px] h-[15px]" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
                         <path d="M17 8h1a4 4 0 0 1 0 8h-1" />
                         <path d="M3 8h14v9a4 4 0 0 1-4 4H7a4 4 0 0 1-4-4z" />
                         <path d="M6 2v3M10 2v3M14 2v3" />
                       </svg>
-                      <svg v-else class="w-[18px] h-[18px]" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+                      <svg v-else class="w-[15px] h-[15px]" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
                         <path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z" />
                         <circle cx="12" cy="13" r="4" />
                       </svg>
                     </span>
-                    <p class="flex-1 text-[17px] text-gray-700 dark:text-gray-300">
-                      {{ session.title }}
-                    </p>
+                    <p class="flex-1 text-[15px] italic">{{ session.title }}</p>
                     <span
                       v-if="session.durationMinutes"
-                      class="font-mono text-[12px] text-gray-400 dark:text-gray-500"
+                      class="font-mono text-[11.5px] text-gray-400 dark:text-gray-500"
                     >
                       {{ session.durationMinutes }} min
                     </span>
-                  </article>
+                  </li>
 
                   <!-- Sponsored row -->
-                  <article
-                    v-else-if="session.kind === 'sponsored' && session.sponsor"
-                    class="agenda-session py-6 border-b border-dashed border-gray-200 dark:border-verse-900 last:border-b-0"
+                  <li
+                    v-else-if="session.kind === 'sponsored'"
+                    class="agenda-session py-4 flex items-center gap-4 flex-wrap"
                   >
-                    <span class="font-mono text-[10.5px] uppercase tracking-[0.14em] text-coral-strong font-semibold">
-                      Sponsor spotlight
+                    <component
+                      :is="session.sponsor ? 'Link' : 'div'"
+                      :href="session.sponsor ? `/sponsor/${session.sponsor.id}` : undefined"
+                      class="flex items-center gap-3.5 min-w-0 flex-1 group/sponsor"
+                    >
+                      <img
+                        v-if="session.sponsor && (session.sponsor.logoUrl || session.sponsor.logomarkUrl)"
+                        :src="(session.sponsor.logoUrl || session.sponsor.logomarkUrl) as string"
+                        :alt="session.sponsor.name"
+                        class="h-8 w-auto object-contain opacity-90 group-hover/sponsor:opacity-100 transition-opacity shrink-0"
+                      />
+                      <div class="min-w-0 leading-tight">
+                        <span class="font-mono text-[10.5px] uppercase tracking-[0.12em] text-coral-strong font-semibold">
+                          Sponsor spotlight
+                        </span>
+                        <p class="mt-1 font-display text-[20px] md:text-[22px] leading-[1.15] text-gray-900 dark:text-gray-100 truncate">
+                          {{ session.title }}
+                        </p>
+                        <p
+                          v-if="session.sponsor"
+                          class="mt-0.5 text-[13px] text-gray-500 dark:text-gray-400 group-hover/sponsor:text-verse-500 transition-colors"
+                        >
+                          by {{ session.sponsor.name }}
+                        </p>
+                      </div>
+                    </component>
+                    <span
+                      v-if="session.durationMinutes"
+                      class="font-mono text-[11.5px] text-gray-400 dark:text-gray-500"
+                    >
+                      {{ session.durationMinutes }} min
                     </span>
-                    <div class="mt-2 flex items-center gap-4 flex-wrap">
-                      <Link
-                        :href="`/sponsor/${session.sponsor.id}`"
-                        class="flex items-center gap-4 group/sponsor"
-                      >
-                        <img
-                          v-if="session.sponsor.logoUrl || session.sponsor.logomarkUrl"
-                          :src="(session.sponsor.logoUrl || session.sponsor.logomarkUrl) as string"
-                          :alt="session.sponsor.name"
-                          class="h-10 w-auto object-contain opacity-90 group-hover/sponsor:opacity-100 transition-opacity"
-                        />
-                        <div class="leading-tight">
-                          <h3 class="font-display text-[24px] md:text-[26px] leading-[1.15] text-gray-900 dark:text-gray-100">
-                            {{ session.title }}
-                          </h3>
-                          <p class="mt-1 text-[14px] text-gray-500 dark:text-gray-400 group-hover/sponsor:text-verse-500 transition-colors">
-                            by {{ session.sponsor.name }}
-                          </p>
-                        </div>
-                      </Link>
-                      <span
-                        v-if="session.durationMinutes"
-                        class="font-mono text-[12px] text-gray-400 dark:text-gray-500 ml-auto"
-                      >
-                        {{ session.durationMinutes }} min
-                      </span>
-                    </div>
-                  </article>
+                  </li>
 
-                  <!-- Talk / intro / quiz / other: full card with speakers -->
-                  <article
+                  <!-- Talk / intro / quiz / other -->
+                  <li
                     v-else
-                    class="agenda-session py-8 border-b border-dashed border-gray-200 dark:border-verse-900 last:border-b-0"
+                    class="agenda-session py-5 flex items-start gap-5 flex-wrap md:flex-nowrap"
                   >
-                    <div class="flex items-center gap-3 mb-2 flex-wrap">
-                      <span
-                        v-if="session.kind && session.kind !== 'talk'"
-                        class="px-2 py-0.5 bg-verse-50 dark:bg-verse-900 text-verse-600 dark:text-verse-300 text-[10.5px] font-mono font-semibold uppercase tracking-[0.12em] rounded"
-                      >
-                        {{ session.kind }}
-                      </span>
-                      <span
-                        v-if="session.durationMinutes"
-                        class="font-mono text-[12px] text-gray-400 dark:text-gray-500"
-                      >
-                        {{ session.durationMinutes }} min
-                      </span>
+                    <div class="min-w-0 flex-1">
+                      <div v-if="session.kind && session.kind !== 'talk' || session.durationMinutes" class="flex items-center gap-2.5 mb-1.5 flex-wrap">
+                        <span
+                          v-if="session.kind && session.kind !== 'talk'"
+                          class="font-mono text-[10.5px] uppercase tracking-[0.12em] font-semibold text-verse-600 dark:text-verse-300"
+                        >
+                          {{ session.kind }}
+                        </span>
+                        <span
+                          v-if="session.durationMinutes"
+                          class="font-mono text-[11.5px] text-gray-400 dark:text-gray-500"
+                        >
+                          {{ session.durationMinutes }} min
+                        </span>
+                      </div>
+                      <h3 class="font-display text-[22px] md:text-[24px] leading-[1.2] text-gray-900 dark:text-gray-100">
+                        {{ session.title }}
+                      </h3>
                     </div>
-                    <h3 class="font-display text-[26px] md:text-[30px] leading-[1.1] text-gray-900 dark:text-gray-100">
-                      {{ session.title }}
-                    </h3>
-                    <div v-if="session.speakers?.length" class="mt-4 flex flex-wrap gap-x-6 gap-y-4">
+                    <div
+                      v-if="session.speakers?.length"
+                      class="flex flex-wrap gap-x-5 gap-y-2 md:justify-end md:min-w-[220px] md:pt-1"
+                    >
                       <Link
                         v-for="speaker in session.speakers"
                         :key="speaker.id"
                         :href="`/speaker/${speaker.id}`"
-                        class="flex items-center gap-3 group/speaker"
+                        class="flex items-center gap-2.5 group/speaker"
                       >
                         <SpeakerAvatar
-                          size="md"
+                          size="sm"
                           :name="speaker.name"
                           :github-username="speaker.githubUsername"
                           class="ring-2 ring-gray-100 dark:ring-verse-900 group-hover/speaker:ring-verse-500 transition-all"
                         />
-                        <div class="leading-tight">
-                          <p class="text-[15px] font-semibold text-gray-900 dark:text-gray-200 group-hover/speaker:text-verse-500 transition-colors">
-                            {{ speaker.name }}
-                          </p>
-                          <p v-if="speaker.githubUsername" class="text-[12px] text-gray-400 mt-1 font-mono">
-                            @{{ speaker.githubUsername }}
-                          </p>
-                        </div>
+                        <span class="text-[14px] font-semibold text-gray-900 dark:text-gray-200 group-hover/speaker:text-verse-500 transition-colors">
+                          {{ speaker.name }}
+                        </span>
                       </Link>
                     </div>
-                  </article>
+                  </li>
                 </template>
-              </div>
+              </ol>
             </section>
 
             <!-- Speakers (dedicated card grid when we have them) -->

--- a/packages/frontendmu-adonis/inertia/pages/meetups/show.vue
+++ b/packages/frontendmu-adonis/inertia/pages/meetups/show.vue
@@ -305,13 +305,13 @@ const calendarUrl = computed(() => {
 
 <template>
   <Head :title="meetup?.title || 'Meetup'" />
-  <main class="relative min-h-screen pt-36 md:pt-44 pb-24">
+  <main class="relative min-h-screen pt-32 md:pt-40 pb-24">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 relative z-10">
       <template v-if="meetup">
         <!-- ===== HERO ZONE ===== -->
-        <section id="rsvp-section" class="pb-16 border-b border-gray-200 dark:border-verse-900">
+        <section id="rsvp-section" class="pb-10 border-b border-gray-200 dark:border-verse-900">
           <!-- Breadcrumb + Edit -->
-          <div class="flex items-center justify-between flex-wrap gap-3 mb-7">
+          <div class="flex items-center justify-between flex-wrap gap-3 mb-5">
             <p class="mono-eyebrow">
               <Link href="/meetups">MEETUPS</Link>
               <span v-if="eventDate" class="sep">/</span>
@@ -332,7 +332,7 @@ const calendarUrl = computed(() => {
           </div>
 
           <!-- Status pill -->
-          <div class="mb-8 flex items-center gap-3 flex-wrap">
+          <div class="mb-4 flex items-center gap-3 flex-wrap">
             <span
               class="inline-flex items-center gap-2 px-3 py-1.5 rounded-full font-mono text-[11px] font-semibold uppercase tracking-widest border"
               :class="
@@ -350,7 +350,7 @@ const calendarUrl = computed(() => {
 
           <!-- Title — editorial serif with italic tail -->
           <h1
-            class="font-display text-[clamp(44px,6.5vw,84px)] leading-[0.98] text-gray-900 dark:text-gray-100 text-balance max-w-[16ch] mb-8"
+            class="font-display text-[clamp(44px,6.5vw,84px)] leading-[0.98] text-gray-900 dark:text-gray-100 text-balance max-w-[16ch] mb-6"
           >
             <template v-if="titleParts.plain">{{ titleParts.plain }}&nbsp;</template><span class="font-display-italic text-verse-500 dark:text-verse-300">{{ titleParts.italic }}</span>
           </h1>
@@ -358,13 +358,13 @@ const calendarUrl = computed(() => {
           <!-- Subtitle (first sentence of description, muted) -->
           <p
             v-if="heroSubtitle"
-            class="text-[18px] leading-[1.55] text-gray-500 dark:text-gray-400 max-w-[56ch] mb-12"
+            class="text-[18px] leading-[1.55] text-gray-500 dark:text-gray-400 max-w-[56ch] mb-8"
           >
             {{ heroSubtitle }}
           </p>
 
           <!-- Meta row: icon-tiled Date / Time / Venue -->
-          <div class="flex flex-wrap gap-x-10 gap-y-5 pt-4">
+          <div class="flex flex-wrap gap-x-9 gap-y-5 pt-2">
             <div v-if="eventDate" class="flex items-start gap-3">
               <div
                 class="w-9 h-9 rounded-[10px] bg-verse-50 dark:bg-verse-900/60 text-verse-600 dark:text-verse-300 grid place-items-center shrink-0"

--- a/packages/frontendmu-adonis/resources/views/inertia_layout.edge
+++ b/packages/frontendmu-adonis/resources/views/inertia_layout.edge
@@ -7,7 +7,7 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT,WONK@0,9..144,400..700,0..100,0..1;1,9..144,400..700,0..100,0..1&family=Inter:wght@400;500;600;700&family=Instrument+Serif:ital@0;1&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
     <script nonce="{{ cspNonce }}">
       // Prevent flash of incorrect theme
       (function() {

--- a/packages/frontendmu-adonis/resources/views/inertia_layout.edge
+++ b/packages/frontendmu-adonis/resources/views/inertia_layout.edge
@@ -23,5 +23,29 @@
 <body>
     @inertia()
     @debugbar()
+    <script nonce="{{ cspNonce }}">
+      // Keep the AdonisJS debug bar collapsed on initial load — the library
+      // hardcodes isPanelOpen: true and does not persist the state. We wait
+      // for the debug bar's boot script to run its first render (which flips
+      // #dbg-panel to display:block), then click close to sync its state.
+      (function () {
+        var closed = false;
+        var tryClose = function () {
+          if (closed) return true;
+          var panel = document.getElementById('dbg-panel');
+          var btn = document.getElementById('dbg-btn-close');
+          if (panel && btn && panel.style.display === 'block') {
+            btn.click();
+            closed = true;
+            return true;
+          }
+          return false;
+        };
+        var start = Date.now();
+        var interval = setInterval(function () {
+          if (tryClose() || Date.now() - start > 8000) clearInterval(interval);
+        }, 50);
+      })();
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- **Typography foundation** — Fraunces display / Inter sans / JetBrains Mono, bigger section labels, overhauled `EventCard` and meetup listing + detail pages
- **Session kinds** — talks now share the agenda with \`intro\`, \`sponsored\`, \`break\`, \`photo\`, \`quiz\`, and \`other\`. New \`kind\`, \`sponsor_id\`, \`duration_minutes\` columns on \`sessions\`; admin form gains a Type dropdown, sponsor picker (only for sponsored), optional duration, and quick-add buttons (+Intro / +Lunch break / +Group photo / +Quiz / +Sponsored). Rendering is kind-aware with a consistent avatar/icon left column
- **Speakers scoped to talks** — intro hosts and quiz MCs are no longer counted as event speakers. The EventTransformer now derives a top-level \`speakers\` field that filters to \`talk | other\` kinds and both the Inertia page and public API consume it
- **Cover images on listing** — each card's right column now renders the first album photo (via \`images.weserv.nl\` thumbnail, 600px). The right column is hidden entirely when no cover exists, giving upcoming / un-synced events a cleaner single-column layout
- **Photos section moved above Speakers** on the meetup detail page
- **Hide debug bar by default** on page load (library defaults to open and doesn't persist the state)

## Migration note

\`1776900000000_add_kind_and_sponsor_to_sessions.ts\` adds \`kind\` + \`sponsor_id\` + \`duration_minutes\`. Adding an FK in SQLite triggers a table-recreate, and the existing \`session_speakers → sessions\` FK has \`ON DELETE CASCADE\`. Without guards this wipes the pivot table mid-migration. The migration uses \`static disableTransactions = true\` and brackets the alter with \`PRAGMA foreign_keys OFF/ON\` — verified locally that 159 pivot rows survive a rollback-and-reapply cycle.

## Deploy action needed

Production needs a one-off \`node ace photos:sync\` run — the \`event_photos\` table has been empty across all environments since the gallery feature shipped (PR #338 said "add this to the post-deploy step" but the workflow change was missed). Once sync runs, meetup galleries and listing covers populate automatically.

## Test plan

- [ ] Open \`/meetups\` — cards show cover photos for past events with synced albums, collapsed single-column for upcoming / un-synced
- [ ] Open \`/meetup/2025-november\` — agenda renders with talk avatars, icon medallions for intro/break/photo/quiz, speaker attribution inline for intro/quiz, sponsor logo for sponsored
- [ ] Speakers card grid shows only talk speakers — no quiz hosts or intro MCs
- [ ] Admin event edit — add \`+Intro\` / \`+Lunch break\` / \`+Quiz\`, confirm speaker picker hidden for break/photo/sponsored, sponsor picker shown only for sponsored
- [ ] Rollback + re-run migration: 159 session_speakers survive

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sessions gain explicit types (talk/intro/sponsored/break/photo/quiz/other), optional duration, and sponsorship support with sponsor display.
  * Meetup listings: search/status filters, attendee totals, featured per-year layout.
  * Events: cover thumbnail, deduplicated speaker lists, redesigned agenda, expanded sharing (Twitter/LinkedIn/copy).

* **Style**
  * New typography (Fraunces, Inter, JetBrains Mono), coral accent palette, pulse animation, and refined display utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->