### PR TITLE
fix(a11y): improve sponsor and auth pages

### DIFF
--- a/packages/frontendmu-adonis/inertia/components/layout/Menu.vue
+++ b/packages/frontendmu-adonis/inertia/components/layout/Menu.vue
@@ -563,6 +563,7 @@ onUnmounted(() => {
         <Link
           href="/"
           class="flex items-center gap-2 group"
+          aria-label="Go to coders.mu home"
           @contextmenu.prevent="router.visit('/branding')"
         >
           <div

--- a/packages/frontendmu-adonis/inertia/pages/auth/login.vue
+++ b/packages/frontendmu-adonis/inertia/pages/auth/login.vue
@@ -69,7 +69,7 @@ const googleOauthEnabled = computed(() => page.props.auth.providers.google)
             <div class="w-full border-t border-gray-300 dark:border-verse-900"></div>
           </div>
           <div class="relative flex justify-center text-xs">
-            <span class="px-2 bg-white dark:bg-verse-950 text-gray-400">or</span>
+            <span class="px-2 bg-white dark:bg-verse-950 text-gray-500 dark:text-gray-300">or</span>
           </div>
         </div>
 

--- a/packages/frontendmu-adonis/inertia/pages/auth/register.vue
+++ b/packages/frontendmu-adonis/inertia/pages/auth/register.vue
@@ -114,7 +114,7 @@ const errors = computed(() => page.props.errors as Record<string, string> | unde
           Already registered?
           <Link
             href="/login"
-            class="text-verse-500 hover:text-verse-600 dark:text-verse-400 dark:hover:text-verse-300 ml-1 font-medium"
+            class="text-verse-500 hover:text-verse-600 dark:text-verse-300 dark:hover:text-verse-200 ml-1 font-medium"
           >
             Sign in
           </Link>

--- a/packages/frontendmu-adonis/inertia/pages/sponsor-us.vue
+++ b/packages/frontendmu-adonis/inertia/pages/sponsor-us.vue
@@ -25,7 +25,7 @@ import { Link } from '@inertiajs/vue3'
           <div class="lg:col-span-7 space-y-12">
             <section class="space-y-8">
               <div class="flex items-center gap-2">
-                <span class="text-sm font-semibold text-verse-500 dark:text-verse-400">The Value</span>
+                <h2 class="text-sm font-semibold text-verse-500 dark:text-verse-400">The Value</h2>
                 <div class="h-px flex-1 bg-gray-100 dark:bg-verse-900"></div>
               </div>
               
@@ -53,7 +53,7 @@ import { Link } from '@inertiajs/vue3'
           <div class="lg:col-span-5 space-y-8">
             <!-- Contact Card -->
             <div class="p-8 bg-gray-900 dark:bg-white text-white dark:text-gray-900 rounded-2xl shadow-2xl space-y-6">
-              <h3 class="text-2xl font-display tracking-tight leading-tight">Let's talk partnerships.</h3>
+              <h2 class="text-2xl font-display tracking-tight leading-tight">Let's talk partnerships.</h2>
               <p class="text-base font-medium opacity-70 leading-relaxed">
                 Every sponsorship is a custom partnership. We'll work with you to ensure your goals are met.
               </p>
@@ -65,18 +65,18 @@ import { Link } from '@inertiajs/vue3'
                   Send an Inquiry
                 </a>
               </div>
-              <p class="text-center text-[9px] font-bold opacity-50 uppercase tracking-widest italic">
+              <p class="text-center text-[9px] font-bold text-gray-400 dark:text-gray-600 uppercase tracking-widest italic">
                 Response time: 24-48 hours
               </p>
             </div>
 
             <!-- Sponsorship Tiers (Simplified) -->
             <div class="p-8 border border-gray-100 dark:border-verse-800 rounded-2xl space-y-6 bg-white/50 dark:bg-verse-950/20 backdrop-blur-xl">
-              <h4 class="text-sm font-semibold text-gray-400">Available Options</h4>
+              <h2 class="text-sm font-semibold text-gray-500 dark:text-gray-300">Available Options</h2>
               <ul class="space-y-4">
                 <li class="flex items-center justify-between font-bold text-sm">
                   <span class="text-gray-600 dark:text-gray-300">Venue Hosting</span>
-                  <span class="text-[10px] font-bold text-verse-500 bg-verse-500/10 px-2.5 py-0.5 rounded">Popular</span>
+                  <span class="text-[10px] font-bold text-verse-600 bg-verse-500/10 dark:bg-verse-400/10 dark:text-verse-200 px-2.5 py-0.5 rounded">Popular</span>
                 </li>
                 <li class="h-px w-full bg-gray-50 dark:bg-verse-800"></li>
                 <li class="flex items-center justify-between font-bold text-sm text-gray-600 dark:text-gray-300">

--- a/packages/frontendmu-adonis/inertia/pages/sponsors.vue
+++ b/packages/frontendmu-adonis/inertia/pages/sponsors.vue
@@ -44,6 +44,7 @@ const { isAdmin } = useAuth()
         v-if="sponsors.length"
         class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 mb-32"
       >
+        <h2 class="sr-only">Current partners</h2>
         <Link
           v-for="sponsor in sponsors"
           :key="sponsor.id"
@@ -59,7 +60,7 @@ const { isAdmin } = useAuth()
             <img
               v-if="sponsor.logoUrl"
               :src="sponsor.logoUrl"
-              :alt="sponsor.name"
+              alt=""
               class="max-w-[180px] max-h-[80px] object-contain transition-transform duration-200 group-hover:scale-105"
             />
             <span
@@ -85,7 +86,7 @@ const { isAdmin } = useAuth()
               <span
                 v-for="type in sponsor.sponsorTypes"
                 :key="type"
-                class="px-2 py-0.5 bg-verse-500/10 text-verse-600 dark:text-verse-400 border border-verse-500/20 rounded-full text-[10px] font-bold uppercase tracking-wider"
+                class="px-2 py-0.5 bg-verse-500/10 text-verse-600 dark:bg-verse-400/10 dark:text-verse-200 border border-verse-500/20 dark:border-verse-300/30 rounded-full text-[10px] font-bold uppercase tracking-wider"
               >
                 {{ type }}
               </span>


### PR DESCRIPTION
## Summary
- fix sponsor page heading and dark-mode contrast issues
- improve auth page contrast on login and register
- add an accessible name to the shared logo-only home link used on mobile

## Testing
- axe scan on `/sponsors` in desktop/mobile and light/dark
- axe scan on `/login` in desktop/mobile and light/dark
- axe scan on `/register` in desktop/mobile and light/dark
- axe scan on `/sponsor-us` in desktop/mobile and light/dark

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Added screen-reader labels to improve navigation and content structure.
  * Enhanced semantic heading hierarchy for better accessibility.

* **Style**
  * Refined dark mode color schemes across authentication and sponsor pages.
  * Updated separator and badge styling for improved visual consistency.
  * Adjusted text colors for better contrast in light and dark themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->