### PR TITLE
Tighten meetup pages, mobile header, and sponsor grid

### DIFF
--- a/packages/frontendmu-adonis/inertia/components/event/EventCard.vue
+++ b/packages/frontendmu-adonis/inertia/components/event/EventCard.vue
@@ -53,7 +53,7 @@ function stripHtml(input: string): string {
 
 <template>
   <article
-    class="meetup-card group relative grid rounded-[14px] overflow-hidden border transition-all duration-200 hover:-translate-y-[3px] bg-white dark:bg-verse-950"
+    class="meetup-card group relative grid h-full rounded-[14px] overflow-hidden border transition-all duration-200 hover:-translate-y-[3px] bg-white dark:bg-verse-950"
     :class="[
       coverThumbnail
         ? featured

--- a/packages/frontendmu-adonis/inertia/components/home/Sponsors.vue
+++ b/packages/frontendmu-adonis/inertia/components/home/Sponsors.vue
@@ -59,10 +59,8 @@ const grid = computed(() => {
           <Link
             v-if="cell.sponsor"
             :href="`/sponsor/${cell.sponsor.id}`"
-            class="hex-cell hex-cell--filled hex-wave"
-            :style="
-              { '--hex-fill': cell.sponsor.logoBg || undefined, '--wave-i': rowIdx + colIdx } as any
-            "
+            class="hex-cell hex-cell--filled"
+            :style="{ '--hex-fill': cell.sponsor.logoBg || undefined } as any"
           >
             <img
               v-if="cell.sponsor.logoUrl"
@@ -78,11 +76,7 @@ const grid = computed(() => {
               {{ cell.sponsor.name }}
             </span>
           </Link>
-          <div
-            v-else
-            class="hex-cell hex-cell--empty hex-wave"
-            :style="{ '--wave-i': rowIdx + colIdx } as any"
-          />
+          <div v-else class="hex-cell hex-cell--empty" />
         </template>
       </div>
     </div>
@@ -169,44 +163,6 @@ const grid = computed(() => {
   text-align: center;
   padding: 0 8px;
   color: #111827;
-}
-
-/* Wave animation */
-.hex-wave {
-  animation: hex-wave 6s ease-in-out infinite;
-  animation-delay: calc(var(--wave-i) * 0.15s);
-  transition: transform 0.4s ease;
-}
-
-@keyframes hex-wave {
-  0%,
-  100% {
-    transform: translateY(0);
-  }
-  15% {
-    transform: translateY(-4px);
-  }
-  30% {
-    transform: translateY(0);
-  }
-}
-
-.hex-grid:hover .hex-wave {
-  animation: hex-wave-hard 3s ease-in-out infinite;
-  animation-delay: calc(var(--wave-i) * 0.1s);
-}
-
-@keyframes hex-wave-hard {
-  0%,
-  100% {
-    transform: translateY(0);
-  }
-  15% {
-    transform: translateY(-10px);
-  }
-  30% {
-    transform: translateY(0);
-  }
 }
 
 /* Responsive hex sizing */

--- a/packages/frontendmu-adonis/inertia/components/layout/Menu.vue
+++ b/packages/frontendmu-adonis/inertia/components/layout/Menu.vue
@@ -556,7 +556,7 @@ onUnmounted(() => {
   >
     <div
       ref="menuInner"
-      class="menu-inner w-[92%] max-w-7xl bg-white/80 dark:bg-verse-950/60 backdrop-blur-xl border border-gray-100 dark:border-verse-800 rounded-2xl squircle px-3 md:px-5 h-16 flex items-center justify-between shadow-sm"
+      class="menu-inner relative w-[92%] max-w-7xl bg-white/80 dark:bg-verse-950/60 backdrop-blur-xl border border-gray-100 dark:border-verse-800 rounded-2xl squircle px-3 md:px-5 h-16 flex items-center justify-between shadow-sm"
     >
       <!-- Brand -->
       <div class="flex items-center">
@@ -577,6 +577,14 @@ onUnmounted(() => {
           </span>
         </Link>
       </div>
+
+      <!-- Mobile centered site title -->
+      <Link
+        href="/"
+        class="sm:hidden absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 text-base font-black tracking-tighter dark:text-gray-100 uppercase tracking-[0.1em]"
+      >
+        coders<span class="text-verse-500">.mu</span>
+      </Link>
 
       <!-- Navigation -->
       <nav class="hidden md:block">

--- a/packages/frontendmu-adonis/inertia/pages/meetups/index.vue
+++ b/packages/frontendmu-adonis/inertia/pages/meetups/index.vue
@@ -100,7 +100,7 @@ function featuredForYear(year: number): Data.Event | undefined {
 
 <template>
   <Head title="All Meetups" />
-  <main class="relative min-h-screen pt-32 pb-24">
+  <main class="relative min-h-screen pt-32 pb-24 overflow-x-clip">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 relative z-10">
       <!-- Page Header -->
       <header class="mb-10 max-w-3xl space-y-4">
@@ -204,16 +204,17 @@ function featuredForYear(year: number): Data.Event | undefined {
       <div class="space-y-16">
         <template v-for="year in years" :key="year">
           <section class="year-section relative">
-            <!-- Giant vertical year label -->
+            <!-- Giant vertical year label — breaks out of the container to the left -->
             <div
               aria-hidden="true"
-              class="year-label absolute left-[-8px] top-[160px] font-display font-normal pointer-events-none select-none hidden md:block text-gray-200/90 dark:text-verse-900"
+              class="year-label absolute top-[40px] font-display font-normal pointer-events-none select-none hidden md:block text-gray-200/90 dark:text-verse-900"
               :style="{
                 fontSize: 'clamp(80px, 12vw, 180px)',
                 lineHeight: '0.8',
                 letterSpacing: '-0.04em',
                 writingMode: 'vertical-rl',
                 transform: 'rotate(180deg)',
+                right: 'calc(100% + 1.25rem)',
                 zIndex: 0,
               }"
             >
@@ -221,7 +222,7 @@ function featuredForYear(year: number): Data.Event | undefined {
             </div>
 
             <!-- Year header -->
-            <div class="relative z-10 flex items-baseline gap-5 mb-7 md:pl-20">
+            <div class="relative z-10 flex items-baseline gap-5 mb-7">
               <h2 class="font-display text-[32px] md:text-[38px] leading-none tracking-tight text-gray-900 dark:text-gray-100">
                 {{ year }}
               </h2>
@@ -232,7 +233,7 @@ function featuredForYear(year: number): Data.Event | undefined {
             </div>
 
             <!-- Events Grid -->
-            <div class="relative z-10 md:pl-20 grid grid-cols-1 md:grid-cols-2 gap-5">
+            <div class="relative z-10 grid grid-cols-1 md:grid-cols-2 gap-5">
               <template v-for="event in meetupsGroupedByYear[year]" :key="event.id">
                 <div
                   :class="event.id === featuredForYear(year)?.id ? 'md:col-span-2' : ''"

--- a/packages/frontendmu-adonis/inertia/pages/meetups/show.vue
+++ b/packages/frontendmu-adonis/inertia/pages/meetups/show.vue
@@ -360,12 +360,44 @@ const calendarUrl = computed(() => {
             </span>
           </div>
 
-          <!-- Title — editorial serif with italic tail -->
-          <h1
-            class="font-display text-[clamp(44px,6.5vw,84px)] leading-[0.98] text-gray-900 dark:text-gray-100 text-balance max-w-[16ch] mb-6"
-          >
-            <template v-if="titleParts.plain">{{ titleParts.plain }}&nbsp;</template><span class="font-display-italic text-verse-500 dark:text-verse-300">{{ titleParts.italic }}</span>
-          </h1>
+          <!-- Title + Sponsors row — editorial serif with italic tail; sponsors right-aligned -->
+          <div class="flex items-end justify-between gap-8 flex-wrap mb-6">
+            <h1
+              class="font-display text-[clamp(44px,6.5vw,84px)] leading-[0.98] text-gray-900 dark:text-gray-100 text-balance max-w-[16ch]"
+            >
+              <template v-if="titleParts.plain">{{ titleParts.plain }}&nbsp;</template><span class="font-display-italic text-verse-500 dark:text-verse-300">{{ titleParts.italic }}</span>
+            </h1>
+
+            <div v-if="meetup.sponsors?.length" class="flex flex-col items-start md:items-end gap-3 shrink-0">
+              <span class="font-mono text-[9.5px] uppercase tracking-[0.12em] text-gray-400 dark:text-gray-500">
+                Sponsored by
+              </span>
+              <div class="flex flex-wrap justify-start md:justify-end gap-2.5">
+                <Link
+                  v-for="sponsor in meetup.sponsors"
+                  :key="sponsor.id"
+                  :href="`/sponsor/${sponsor.id}`"
+                  class="flex items-center justify-center h-28 min-w-[180px] px-8 rounded-xl border border-gray-200 dark:border-verse-900 hover:border-verse-300 dark:hover:border-verse-700 transition-colors"
+                  :class="sponsor.logoBg ? '' : 'bg-white dark:bg-white'"
+                  :style="sponsor.logoBg ? { backgroundColor: sponsor.logoBg } : {}"
+                >
+                  <img
+                    v-if="sponsor.logoUrl"
+                    :src="sponsor.logoUrl"
+                    :alt="sponsor.name"
+                    class="max-h-16 w-auto object-contain"
+                  />
+                  <span
+                    v-else
+                    class="font-display text-[20px]"
+                    :class="sponsor.logoBg && sponsor.logoBg !== '#ffffff' ? 'text-gray-100' : 'text-gray-900'"
+                  >
+                    {{ sponsor.name }}
+                  </span>
+                </Link>
+              </div>
+            </div>
+          </div>
 
           <!-- Subtitle (first sentence of description, muted) -->
           <p
@@ -438,7 +470,7 @@ const calendarUrl = computed(() => {
         </section>
 
         <!-- ===== TWO-COLUMN GRID ===== -->
-        <div class="grid grid-cols-1 lg:grid-cols-[1fr_380px] gap-10 lg:gap-14 mt-12 items-start">
+        <div class="grid grid-cols-1 lg:grid-cols-[1fr_380px] gap-10 lg:gap-14 mt-12">
           <!-- Left Column: Content -->
           <div class="min-w-0">
             <!-- About -->
@@ -717,29 +749,6 @@ const calendarUrl = computed(() => {
               </div>
             </section>
 
-            <!-- Sponsors -->
-            <section v-if="meetup.sponsors?.length" class="py-12 border-b border-gray-200 dark:border-verse-900">
-              <span class="section-label">Sponsors</span>
-              <div
-                class="mt-6 flex flex-wrap gap-x-10 gap-y-4 items-center px-7 py-6 rounded-xl border border-dashed border-gray-300 dark:border-verse-800 bg-white dark:bg-verse-950"
-              >
-                <Link
-                  v-for="sponsor in meetup.sponsors"
-                  :key="sponsor.id"
-                  :href="`/sponsor/${sponsor.id}`"
-                  class="flex items-center gap-3 text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 transition-colors"
-                >
-                  <img
-                    v-if="sponsor.logoUrl"
-                    :src="sponsor.logoUrl"
-                    :alt="sponsor.name"
-                    class="h-9 w-auto object-contain"
-                  />
-                  <span v-else class="font-display text-[17px]">{{ sponsor.name }}</span>
-                </Link>
-              </div>
-            </section>
-
             <!-- Share bar -->
             <div
               class="flex items-center gap-3 flex-wrap py-6 border-b border-gray-200 dark:border-verse-900"
@@ -887,13 +896,13 @@ const calendarUrl = computed(() => {
                     <span class="font-mono text-[10.5px] uppercase tracking-[0.12em] text-gray-400 dark:text-gray-500">Venue</span>
                     <div class="text-[15px] font-semibold text-gray-900 dark:text-gray-100 mt-1.5 leading-snug">{{ meetup.venue }}</div>
                     <div v-if="meetup.location" class="text-[13.5px] text-gray-500 dark:text-gray-400 leading-snug">{{ meetup.location }}</div>
-                    <div v-if="meetup.mapUrl || meetup.parkingLocation" class="mt-3 flex flex-wrap gap-x-4 gap-y-1.5">
+                    <div v-if="meetup.mapUrl || meetup.parkingLocation" class="mt-3 flex flex-wrap gap-2">
                       <a
                         v-if="meetup.mapUrl"
                         :href="meetup.mapUrl"
                         target="_blank"
                         rel="noopener noreferrer"
-                        class="inline-flex items-center gap-1.5 font-mono text-[11.5px] font-semibold text-verse-600 dark:text-verse-400 hover:text-verse-700"
+                        class="inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-md border border-gray-200 dark:border-verse-800 font-mono text-[11.5px] font-semibold text-gray-600 dark:text-gray-300 hover:border-verse-400 hover:text-verse-600 dark:hover:text-verse-400 transition-colors"
                       >
                         <svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
                           <path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 1 1 16 0Z" />
@@ -901,9 +910,19 @@ const calendarUrl = computed(() => {
                         </svg>
                         Directions
                       </a>
-                      <span v-if="meetup.parkingLocation" class="inline-flex items-center gap-1.5 font-mono text-[11.5px] text-gray-400 dark:text-gray-500">
-                        Parking: {{ meetup.parkingLocation }}
-                      </span>
+                      <a
+                        v-if="meetup.parkingLocation"
+                        :href="meetup.parkingLocation"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-md border border-gray-200 dark:border-verse-800 font-mono text-[11.5px] font-semibold text-gray-600 dark:text-gray-300 hover:border-verse-400 hover:text-verse-600 dark:hover:text-verse-400 transition-colors"
+                      >
+                        <svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+                          <rect x="3" y="3" width="18" height="18" rx="3" />
+                          <path d="M9 17V7h4a3 3 0 0 1 0 6H9" />
+                        </svg>
+                        Parking
+                      </a>
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
## Summary

Polish pass across meetup listing, meetup detail, mobile header, and the homepage sponsor grid.

### Meetup listing
- Year label breaks out of the container on the left so cards align flush with the page's main column.
- Event cards fill the grid row's height (no more jagged rows when covers or copy vary in length).

### Meetup detail
- Restored sidebar stickiness — `items-start` on the grid was collapsing the aside and leaving sticky with no room to stick.
- Sponsors are now in the hero next to the title (right-aligned on md+, left-aligned and smaller "Sponsored by" label on mobile) instead of buried below the fold.
- Directions and Parking are a matched pair of bordered chips; Parking is now a real link to its URL (the admin field is a URL) instead of loose text.

### Mobile header
- Centered "coders.mu" title on narrow viewports so the site identity isn't just the logo mark.

### Homepage sponsors
- Dropped the wave animation on the honeycomb grid — distracting and uninvited motion. Grid is static now.

## Test plan
- [ ] Meetups listing: year label sits left of the container on xl+, clips gracefully on narrower viewports; cards in each row share height.
- [ ] Meetup detail: sidebar sticks while scrolling the long left column; sponsors appear in the hero and clear from the lower content area; Directions + Parking chips both open in a new tab.
- [ ] Mobile header (<640px): "coders.mu" appears centered between the logo mark and hamburger.
- [ ] Homepage sponsor grid: no animation, static hex tiles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mobile header now displays "coders.mu" site title.

* **Improvements**
  * Event cards stretch to full container height for consistent layouts.
  * Sponsors repositioned prominently in meetup hero sections.
  * Parking information now available as clickable external link.
  * Layout refinements on meetups pages.

* **Style**
  * Removed animations from sponsor hex cells.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->