### PR TITLE
Improve home page accessibility contrast

### DIFF
--- a/packages/frontendmu-adonis/inertia/components/home/FeaturedSpeakers.vue
+++ b/packages/frontendmu-adonis/inertia/components/home/FeaturedSpeakers.vue
@@ -55,7 +55,7 @@ defineProps<Props>()
       <div class="mt-16 flex justify-center">
         <Link
           href="/speakers"
-          class="group inline-flex items-center gap-3 text-sm font-semibold text-verse-500 dark:text-verse-400 hover:text-verse-600 dark:hover:text-verse-300 transition-colors"
+          class="group inline-flex items-center gap-3 text-sm font-semibold text-verse-500 dark:text-verse-300 hover:text-verse-600 dark:hover:text-verse-200 transition-colors"
         >
           See all speakers
           <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/packages/frontendmu-adonis/inertia/components/home/Hero.vue
+++ b/packages/frontendmu-adonis/inertia/components/home/Hero.vue
@@ -161,7 +161,7 @@ onUnmounted(() => {
                   <span class="text-[11px] leading-none">{{
                     formatDate(featuredEvent.date).day
                   }}</span>
-                  <span class="text-[6px] uppercase tracking-wider opacity-80">{{
+                  <span class="text-[7px] uppercase tracking-[0.16em] text-white/95">{{
                     formatDate(featuredEvent.date).month
                   }}</span>
                 </div>

--- a/packages/frontendmu-adonis/inertia/components/home/LatestMeetup.vue
+++ b/packages/frontendmu-adonis/inertia/components/home/LatestMeetup.vue
@@ -76,11 +76,11 @@ const remainingUpcomingData = computed(() =>
 
           <Link
             href="/meetups"
-            class="hidden md:inline-flex items-center gap-2 text-verse-500 dark:text-verse-400 font-medium hover:text-verse-600 dark:hover:text-verse-300 transition-colors"
+            class="hidden md:inline-flex items-center gap-2 text-verse-500 dark:text-verse-300 font-medium hover:text-verse-600 dark:hover:text-verse-200 transition-colors"
           >
             Explore all meetups
             <svg
-              class="w-5 h-5 text-verse-500 dark:text-verse-400"
+              class="w-5 h-5 text-verse-500 dark:text-verse-300"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
@@ -102,7 +102,7 @@ const remainingUpcomingData = computed(() =>
         <div class="flex md:hidden pt-4">
           <Link
             href="/meetups"
-            class="w-full text-center py-3 bg-verse-50 dark:bg-verse-900 text-verse-600 dark:text-verse-400 rounded-md font-medium"
+            class="w-full text-center py-3 bg-verse-50 dark:bg-verse-900 text-verse-600 dark:text-verse-200 rounded-md font-medium"
           >
             Explore all meetups
           </Link>

--- a/packages/frontendmu-adonis/inertia/components/home/SocialCard.vue
+++ b/packages/frontendmu-adonis/inertia/components/home/SocialCard.vue
@@ -27,7 +27,7 @@ defineProps<Props>()
       <h3 class="font-bold text-lg leading-tight">
         <slot name="tagline" />
       </h3>
-      <p class="text-xs text-white/80 line-clamp-2">
+      <p class="text-xs text-white line-clamp-2">
         <slot name="description" />
       </p>
     </div>

--- a/packages/frontendmu-adonis/inertia/components/home/Sponsors.vue
+++ b/packages/frontendmu-adonis/inertia/components/home/Sponsors.vue
@@ -42,10 +42,10 @@ const grid = computed(() => {
   <section v-if="sponsors.length > 0" class="relative py-16 overflow-x-clip">
     <div class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 mb-10">
       <div class="flex items-center justify-between">
-        <p class="text-xs font-semibold text-gray-400 dark:text-gray-500">Trusted by</p>
+        <p class="text-xs font-semibold text-gray-600 dark:text-gray-400">Trusted by</p>
         <Link
           href="/sponsors"
-          class="text-xs font-semibold text-gray-400 dark:text-gray-500 hover:text-verse-500 dark:hover:text-verse-400 transition-colors"
+          class="text-xs font-semibold text-gray-600 dark:text-gray-400 hover:text-verse-600 dark:hover:text-verse-300 transition-colors"
         >
           View all
         </Link>

--- a/packages/frontendmu-adonis/inertia/components/layout/Menu.vue
+++ b/packages/frontendmu-adonis/inertia/components/layout/Menu.vue
@@ -563,6 +563,7 @@ onUnmounted(() => {
         <Link
           href="/"
           class="flex items-center gap-2 group"
+          aria-label="Go to coders.mu home"
           @contextmenu.prevent="router.visit('/branding')"
         >
           <div

--- a/packages/frontendmu-adonis/inertia/css/app.css
+++ b/packages/frontendmu-adonis/inertia/css/app.css
@@ -191,3 +191,8 @@ dialog[open] {
   display: flex;
   flex-direction: column;
 }
+
+/* Improve contrast for the local Adonis debug bar launcher on dark surfaces. */
+#dbg-launcher > span {
+  color: #cbd5e1;
+}


### PR DESCRIPTION
## Summary
- increase contrast for home page CTA and supporting copy in both light and dark themes
- fix the mobile dark-mode "Explore all meetups" CTA flagged in manual axe testing
- add an accessible name to the logo-only home link and improve the local debugbar launcher contrast

## Verification
- mobile dark-mode axe scan on http://localhost:3333/ returned no violations after the fixes
- focused light and dark axe scans on http://127.0.0.1:34123/ returned no violations
- A11Y_BASE_URL=http://localhost:34123 pnpm exec playwright test -c playwright.a11y.config.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined dark mode text colors across featured speakers, latest meetups, and sponsors sections for improved visual hierarchy.
  * Updated event date badge typography with adjusted font size and letter spacing.
  * Enhanced description text visibility in social cards.
  * Improved debug bar launcher contrast on dark backgrounds.

* **Accessibility**
  * Added aria-label to home navigation link for better screen reader support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->