### PR TITLE
fix(adonis): respect sponsor logoBg on meetup agenda sponsored sessions

### DIFF
--- a/packages/frontendmu-adonis/app/transformers/session_transformer.ts
+++ b/packages/frontendmu-adonis/app/transformers/session_transformer.ts
@@ -30,6 +30,7 @@ export default class SessionTransformer extends BaseTransformer<Session> {
             name: sponsor.name,
             logoUrl: sponsor.logoUrl,
             logomarkUrl: sponsor.logomarkUrl,
+            logoBg: sponsor.logoBg,
           }
         : null,
     }

--- a/packages/frontendmu-adonis/inertia/pages/meetups/show.vue
+++ b/packages/frontendmu-adonis/inertia/pages/meetups/show.vue
@@ -508,7 +508,9 @@ const calendarUrl = computed(() => {
                     <!-- Sponsored: sponsor logo if present, else icon -->
                     <div
                       v-else-if="session.kind === 'sponsored' && session.sponsor && (session.sponsor.logoUrl || session.sponsor.logomarkUrl)"
-                      class="w-10 h-10 rounded-full bg-white dark:bg-verse-900 border border-gray-200 dark:border-verse-800 grid place-items-center overflow-hidden"
+                      class="w-10 h-10 rounded-full border border-gray-200 dark:border-verse-800 grid place-items-center overflow-hidden"
+                      :class="session.sponsor.logoBg ? '' : 'bg-white dark:bg-verse-900'"
+                      :style="session.sponsor.logoBg ? { backgroundColor: session.sponsor.logoBg } : {}"
                     >
                       <img
                         :src="(session.sponsor.logomarkUrl || session.sponsor.logoUrl) as string"


### PR DESCRIPTION
## Summary
- Agenda medallions for sponsored sessions on the meetup detail page ignored the sponsor's configured `logoBg`, always rendering on a white/verse-900 tile.
- `SessionTransformer` now includes `logoBg` on the serialized `session.sponsor`, and the agenda medallion applies it as `backgroundColor` when set (matching the hero sponsor tiles).

## Test plan
- [ ] Open a meetup detail page with a sponsored session whose sponsor has a custom `logoBg` — medallion background reflects that color in both light and dark mode.
- [ ] Sponsored session whose sponsor has no `logoBg` still falls back to white/verse-900.
- [ ] Non-sponsored agenda sessions (talk/intro/quiz/break/photo/other) are unaffected.