### PR TITLE
chore(adonis): gate email registration behind ENABLE_REGISTRATION flag

### DIFF
--- a/packages/frontendmu-adonis/.env.example
+++ b/packages/frontendmu-adonis/.env.example
@@ -16,5 +16,6 @@ DB_DATABASE=database/db.local.sqlite3
 
 # Feature Flags
 FEATURE_RSVP_PAST_EVENTS=false  # Allow users to RSVP to past events
+ENABLE_REGISTRATION=false  # Allow email+password sign-up. Off in production (spam control); Google OAuth is the only public signup path.
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=

--- a/packages/frontendmu-adonis/app/controllers/auth/register_controller.ts
+++ b/packages/frontendmu-adonis/app/controllers/auth/register_controller.ts
@@ -3,15 +3,31 @@ import { urlFor } from '@adonisjs/core/services/url_builder'
 import User from '#models/user'
 import Role from '#models/role'
 import { registerValidator } from '#validators/register_validator'
+import featureFlags from '#config/feature_flags'
 import logger from '@adonisjs/core/services/logger'
 import { safeReturnUrl } from '../../lib/safe_return_url.js'
 
+const REGISTRATION_DISABLED_MESSAGE =
+  'Public sign-up is closed. Please continue with Google to join.'
+
 export default class RegisterController {
-  async show({ inertia }: HttpContext) {
+  async show({ inertia, response, session, request }: HttpContext) {
+    if (!featureFlags.registrationEnabled) {
+      session.flash('error', REGISTRATION_DISABLED_MESSAGE)
+      const next = safeReturnUrl(request.input('next'))
+      const target = next ? `/login?next=${encodeURIComponent(next)}` : '/login'
+      return response.redirect().toPath(target)
+    }
     return inertia.render('auth/register', {})
   }
 
   async store({ request, response, session, auth }: HttpContext) {
+    if (!featureFlags.registrationEnabled) {
+      session.flash('error', REGISTRATION_DISABLED_MESSAGE)
+      const next = safeReturnUrl(request.input('next'))
+      const target = next ? `/login?next=${encodeURIComponent(next)}` : '/login'
+      return response.redirect().toPath(target)
+    }
     const data = await request.validateUsing(registerValidator)
     const next = safeReturnUrl(request.input('next'))
 

--- a/packages/frontendmu-adonis/app/middleware/inertia_middleware.ts
+++ b/packages/frontendmu-adonis/app/middleware/inertia_middleware.ts
@@ -45,6 +45,7 @@ export default class InertiaMiddleware extends BaseInertiaMiddleware {
         providers: {
           google: googleOauthEnabled,
         },
+        registrationEnabled: featureFlags.registrationEnabled,
         csrfToken: ctx.request.csrfToken ?? '',
       }),
       featureFlags,

--- a/packages/frontendmu-adonis/config/feature_flags.ts
+++ b/packages/frontendmu-adonis/config/feature_flags.ts
@@ -12,6 +12,13 @@ const featureFlags = {
    * Useful for testing or special circumstances.
    */
   rsvpPastEvents: env.get('FEATURE_RSVP_PAST_EVENTS', false),
+  /**
+   * Allow new users to register with email + password.
+   * Disabled in production to prevent spam signups; Google OAuth
+   * is the only public sign-up path. Email/password login still
+   * works for existing accounts (super admins, local dev).
+   */
+  registrationEnabled: env.get('ENABLE_REGISTRATION', false),
 }
 
 export default featureFlags

--- a/packages/frontendmu-adonis/inertia/components/layout/Menu.vue
+++ b/packages/frontendmu-adonis/inertia/components/layout/Menu.vue
@@ -29,6 +29,7 @@ interface InertSiblingState {
 const page = usePage<Data.SharedProps>()
 const isAuthenticated = computed(() => page.props.auth.isAuthenticated)
 const user = computed(() => page.props.auth.user)
+const registrationEnabled = computed(() => page.props.auth.registrationEnabled)
 const currentPath = computed(() => page.url)
 const isMobileMenuOpen = ref(false)
 const expandedSections = ref<string[]>([])
@@ -98,10 +99,11 @@ const authLinks = computed(() => {
   if (isAuthenticated.value && user.value) {
     return [{ title: 'Profile', href: '/profile' }]
   }
-  return [
-    { title: 'Login', href: '/login' },
-    { title: 'Register', href: '/register' },
-  ]
+  const links = [{ title: 'Login', href: '/login' }]
+  if (registrationEnabled.value) {
+    links.push({ title: 'Register', href: '/register' })
+  }
+  return links
 })
 
 const mobileActionLinks = computed(() => {

--- a/packages/frontendmu-adonis/inertia/pages/about.vue
+++ b/packages/frontendmu-adonis/inertia/pages/about.vue
@@ -1,6 +1,16 @@
 <script setup lang="ts">
-import { Head } from '@inertiajs/vue3'
-import { Link } from '@inertiajs/vue3'
+import { Head, Link, usePage } from '@inertiajs/vue3'
+import type { Data } from '@generated/data'
+import { computed } from 'vue'
+
+const page = usePage<Data.SharedProps>()
+const registrationEnabled = computed(() => page.props.auth.registrationEnabled)
+const googleOauthEnabled = computed(() => page.props.auth.providers.google)
+const joinHref = computed(() => {
+  if (registrationEnabled.value) return '/register'
+  if (googleOauthEnabled.value) return '/auth/google'
+  return '/login'
+})
 </script>
 
 <template>
@@ -56,7 +66,7 @@ import { Link } from '@inertiajs/vue3'
                 Whether you're writing your first line of CSS or architecting cloud systems, there's a seat for you.
               </p>
               <div class="flex flex-col gap-3">
-                <Link href="/register" class="block w-full py-3.5 bg-verse-500 text-white text-center font-bold text-sm rounded-lg hover:bg-verse-600 transition-colors">
+                <Link :href="joinHref" class="block w-full py-3.5 bg-verse-500 text-white text-center font-bold text-sm rounded-lg hover:bg-verse-600 transition-colors">
                   Join the Community
                 </Link>
                 <a href="https://discord.gg/WxXW9Jvv6k" target="_blank" rel="noopener noreferrer" class="block w-full py-3.5 border border-white/20 dark:border-gray-200 text-center font-bold text-sm rounded-lg hover:bg-white/10 dark:hover:bg-gray-100 transition-colors">

--- a/packages/frontendmu-adonis/inertia/pages/auth/login.vue
+++ b/packages/frontendmu-adonis/inertia/pages/auth/login.vue
@@ -6,6 +6,7 @@ import { computed } from 'vue'
 const page = usePage<Data.SharedProps>()
 const errors = computed(() => page.props.errors as Record<string, string> | undefined)
 const googleOauthEnabled = computed(() => page.props.auth.providers.google)
+const registrationEnabled = computed(() => page.props.auth.registrationEnabled)
 
 const nextParam = computed(() => {
   const query = page.url.split('?')[1]
@@ -132,7 +133,10 @@ const registerHref = computed(() =>
           </button>
         </form>
 
-        <p class="mt-6 text-center text-sm text-gray-500 dark:text-gray-400">
+        <p
+          v-if="registrationEnabled"
+          class="mt-6 text-center text-sm text-gray-500 dark:text-gray-400"
+        >
           Don't have an account?
           <Link
             :href="registerHref"

--- a/packages/frontendmu-adonis/start/env.ts
+++ b/packages/frontendmu-adonis/start/env.ts
@@ -34,6 +34,7 @@ export default await Env.create(new URL('../', import.meta.url), {
   |----------------------------------------------------------
   */
   FEATURE_RSVP_PAST_EVENTS: Env.schema.boolean.optional(),
+  ENABLE_REGISTRATION: Env.schema.boolean.optional(),
 
   /*
   |----------------------------------------------------------

--- a/packages/frontendmu-adonis/tests/a11y/public-routes.spec.ts
+++ b/packages/frontendmu-adonis/tests/a11y/public-routes.spec.ts
@@ -53,7 +53,6 @@ const staticRoutes = [
   '/coding-guidelines',
   '/api-docs',
   '/login',
-  '/register',
 ]
 
 const enforcedRoutes = [


### PR DESCRIPTION
## Summary
- Closes public email/password sign-up by default (`ENABLE_REGISTRATION` defaults to `false`) to curb spam account creation; Google OAuth remains the only public sign-up path.
- `GET`/`POST /register` redirect to `/login` with a flash message when registration is disabled. The "Register" / "Create account" / "Join the Community" CTAs are hidden in the header, login page, and About page.
- Email/password **login** is untouched — super admins and local dev still sign in with credentials.

## Rollout
- Production: leave `ENABLE_REGISTRATION` unset (defaults to `false`).
- Local dev: set `ENABLE_REGISTRATION=true` in `.env` to keep the current sign-up flow.

## Files
- `start/env.ts`, `config/feature_flags.ts`, `.env.example` — new flag.
- `app/controllers/auth/register_controller.ts` — gate `show`/`store`, redirect to `/login` with flash.
- `app/middleware/inertia_middleware.ts` — surface `auth.registrationEnabled` to Inertia.
- `inertia/pages/auth/login.vue`, `inertia/components/layout/Menu.vue`, `inertia/pages/about.vue` — hide registration CTAs when flag is off.
- `tests/a11y/public-routes.spec.ts` — drop `/register` from the static route list (it now redirects).

## Test plan
- [ ] With `ENABLE_REGISTRATION=false`: visiting `/register` redirects to `/login` and shows the flash error.
- [ ] With `ENABLE_REGISTRATION=false`: `POST /register` (curl/Postman) redirects without creating a user.
- [ ] With `ENABLE_REGISTRATION=false`: header, About CTA, and login page do not link to `/register`; About CTA points to `/auth/google` when Google is configured.
- [ ] With `ENABLE_REGISTRATION=true` locally: full sign-up flow still works end-to-end.
- [ ] Existing password user can still sign in via `POST /login`.
- [ ] Google OAuth login flow is unaffected.
- [ ] `pnpm test:a11y` passes.