### PR TITLE
[codex] Fix admin session delete production error

### DIFF
--- a/packages/frontendmu-adonis/app/exceptions/handler.ts
+++ b/packages/frontendmu-adonis/app/exceptions/handler.ts
@@ -14,6 +14,10 @@ type InertiaRenderer = {
 function shouldRenderJson(ctx: HttpContext) {
   const accept = ctx.request.header('accept') || ''
 
+  if (ctx.request.header('x-inertia')) {
+    return false
+  }
+
   return (
     ctx.request.method() !== 'GET' ||
     accept.includes('application/json') ||

--- a/packages/frontendmu-adonis/app/exceptions/handler.ts
+++ b/packages/frontendmu-adonis/app/exceptions/handler.ts
@@ -22,7 +22,7 @@ function shouldRenderJson(ctx: HttpContext) {
 }
 
 function getErrorStatus(error: unknown, fallback: number) {
-  return (error as ErrorWithStatus)?.status || fallback
+  return (error as ErrorWithStatus)?.status ?? fallback
 }
 
 function getErrorMessage(error: unknown, fallback: string) {

--- a/packages/frontendmu-adonis/app/exceptions/handler.ts
+++ b/packages/frontendmu-adonis/app/exceptions/handler.ts
@@ -2,15 +2,65 @@ import app from '@adonisjs/core/services/app'
 import { type HttpContext, ExceptionHandler } from '@adonisjs/core/http'
 import type { StatusPageRange, StatusPageRenderer } from '@adonisjs/core/types/http'
 
+type ErrorWithStatus = {
+  message?: string
+  status?: number
+}
+
+type InertiaRenderer = {
+  render: (component: string, props: Record<string, unknown>) => unknown
+}
+
+function shouldRenderJson(ctx: HttpContext) {
+  const accept = ctx.request.header('accept') || ''
+
+  return (
+    ctx.request.method() !== 'GET' ||
+    accept.includes('application/json') ||
+    ctx.request.header('x-requested-with') === 'XMLHttpRequest'
+  )
+}
+
+function getErrorStatus(error: unknown, fallback: number) {
+  return (error as ErrorWithStatus)?.status || fallback
+}
+
+function getErrorMessage(error: unknown, fallback: string) {
+  return (error as ErrorWithStatus)?.message || fallback
+}
+
+function renderStatusPage(
+  component: string,
+  fallbackStatus: number,
+  fallbackMessage: string
+): StatusPageRenderer {
+  return (error, ctx) => {
+    const status = getErrorStatus(error, fallbackStatus)
+
+    if (shouldRenderJson(ctx)) {
+      return ctx.response.status(status).json({
+        message: getErrorMessage(error, fallbackMessage),
+      })
+    }
+
+    const inertia = (ctx as HttpContext & { inertia?: InertiaRenderer }).inertia
+    if (inertia) {
+      return inertia.render(component, { error })
+    }
+
+    return ctx.response.status(status).send(getErrorMessage(error, fallbackMessage))
+  }
+}
+
 export default class HttpExceptionHandler extends ExceptionHandler {
   protected debug = !app.inProduction
 
   protected renderStatusPages = app.inProduction
 
   protected statusPages: Record<StatusPageRange, StatusPageRenderer> = {
-    '403': (error, { inertia }) => inertia.render('errors/forbidden', { error }),
-    '404': (error, { inertia }) => inertia.render('errors/not_found', { error }),
-    '500..599': (error, { inertia }) => inertia.render('errors/server_error', { error }),
+    '403': renderStatusPage('errors/forbidden', 403, 'Forbidden'),
+    '404': renderStatusPage('errors/not_found', 404, 'Not found'),
+    '500..599': renderStatusPage('errors/server_error', 500, 'Internal server error'),
   }
 
   async handle(error: unknown, ctx: HttpContext) {

--- a/packages/frontendmu-adonis/inertia/composables/use_api.ts
+++ b/packages/frontendmu-adonis/inertia/composables/use_api.ts
@@ -7,22 +7,52 @@ function getCsrfToken(): string {
   )
 }
 
+function textToMessage(text: string, fallback: string) {
+  const message = text
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+
+  return message || fallback
+}
+
+async function readResponseData<T>(response: Response): Promise<T> {
+  if (response.status === 204) {
+    return undefined as T
+  }
+
+  const contentType = response.headers.get('content-type') || ''
+
+  if (contentType.includes('application/json')) {
+    return (await response.json()) as T
+  }
+
+  const text = await response.text()
+  return {
+    message: textToMessage(text, response.statusText),
+  } as T
+}
+
 export function useApi() {
   async function apiFetch<T = unknown>(
     url: string,
     options: RequestInit = {}
-  ): Promise<{ ok: boolean; data: T }> {
+  ): Promise<{ ok: boolean; data: T; response: Response }> {
+    const headers = new Headers(options.headers)
+    headers.set('Accept', 'application/json')
+    headers.set('X-XSRF-TOKEN', getCsrfToken())
+
+    if (options.body && !headers.has('Content-Type')) {
+      headers.set('Content-Type', 'application/json')
+    }
+
     const response = await fetch(url, {
       ...options,
-      headers: {
-        'Content-Type': 'application/json',
-        'X-XSRF-TOKEN': getCsrfToken(),
-        ...options.headers,
-      },
+      headers,
     })
 
-    const data = (await response.json()) as T
-    return { ok: response.ok, data }
+    const data = await readResponseData<T>(response)
+    return { ok: response.ok, data, response }
   }
 
   return { apiFetch }

--- a/packages/frontendmu-adonis/inertia/composables/use_api.ts
+++ b/packages/frontendmu-adonis/inertia/composables/use_api.ts
@@ -7,13 +7,21 @@ function getCsrfToken(): string {
   )
 }
 
-function textToMessage(text: string, fallback: string) {
-  const message = text
-    .replace(/<[^>]*>/g, ' ')
-    .replace(/\s+/g, ' ')
-    .trim()
+async function getFallbackMessage(response: Response, contentType: string) {
+  const fallback = response.statusText || `HTTP ${response.status}`
 
-  return message || fallback
+  if (contentType.includes('text/html')) {
+    return fallback
+  }
+
+  const body = await response.text()
+  const text = body.replace(/\s+/g, ' ').trim()
+
+  if (!text) {
+    return fallback
+  }
+
+  return text.length > 200 ? `${text.slice(0, 200)}...` : text
 }
 
 async function readResponseData<T>(response: Response): Promise<T> {
@@ -27,9 +35,8 @@ async function readResponseData<T>(response: Response): Promise<T> {
     return (await response.json()) as T
   }
 
-  const text = await response.text()
   return {
-    message: textToMessage(text, response.statusText),
+    message: await getFallbackMessage(response, contentType),
   } as T
 }
 

--- a/packages/frontendmu-adonis/inertia/pages/admin/events/edit.vue
+++ b/packages/frontendmu-adonis/inertia/pages/admin/events/edit.vue
@@ -1092,7 +1092,7 @@ async function removeSponsor(sponsorId: string) {
                   </button>
                   <button
                     type="button"
-                    @click.stop.prevent="deleteSession(session)"
+                    @click.stop="deleteSession(session)"
                     class="p-2 text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-200 hover:bg-red-100 dark:hover:bg-red-900/30 squircle rounded-lg transition-colors"
                     title="Delete session"
                   >

--- a/packages/frontendmu-adonis/inertia/pages/admin/events/edit.vue
+++ b/packages/frontendmu-adonis/inertia/pages/admin/events/edit.vue
@@ -300,16 +300,24 @@ async function saveSession() {
 }
 
 async function deleteSession(session: Data.Session) {
+  if (!session.id) {
+    console.error('Cannot delete a session without an id:', session)
+    return
+  }
+
   if (!confirm(`Are you sure you want to delete "${session.title}"?`)) {
     return
   }
 
   try {
-    const { ok } = await apiFetch(`/admin/sessions/${session.id}`, {
+    const { ok, data } = await apiFetch<{ message?: string }>(`/admin/sessions/${session.id}`, {
       method: 'DELETE',
     })
+
     if (ok) {
       sessions.value = sessions.value.filter((s) => s.id !== session.id)
+    } else {
+      console.error('Failed to delete session:', data.message || 'Unknown server error')
     }
   } catch (error) {
     console.error('Failed to delete session:', error)
@@ -964,8 +972,12 @@ async function removeSponsor(sponsorId: string) {
           </div>
 
           <!-- Quick-add presets -->
-          <div class="flex flex-wrap items-center gap-2 mb-4 pb-4 border-b border-verse-200 dark:border-verse-700">
-            <span class="text-xs font-medium text-verse-500 dark:text-verse-400 uppercase tracking-wide">
+          <div
+            class="flex flex-wrap items-center gap-2 mb-4 pb-4 border-b border-verse-200 dark:border-verse-700"
+          >
+            <span
+              class="text-xs font-medium text-verse-500 dark:text-verse-400 uppercase tracking-wide"
+            >
               Quick add
             </span>
             <button
@@ -978,7 +990,9 @@ async function removeSponsor(sponsorId: string) {
               ]"
               :key="preset.key"
               type="button"
-              @click="openNewSessionForm(preset.key as 'intro' | 'break' | 'photo' | 'quiz' | 'sponsored')"
+              @click="
+                openNewSessionForm(preset.key as 'intro' | 'break' | 'photo' | 'quiz' | 'sponsored')
+              "
               class="px-2.5 py-1 text-xs font-medium text-verse-700 dark:text-verse-300 bg-white dark:bg-verse-700 border border-verse-300 dark:border-verse-600 hover:border-verse-500 hover:text-verse-900 dark:hover:text-verse-100 squircle rounded-md transition-colors"
             >
               {{ preset.label }}
@@ -1078,7 +1092,7 @@ async function removeSponsor(sponsorId: string) {
                   </button>
                   <button
                     type="button"
-                    @click="deleteSession(session)"
+                    @click.stop.prevent="deleteSession(session)"
                     class="p-2 text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-200 hover:bg-red-100 dark:hover:bg-red-900/30 squircle rounded-lg transition-colors"
                     title="Delete session"
                   >


### PR DESCRIPTION
## Summary
- harden admin session deletion so delete clicks stop/prevent propagation and only call `DELETE /admin/sessions/:id`
- make `useApi` request JSON, preserve the `Response`, and avoid crashing when the server returns HTML
- make production status-page rendering return JSON for non-GET/fetch-style requests and fall back safely when Inertia is unavailable

## Root cause
The reported production request targeted `DELETE /admin/events/:id/edit`, which is not a valid session delete route. Production status-page rendering then attempted to call `inertia.render` even when Inertia was not initialized for that failing request, producing `Cannot read properties of undefined (reading 'render')`. The client then tried to parse the HTML error page as JSON.

Closes #355.

## Validation
- `pnpm exec eslint app/exceptions/handler.ts inertia/composables/use_api.ts --no-warn-ignored`
- `pnpm exec prettier --check app/exceptions/handler.ts inertia/composables/use_api.ts inertia/pages/admin/events/edit.vue`
- `NODE_ENV=development PORT=3333 HOST=localhost LOG_LEVEL=info APP_KEY=00000000000000000000000000000000 SESSION_DRIVER=cookie DB_DATABASE=database/db.local.sqlite3 pnpm exec node ace list:routes | rg "admin/(events|sessions)"`

## Known baseline blockers
- `pnpm exec tsc --noEmit --pretty false` still fails on existing Inertia page-name typing errors where controller `inertia.render(...)` calls resolve the component type to `never`.
- Full `pnpm --filter frontendmu-adonis lint` still fails on existing formatting/filename issues in a11y files unrelated to this PR.
