### PR TITLE
Fix meetups a11y contrast and stabilize axe scans

### DIFF
--- a/packages/frontendmu-adonis/inertia/pages/meetups/index.vue
+++ b/packages/frontendmu-adonis/inertia/pages/meetups/index.vue
@@ -207,7 +207,7 @@ function featuredForYear(year: number): Data.Event | undefined {
             <!-- Giant vertical year label — breaks out of the container to the left -->
             <div
               aria-hidden="true"
-              class="year-label absolute top-[40px] font-display font-normal pointer-events-none select-none hidden md:block text-gray-200/90 dark:text-verse-900"
+              class="year-label absolute top-[40px] font-display font-normal pointer-events-none select-none hidden md:block text-gray-500 dark:text-verse-400"
               :style="{
                 fontSize: 'clamp(80px, 12vw, 180px)',
                 lineHeight: '0.8',

--- a/packages/frontendmu-adonis/tests/a11y/public-routes.spec.ts
+++ b/packages/frontendmu-adonis/tests/a11y/public-routes.spec.ts
@@ -29,6 +29,10 @@ type RouteScan = {
   }[]
 }
 
+async function waitForInertiaApp(page: Page) {
+  await page.locator('#app > *').first().waitFor({ state: 'attached' })
+}
+
 function getReportSlug(baseURL: string) {
   const { hostname } = new URL(baseURL)
   return hostname.replace(/[^a-z0-9.-]+/gi, '-')
@@ -63,6 +67,7 @@ async function discoverRoute(
 ) {
   await page.goto(seedRoute, { waitUntil: 'domcontentloaded' })
   await page.waitForLoadState('load')
+  await waitForInertiaApp(page)
   const links = page.locator(selector)
   if ((await links.count()) === 0) {
     return null
@@ -95,6 +100,7 @@ test('public routes do not have detectable axe violations', async ({ page }, tes
   for (const route of routes) {
     await page.goto(route, { waitUntil: 'domcontentloaded' })
     await page.waitForLoadState('load')
+    await waitForInertiaApp(page)
 
     const results: AxeResults = await new AxeBuilder({ page }).analyze()
     report.push({


### PR DESCRIPTION
## Summary
- increase the decorative year-label contrast on the meetups index so the page clears the shared axe color-contrast finding
- wait for the mounted Inertia app before discovering links or running axe so the accessibility spec audits real page content instead of the empty SSR shell

## Verification
- A11Y_BASE_URL=http://127.0.0.1:34123 pnpm --dir packages/frontendmu-adonis exec playwright test -c playwright.a11y.config.ts
- confirmed /meetups has 0 violations in packages/frontendmu-adonis/tests/a11y/test-results/a11y-report.127.0.0.1.json