### PR TITLE
fix(adonis): return to origin page after login/register

### DIFF
--- a/packages/frontendmu-adonis/app/controllers/auth/google_controller.ts
+++ b/packages/frontendmu-adonis/app/controllers/auth/google_controller.ts
@@ -3,15 +3,25 @@ import { urlFor } from '@adonisjs/core/services/url_builder'
 import { googleOauthEnabled } from '#config/ally'
 import User from '#models/user'
 import Role from '#models/role'
+import { safeReturnUrl } from '../../lib/safe_return_url.js'
+
+const RETURN_TO_KEY = 'auth.returnTo'
 
 export default class GoogleController {
   /**
    * Redirect the user to Google for authentication
    */
-  async redirect({ ally, response, session }: HttpContext) {
+  async redirect({ ally, request, response, session }: HttpContext) {
     if (!googleOauthEnabled) {
       session.flash('error', 'Google sign-in is not available right now.')
       return response.redirect().toPath(urlFor('auth.login.show'))
+    }
+
+    const next = safeReturnUrl(request.input('next'))
+    if (next) {
+      session.put(RETURN_TO_KEY, next)
+    } else {
+      session.forget(RETURN_TO_KEY)
     }
 
     return ally.use('google').redirect()
@@ -117,6 +127,11 @@ export default class GoogleController {
     await auth.use('web').login(user)
 
     session.flash('success', `Welcome back, ${user.name}!`)
+
+    const returnTo = safeReturnUrl(session.pull(RETURN_TO_KEY))
+    if (returnTo) {
+      return response.redirect().toPath(returnTo)
+    }
     return response.redirect().toPath(urlFor('home'))
   }
 }

--- a/packages/frontendmu-adonis/app/controllers/auth/login_controller.ts
+++ b/packages/frontendmu-adonis/app/controllers/auth/login_controller.ts
@@ -2,6 +2,7 @@ import type { HttpContext } from '@adonisjs/core/http'
 import { urlFor } from '@adonisjs/core/services/url_builder'
 import User from '#models/user'
 import { loginValidator } from '#validators/login_validator'
+import { safeReturnUrl } from '../../lib/safe_return_url.js'
 
 export default class LoginController {
   async show({ inertia }: HttpContext) {
@@ -10,10 +11,14 @@ export default class LoginController {
 
   async store({ request, response, session, auth }: HttpContext) {
     const { email, password } = await request.validateUsing(loginValidator)
+    const next = safeReturnUrl(request.input('next'))
 
     try {
       const user = await User.verifyCredentials(email, password)
       await auth.use('web').login(user)
+      if (next) {
+        return response.redirect().toPath(next)
+      }
       return response.redirect().toPath(urlFor('home'))
     } catch {
       session.flash('inputErrorsBag', { login: 'Invalid credentials' })

--- a/packages/frontendmu-adonis/app/controllers/auth/register_controller.ts
+++ b/packages/frontendmu-adonis/app/controllers/auth/register_controller.ts
@@ -4,6 +4,7 @@ import User from '#models/user'
 import Role from '#models/role'
 import { registerValidator } from '#validators/register_validator'
 import logger from '@adonisjs/core/services/logger'
+import { safeReturnUrl } from '../../lib/safe_return_url.js'
 
 export default class RegisterController {
   async show({ inertia }: HttpContext) {
@@ -12,6 +13,7 @@ export default class RegisterController {
 
   async store({ request, response, session, auth }: HttpContext) {
     const data = await request.validateUsing(registerValidator)
+    const next = safeReturnUrl(request.input('next'))
 
     const existingUser = await User.findBy('email', data.email)
     if (existingUser) {
@@ -43,6 +45,9 @@ export default class RegisterController {
       return response.redirect().back()
     }
 
+    if (next) {
+      return response.redirect().toPath(next)
+    }
     return response.redirect().toPath(urlFor('home'))
   }
 }

--- a/packages/frontendmu-adonis/app/lib/safe_return_url.ts
+++ b/packages/frontendmu-adonis/app/lib/safe_return_url.ts
@@ -1,0 +1,14 @@
+/**
+ * Returns the value only if it's a safe same-origin pathname.
+ * Rejects non-strings, absolute URLs, protocol-relative URLs (`//…`),
+ * backslash bypasses, and control characters (guards against
+ * response-splitting if this is ever written to a header).
+ */
+export function safeReturnUrl(value: unknown): string | null {
+  if (typeof value !== 'string') return null
+  if (value.length === 0 || value.length > 2048) return null
+  if (/[\x00-\x1f\x7f]/.test(value)) return null
+  if (!value.startsWith('/')) return null
+  if (value.startsWith('//') || value.startsWith('/\\')) return null
+  return value
+}

--- a/packages/frontendmu-adonis/inertia/pages/auth/login.vue
+++ b/packages/frontendmu-adonis/inertia/pages/auth/login.vue
@@ -1,11 +1,24 @@
 <script setup lang="ts">
-import { Head, usePage } from '@inertiajs/vue3'
+import { Head, Link, usePage } from '@inertiajs/vue3'
 import type { Data } from '@generated/data'
 import { computed } from 'vue'
 
 const page = usePage<Data.SharedProps>()
 const errors = computed(() => page.props.errors as Record<string, string> | undefined)
 const googleOauthEnabled = computed(() => page.props.auth.providers.google)
+
+const nextParam = computed(() => {
+  const query = page.url.split('?')[1]
+  if (!query) return null
+  const value = new URLSearchParams(query).get('next')
+  return value && value.startsWith('/') && !value.startsWith('//') ? value : null
+})
+const googleHref = computed(() =>
+  nextParam.value ? `/auth/google?next=${encodeURIComponent(nextParam.value)}` : '/auth/google'
+)
+const registerHref = computed(() =>
+  nextParam.value ? `/register?next=${encodeURIComponent(nextParam.value)}` : '/register'
+)
 </script>
 
 <template>
@@ -33,7 +46,7 @@ const googleOauthEnabled = computed(() => page.props.auth.providers.google)
         <!-- Google Sign In -->
         <a
           v-if="googleOauthEnabled"
-          href="/auth/google"
+          :href="googleHref"
           class="w-full flex items-center justify-center gap-2.5 px-4 py-2.5 bg-white dark:bg-verse-900 border border-gray-300 dark:border-verse-800 rounded-md text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-verse-800 transition-colors"
         >
           <svg class="w-4 h-4" viewBox="0 0 24 24">
@@ -75,6 +88,7 @@ const googleOauthEnabled = computed(() => page.props.auth.providers.google)
 
         <form method="POST" action="/login" class="space-y-4">
           <input type="hidden" name="_csrf" :value="$page.props.auth.csrfToken" />
+          <input v-if="nextParam" type="hidden" name="next" :value="nextParam" />
 
           <div>
             <label
@@ -121,7 +135,7 @@ const googleOauthEnabled = computed(() => page.props.auth.providers.google)
         <p class="mt-6 text-center text-sm text-gray-500 dark:text-gray-400">
           Don't have an account?
           <Link
-            href="/register"
+            :href="registerHref"
             class="text-verse-500 hover:text-verse-600 dark:text-verse-400 dark:hover:text-verse-300 ml-1 font-medium"
           >
             Create account

--- a/packages/frontendmu-adonis/inertia/pages/auth/register.vue
+++ b/packages/frontendmu-adonis/inertia/pages/auth/register.vue
@@ -5,6 +5,16 @@ import { computed } from 'vue'
 
 const page = usePage<Data.SharedProps>()
 const errors = computed(() => page.props.errors as Record<string, string> | undefined)
+
+const nextParam = computed(() => {
+  const query = page.url.split('?')[1]
+  if (!query) return null
+  const value = new URLSearchParams(query).get('next')
+  return value && value.startsWith('/') && !value.startsWith('//') ? value : null
+})
+const loginHref = computed(() =>
+  nextParam.value ? `/login?next=${encodeURIComponent(nextParam.value)}` : '/login'
+)
 </script>
 
 <template>
@@ -31,6 +41,7 @@ const errors = computed(() => page.props.errors as Record<string, string> | unde
 
         <form method="POST" action="/register" class="space-y-4">
           <input type="hidden" name="_csrf" :value="$page.props.auth.csrfToken" />
+          <input v-if="nextParam" type="hidden" name="next" :value="nextParam" />
 
           <div>
             <label
@@ -113,7 +124,7 @@ const errors = computed(() => page.props.errors as Record<string, string> | unde
         <p class="mt-6 text-center text-sm text-gray-500 dark:text-gray-400">
           Already registered?
           <Link
-            href="/login"
+            :href="loginHref"
             class="text-verse-500 hover:text-verse-600 dark:text-verse-300 dark:hover:text-verse-200 ml-1 font-medium"
           >
             Sign in

--- a/packages/frontendmu-adonis/inertia/pages/meetups/show.vue
+++ b/packages/frontendmu-adonis/inertia/pages/meetups/show.vue
@@ -22,6 +22,7 @@ const page = usePage<Data.SharedProps>()
 const { apiFetch } = useApi()
 const isAuthenticated = computed(() => page.props.auth?.isAuthenticated)
 const featureFlags = computed(() => page.props.featureFlags)
+const loginHref = computed(() => `/login?next=${encodeURIComponent(page.url)}`)
 
 // RSVP state
 const isRsvpLoading = ref(false)
@@ -936,7 +937,7 @@ const calendarUrl = computed(() => {
                   <template v-if="isUpcoming || isToday || (featureFlags.rsvpPastEvents && isPast && meetup.acceptingRsvp)">
                     <template v-if="!isAuthenticated && canRsvp">
                       <Link
-                        href="/login"
+                        :href="loginHref"
                         class="flex-1 py-3 text-center text-sm font-semibold bg-verse-600 text-white rounded-lg hover:bg-verse-700 transition-colors"
                       >
                         Login to RSVP
@@ -1051,7 +1052,7 @@ const calendarUrl = computed(() => {
 
           <template v-if="!isAuthenticated">
             <Link
-              href="/login"
+              :href="loginHref"
               class="px-6 py-2.5 bg-verse-600 text-white font-medium rounded-md text-sm"
             >
               Login

--- a/packages/frontendmu-adonis/inertia/pages/profile.vue
+++ b/packages/frontendmu-adonis/inertia/pages/profile.vue
@@ -327,7 +327,7 @@ function getUserRoles() {
             Authentication required.
           </h2>
           <Link
-            href="/login"
+            href="/login?next=/profile"
             class="inline-flex items-center gap-3 px-8 py-3.5 bg-verse-600 text-white rounded-xl font-bold text-sm hover:bg-verse-700 transition-colors"
           >
             Sign In to View


### PR DESCRIPTION
## Summary
When a signed-out user clicked **Login to RSVP** on a meetup page, authenticated via Google, and came back, they always landed on the homepage instead of the meetup they started on. There was no return-URL mechanism in the auth flow — `GoogleController.callback`, `LoginController.store`, and `RegisterController.store` all hard-coded a redirect to `home`, and the RSVP CTA just linked to a bare `/login`.

This change threads a validated `next` pathname through the flow:

- **`app/lib/safe_return_url.ts`** — shared validator. Only accepts strings starting with a single `/`, rejects protocol-relative (`//…`), backslash bypasses (`/\\…`), and control characters (guards against response-splitting). Defense-in-depth: validated both on ingress and egress.
- **`GoogleController.redirect`** — reads `?next=`, stashes it in session as `auth.returnTo` (or forgets any stale value).
- **`GoogleController.callback`** — pulls from session, falls back to home.
- **`LoginController.store` / `RegisterController.store`** — read `next` from the POST body, redirect accordingly.
- **`login.vue` / `register.vue`** — preserve `next` across the Google button, the hidden form input, and the login↔register switch link.
- **`meetups/show.vue` / `profile.vue`** — CTAs now link to `/login?next=<current-path>`.

Also fixes a latent bug in `login.vue`: it used `<Link>` without importing it, so Vue rendered it as a native `<link>` element. Now imported from `@inertiajs/vue3`.

The top-nav "Login" menu item is intentionally left as a bare `/login` — it's a generic sign-in, not a contextual CTA.

## Test plan
- [x] `/meetup/2026-may` → **Login to RSVP** lands on `/login?next=%2Fmeetup%2F2026-may`
- [x] Login page hidden `next` input and **Create account** switch link both carry the value
- [x] `node ace build` succeeds; typecheck is clean (pre-existing errors only)
- [ ] With Google OAuth enabled in staging: Google callback redirects to the stashed meetup
- [ ] Email/password login with hidden `next` redirects to the original page
- [ ] Open-redirect guard: `/login?next=https://evil.com` and `/login?next=//evil.com` fall back to home