### PR TITLE
Ensure every user has at least the member role

### DIFF
--- a/packages/frontendmu-adonis/app/controllers/admin/speakers_controller.ts
+++ b/packages/frontendmu-adonis/app/controllers/admin/speakers_controller.ts
@@ -3,6 +3,7 @@ import { randomUUID } from 'node:crypto'
 import { urlFor } from '@adonisjs/core/services/url_builder'
 import db from '@adonisjs/lucid/services/db'
 import User from '#models/user'
+import Role from '#models/role'
 import SpeakerPolicy from '#policies/speaker_policy'
 import { speakerValidator } from '#validators/speaker_validator'
 import SpeakerTransformer from '#transformers/speaker_transformer'
@@ -47,6 +48,11 @@ export default class AdminSpeakersController {
       role: 'member',
       password: null,
     })
+
+    const memberRole = await Role.findBy('name', 'member')
+    if (memberRole) {
+      await speaker.related('roles').attach([memberRole.id])
+    }
 
     session.flash('success', 'Speaker created successfully!')
     return response.redirect().toPath(urlFor('admin.users.edit', { id: speaker.id }))

--- a/packages/frontendmu-adonis/app/controllers/auth/google_controller.ts
+++ b/packages/frontendmu-adonis/app/controllers/auth/google_controller.ts
@@ -73,6 +73,15 @@ export default class GoogleController {
           existingUser.googleId = googleUser.id
           existingUser.avatarUrl = existingUser.avatarUrl || googleUser.avatarUrl
           await existingUser.save()
+
+          const existingRole = await existingUser.related('roles').query().first()
+          if (!existingRole) {
+            const memberRole = await Role.findBy('name', 'member')
+            if (memberRole) {
+              await existingUser.related('roles').attach([memberRole.id])
+            }
+          }
+
           user = existingUser
         } else {
           // Account has a password — user must log in with credentials first

--- a/packages/frontendmu-adonis/database/migrations/1777000000000_backfill_member_role.ts
+++ b/packages/frontendmu-adonis/database/migrations/1777000000000_backfill_member_role.ts
@@ -1,0 +1,31 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  async up() {
+    this.defer(async (db) => {
+      const memberRole = await db.from('roles').where('name', 'member').first()
+      if (!memberRole) return
+
+      const roleless = await db
+        .from('users')
+        .leftJoin('user_roles', 'users.id', 'user_roles.user_id')
+        .whereNull('user_roles.user_id')
+        .select('users.id')
+
+      if (roleless.length === 0) return
+
+      const now = new Date()
+      await db.table('user_roles').insert(
+        roleless.map((u) => ({
+          user_id: u.id,
+          role_id: memberRole.id,
+          created_at: now,
+        }))
+      )
+    })
+  }
+
+  async down() {
+    // No-op: backfilled assignments are indistinguishable from pre-existing ones.
+  }
+}


### PR DESCRIPTION
## Summary
- Backfill migration attaches `member` to every user with zero rows in `user_roles` (idempotent, guarded by `whereNull`).
- Admin-created speakers now get `member` in the `user_roles` pivot at creation time.
- Google auto-link branch (imported speaker signs in via Google) now attaches `member` if the linked user has no roles — guarded so it won't hit the `(user_id, role_id)` unique constraint.

## Why
On prod `/admin/users`, a number of users showed "No roles assigned" and couldn't sign in. Three paths produced role-less users: admin-created speakers, Google auto-linked accounts, and historical data imports. This fixes the first two and backfills the third.

## Test plan
- [ ] `node ace migration:run` on a copy of prod data — verify users with zero roles all get `member`, users with existing roles are untouched.
- [ ] Create a speaker via `/admin/speakers/create` — confirm a row appears in `user_roles`.
- [ ] Sign in with Google as an imported speaker with no password set — confirm `member` is attached.
- [ ] Sign in with Google as a user who already has `organizer`/`superadmin` — confirm no duplicate role attach / no unique constraint error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed missing role assignments for newly created speakers.
  * Fixed missing role assignments when linking Google accounts to existing user accounts.

* **Chores**
  * Added data migration to ensure all existing users have proper role assignments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->