### PR TITLE
feat(adonis): admin attendees + RSVP timeline + phone gate + public Who's coming

### DIFF
--- a/packages/frontendmu-adonis/app/controllers/admin/event_attendees_controller.ts
+++ b/packages/frontendmu-adonis/app/controllers/admin/event_attendees_controller.ts
@@ -1,0 +1,53 @@
+import type { HttpContext } from '@adonisjs/core/http'
+import { DateTime } from 'luxon'
+import Event from '#models/event'
+import Rsvp from '#models/rsvp'
+import EventPolicy from '#policies/event_policy'
+import EventTransformer from '#transformers/event_transformer'
+import AdminAttendeeTransformer from '#transformers/admin_attendee_transformer'
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+export default class AdminEventAttendeesController {
+  async show({ inertia, params, bouncer }: HttpContext) {
+    await bouncer.with(EventPolicy).authorize('viewAny')
+
+    const lookupColumn = UUID_REGEX.test(params.idOrSlug) ? 'id' : 'slug'
+    const event = await Event.query().where(lookupColumn, params.idOrSlug).firstOrFail()
+
+    const rsvps = await Rsvp.query()
+      .where('eventId', event.id)
+      .preload('user')
+      .orderBy('createdAt', 'desc')
+
+    const counts = {
+      total: rsvps.length,
+      confirmed: rsvps.filter((r) => r.status === 'confirmed').length,
+      waitlist: rsvps.filter((r) => r.status === 'waitlist').length,
+      cancelled: rsvps.filter((r) => r.status === 'cancelled').length,
+    }
+
+    const sortedByCreated = [...rsvps].sort((a, b) => {
+      const ta = a.createdAt?.toMillis() ?? 0
+      const tb = b.createdAt?.toMillis() ?? 0
+      return ta - tb
+    })
+    const firstRsvpAt = sortedByCreated[0]?.createdAt ?? null
+    const rsvpOpenAt = firstRsvpAt
+      ? firstRsvpAt.minus({ days: 2 }).toISO()
+      : DateTime.now().toISO()
+
+    const timeline = {
+      rsvpOpenAt,
+      rsvpCloseAt: event.rsvpClosingDate?.toISO() ?? null,
+      eventAt: event.eventDate?.toISO() ?? null,
+    }
+
+    return inertia.render('admin/events/attendees', {
+      event: EventTransformer.transform(event).useVariant('detail'),
+      attendees: AdminAttendeeTransformer.transform(rsvps),
+      counts,
+      timeline,
+    })
+  }
+}

--- a/packages/frontendmu-adonis/app/controllers/admin/event_attendees_controller.ts
+++ b/packages/frontendmu-adonis/app/controllers/admin/event_attendees_controller.ts
@@ -27,14 +27,15 @@ export default class AdminEventAttendeesController {
       cancelled: rsvps.filter((r) => r.status === 'cancelled').length,
     }
 
-    const sortedByCreated = [...rsvps].sort((a, b) => {
-      const ta = a.createdAt?.toMillis() ?? 0
-      const tb = b.createdAt?.toMillis() ?? 0
-      return ta - tb
-    })
-    const firstRsvpAt = sortedByCreated[0]?.createdAt ?? null
-    const rsvpOpenAt = firstRsvpAt
-      ? firstRsvpAt.minus({ days: 2 }).toISO()
+    const firstConfirmedRsvpAt = rsvps
+      .filter((r) => r.status === 'confirmed')
+      .reduce<DateTime | null>((earliest, r) => {
+        if (!r.createdAt) return earliest
+        if (!earliest || r.createdAt < earliest) return r.createdAt
+        return earliest
+      }, null)
+    const rsvpOpenAt = firstConfirmedRsvpAt
+      ? firstConfirmedRsvpAt.minus({ days: 2 }).toISO()
       : DateTime.now().toISO()
 
     const timeline = {

--- a/packages/frontendmu-adonis/app/controllers/events_controller.ts
+++ b/packages/frontendmu-adonis/app/controllers/events_controller.ts
@@ -1,4 +1,5 @@
 import type { HttpContext } from '@adonisjs/core/http'
+import { DateTime } from 'luxon'
 import Event from '#models/event'
 import Rsvp from '#models/rsvp'
 import type User from '#models/user'
@@ -57,20 +58,35 @@ export default class EventsController {
       avatarUrl: string | null
       githubUsername: string | null
     }> = []
-    let rsvpCount = 0
 
     await auth.check()
     const user = auth.user as User | undefined
 
+    const confirmedRsvps = await Rsvp.query()
+      .where('eventId', event.id)
+      .where('status', 'confirmed')
+      .preload('user')
+      .orderBy('createdAt', 'asc')
+
+    const rsvpCount = confirmedRsvps.length
+
+    // Round to UTC day so public viewers can see trend without exact-time correlation.
+    const rsvpedAtList = confirmedRsvps
+      .map((r) => r.createdAt?.toUTC().startOf('day').toISO() ?? null)
+      .filter((iso): iso is string => Boolean(iso))
+
+    const firstRsvpAt = confirmedRsvps[0]?.createdAt ?? null
+    const rsvpOpenAt = firstRsvpAt
+      ? firstRsvpAt.minus({ days: 2 }).toISO()
+      : DateTime.now().toISO()
+
+    const timeline = {
+      rsvpOpenAt,
+      rsvpCloseAt: event.rsvpClosingDate?.toISO() ?? null,
+      eventAt: event.eventDate?.toISO() ?? null,
+    }
+
     if (user) {
-      const rsvps = await Rsvp.query()
-        .where('eventId', event.id)
-        .where('status', 'confirmed')
-        .preload('user')
-        .orderBy('createdAt', 'asc')
-
-      rsvpCount = rsvps.length
-
       userRsvp = await Rsvp.query()
         .where('userId', user.id)
         .where('eventId', event.id)
@@ -80,7 +96,7 @@ export default class EventsController {
       canEdit = await bouncer.with(EventPolicy).allows('edit', event)
 
       attendees = await Promise.all(
-        rsvps.map(async (rsvp) => {
+        confirmedRsvps.map(async (rsvp) => {
           rsvp.user.$extras.displayName = this.truncateName(rsvp.user.name)
           return (await serialize(PublicAttendeeTransformer.transform(rsvp.user))) as {
             id: string
@@ -91,11 +107,12 @@ export default class EventsController {
         })
       )
     } else {
-      const countResult = await Event.query()
-        .where('id', event.id)
-        .withCount('rsvps', (q) => q.where('status', 'confirmed'))
-        .firstOrFail()
-      rsvpCount = Number(countResult.$extras.rsvps_count) || 0
+      attendees = confirmedRsvps.map((rsvp) => ({
+        id: rsvp.id,
+        name: this.truncateName(rsvp.user.name),
+        avatarUrl: null,
+        githubUsername: null,
+      }))
     }
 
     return inertia.render('meetups/show', {
@@ -104,6 +121,8 @@ export default class EventsController {
       rsvpCount,
       canEdit,
       attendees,
+      rsvpedAtList,
+      timeline,
     })
   }
 

--- a/packages/frontendmu-adonis/app/controllers/events_controller.ts
+++ b/packages/frontendmu-adonis/app/controllers/events_controller.ts
@@ -107,8 +107,8 @@ export default class EventsController {
         })
       )
     } else {
-      attendees = confirmedRsvps.map((rsvp) => ({
-        id: rsvp.id,
+      attendees = confirmedRsvps.map((rsvp, index) => ({
+        id: `anon-${index}`,
         name: this.truncateName(rsvp.user.name),
         avatarUrl: null,
         githubUsername: null,

--- a/packages/frontendmu-adonis/app/controllers/profile_controller.ts
+++ b/packages/frontendmu-adonis/app/controllers/profile_controller.ts
@@ -41,6 +41,7 @@ export default class ProfileController {
       linkedinUrl: data.linkedinUrl || null,
       twitterUrl: data.twitterUrl || null,
       websiteUrl: data.websiteUrl || null,
+      phone: data.phone || null,
     })
     await user.save()
 

--- a/packages/frontendmu-adonis/app/controllers/profile_controller.ts
+++ b/packages/frontendmu-adonis/app/controllers/profile_controller.ts
@@ -25,7 +25,7 @@ export default class ProfileController {
       }))
 
     return inertia.render('profile', {
-      user: UserTransformer.transform(user),
+      user: UserTransformer.transform(user).useVariant('forProfile'),
       rsvpMeetups,
     })
   }

--- a/packages/frontendmu-adonis/app/controllers/rsvps_controller.ts
+++ b/packages/frontendmu-adonis/app/controllers/rsvps_controller.ts
@@ -3,6 +3,7 @@ import Event from '#models/event'
 import Rsvp from '#models/rsvp'
 import { rsvpToEvent, cancelRsvp } from '#abilities/main'
 import RsvpTransformer from '#transformers/rsvp_transformer'
+import { createRsvpValidator } from '#validators/rsvp_validator'
 import db from '@adonisjs/lucid/services/db'
 
 export default class RsvpsController {
@@ -10,7 +11,7 @@ export default class RsvpsController {
    * Create a new RSVP for the authenticated user
    */
   async store(ctx: HttpContext) {
-    const { auth, bouncer, params, response, serializeWithoutWrapping: serialize } = ctx
+    const { auth, bouncer, params, request, response, serializeWithoutWrapping: serialize } = ctx
     const user = auth.getUserOrFail()
     const event = await Event.findOrFail(params.eventId)
 
@@ -19,6 +20,22 @@ export default class RsvpsController {
       return response.forbidden({
         message: 'This event is not accepting RSVPs at this time.',
       })
+    }
+
+    const data = await request.validateUsing(createRsvpValidator)
+    const userHasPhone = Boolean(user.phone && user.phone.trim().length > 0)
+
+    if (!userHasPhone && !data.phone) {
+      return response.unprocessableEntity({
+        code: 'PHONE_REQUIRED',
+        message: 'Please add a phone number before RSVPing so we know you’re a real human.',
+        errors: { phone: 'A phone number is required to RSVP.' },
+      })
+    }
+
+    if (data.phone && !userHasPhone) {
+      user.phone = data.phone
+      await user.save()
     }
 
     // Check if user already has an RSVP for this event

--- a/packages/frontendmu-adonis/app/middleware/inertia_middleware.ts
+++ b/packages/frontendmu-adonis/app/middleware/inertia_middleware.ts
@@ -24,6 +24,7 @@ async function getSharedAuthUser(ctx: HttpContext) {
     email: user.email,
     avatarUrl: user.avatarUrl,
     githubUsername: user.githubUsername,
+    hasPhone: Boolean(user.phone && user.phone.trim().length > 0),
     roles: roles.map((role) => ({ id: role.id, name: role.name })),
     role: user.role,
   }

--- a/packages/frontendmu-adonis/app/models/event.ts
+++ b/packages/frontendmu-adonis/app/models/event.ts
@@ -67,7 +67,7 @@ export default class Event extends BaseModel {
   @column()
   declare seatsAvailable: number | null
 
-  @column()
+  @column({ consume: (v: unknown): boolean => Boolean(v) })
   declare acceptingRsvp: boolean
 
   @column.dateTime()

--- a/packages/frontendmu-adonis/app/models/user.ts
+++ b/packages/frontendmu-adonis/app/models/user.ts
@@ -69,13 +69,13 @@ export default class User extends compose(BaseModel, AuthFinder) {
   @column()
   declare websiteUrl: string | null
 
-  @column()
+  @column({ consume: (v: unknown): boolean => Boolean(v) })
   declare featured: boolean
 
-  @column()
+  @column({ consume: (v: unknown): boolean => Boolean(v) })
   declare isOrganizer: boolean
 
-  @column()
+  @column({ consume: (v: unknown): boolean => Boolean(v) })
   declare isCommunityMember: boolean
 
   @column()

--- a/packages/frontendmu-adonis/app/models/user.ts
+++ b/packages/frontendmu-adonis/app/models/user.ts
@@ -69,6 +69,9 @@ export default class User extends compose(BaseModel, AuthFinder) {
   @column()
   declare websiteUrl: string | null
 
+  @column()
+  declare phone: string | null
+
   @column({ consume: (v: unknown): boolean => Boolean(v) })
   declare featured: boolean
 

--- a/packages/frontendmu-adonis/app/transformers/admin_attendee_transformer.ts
+++ b/packages/frontendmu-adonis/app/transformers/admin_attendee_transformer.ts
@@ -1,0 +1,25 @@
+import { BaseTransformer } from '@adonisjs/core/transformers'
+import type Rsvp from '#models/rsvp'
+import { resolveAvatarUrl } from '../lib/avatar_url.js'
+
+export default class AdminAttendeeTransformer extends BaseTransformer<Rsvp> {
+  toObject() {
+    const user = this.resource.user
+
+    return {
+      rsvpId: this.resource.id,
+      status: this.resource.status,
+      notes: this.resource.notes,
+      rsvpedAt: this.resource.createdAt?.toISO() ?? null,
+      user: user
+        ? {
+            id: user.id,
+            name: user.name,
+            email: user.email,
+            githubUsername: user.githubUsername,
+            avatarUrl: resolveAvatarUrl(user),
+          }
+        : null,
+    }
+  }
+}

--- a/packages/frontendmu-adonis/app/transformers/user_transformer.ts
+++ b/packages/frontendmu-adonis/app/transformers/user_transformer.ts
@@ -14,8 +14,14 @@ export default class UserTransformer extends BaseTransformer<User> {
       linkedinUrl: this.resource.linkedinUrl,
       twitterUrl: this.resource.twitterUrl,
       websiteUrl: this.resource.websiteUrl,
-      phone: this.resource.phone,
       roles: this.resource.roles?.map((role) => ({ id: role.id, name: role.name })) ?? [],
+    }
+  }
+
+  forProfile() {
+    return {
+      ...this.toObject(),
+      phone: this.resource.phone,
     }
   }
 

--- a/packages/frontendmu-adonis/app/transformers/user_transformer.ts
+++ b/packages/frontendmu-adonis/app/transformers/user_transformer.ts
@@ -14,6 +14,7 @@ export default class UserTransformer extends BaseTransformer<User> {
       linkedinUrl: this.resource.linkedinUrl,
       twitterUrl: this.resource.twitterUrl,
       websiteUrl: this.resource.websiteUrl,
+      phone: this.resource.phone,
       roles: this.resource.roles?.map((role) => ({ id: role.id, name: role.name })) ?? [],
     }
   }

--- a/packages/frontendmu-adonis/app/validators/profile_validator.ts
+++ b/packages/frontendmu-adonis/app/validators/profile_validator.ts
@@ -14,6 +14,7 @@ export const updateProfileValidator = vine.compile(
       .minLength(7)
       .maxLength(20)
       .regex(/^\+?[0-9 \-()]+$/)
+      .regex(/[0-9].*[0-9].*[0-9].*[0-9].*[0-9]/)
       .optional(),
   })
 )

--- a/packages/frontendmu-adonis/app/validators/profile_validator.ts
+++ b/packages/frontendmu-adonis/app/validators/profile_validator.ts
@@ -8,5 +8,12 @@ export const updateProfileValidator = vine.compile(
     linkedinUrl: vine.string().url().maxLength(500).optional(),
     twitterUrl: vine.string().url().maxLength(500).optional(),
     websiteUrl: vine.string().url().maxLength(500).optional(),
+    phone: vine
+      .string()
+      .trim()
+      .minLength(7)
+      .maxLength(20)
+      .regex(/^\+?[0-9 \-()]+$/)
+      .optional(),
   })
 )

--- a/packages/frontendmu-adonis/app/validators/rsvp_validator.ts
+++ b/packages/frontendmu-adonis/app/validators/rsvp_validator.ts
@@ -6,6 +6,7 @@ const phoneRule = vine
   .minLength(7)
   .maxLength(20)
   .regex(/^\+?[0-9 \-()]+$/)
+  .regex(/[0-9].*[0-9].*[0-9].*[0-9].*[0-9]/)
 
 export const createRsvpValidator = vine.compile(
   vine.object({

--- a/packages/frontendmu-adonis/app/validators/rsvp_validator.ts
+++ b/packages/frontendmu-adonis/app/validators/rsvp_validator.ts
@@ -1,0 +1,14 @@
+import vine from '@vinejs/vine'
+
+const phoneRule = vine
+  .string()
+  .trim()
+  .minLength(7)
+  .maxLength(20)
+  .regex(/^\+?[0-9 \-()]+$/)
+
+export const createRsvpValidator = vine.compile(
+  vine.object({
+    phone: phoneRule.optional(),
+  })
+)

--- a/packages/frontendmu-adonis/database/migrations/1777500000000_add_phone_to_users.ts
+++ b/packages/frontendmu-adonis/database/migrations/1777500000000_add_phone_to_users.ts
@@ -1,0 +1,17 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'users'
+
+  async up() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table.string('phone').nullable()
+    })
+  }
+
+  async down() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table.dropColumn('phone')
+    })
+  }
+}

--- a/packages/frontendmu-adonis/inertia/components/admin/RsvpTimelineChart.vue
+++ b/packages/frontendmu-adonis/inertia/components/admin/RsvpTimelineChart.vue
@@ -1,0 +1,375 @@
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+
+interface Props {
+  rsvpedAtList: string[]
+  rsvpOpenAt: string | null
+  rsvpCloseAt: string | null
+  eventAt: string | null
+  seatsAvailable?: number | null
+  bare?: boolean
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  seatsAvailable: null,
+  bare: false,
+})
+
+const HEIGHT = 220
+const PADDING = { top: 16, right: 8, bottom: 32, left: 8 }
+const FALLBACK_WIDTH = 800
+
+const svgEl = ref<SVGSVGElement | null>(null)
+const measuredWidth = ref(FALLBACK_WIDTH)
+
+const WIDTH = computed(() => measuredWidth.value)
+const plotWidth = computed(() => WIDTH.value - PADDING.left - PADDING.right)
+const plotHeight = HEIGHT - PADDING.top - PADDING.bottom
+
+let resizeObserver: ResizeObserver | null = null
+
+onMounted(() => {
+  if (!svgEl.value || typeof ResizeObserver === 'undefined') return
+  resizeObserver = new ResizeObserver((entries) => {
+    for (const entry of entries) {
+      const w = entry.contentRect.width
+      if (w > 0) measuredWidth.value = w
+    }
+  })
+  resizeObserver.observe(svgEl.value)
+})
+
+onBeforeUnmount(() => {
+  resizeObserver?.disconnect()
+  resizeObserver = null
+})
+
+const series = computed(() => {
+  const stamps = props.rsvpedAtList
+    .map((iso) => new Date(iso).getTime())
+    .filter((t) => Number.isFinite(t))
+    .sort((a, b) => a - b)
+  return stamps
+})
+
+const now = Date.now()
+
+const domain = computed(() => {
+  const candidates: number[] = [now]
+  if (props.rsvpOpenAt) candidates.push(new Date(props.rsvpOpenAt).getTime())
+  if (props.rsvpCloseAt) candidates.push(new Date(props.rsvpCloseAt).getTime())
+  if (props.eventAt) candidates.push(new Date(props.eventAt).getTime())
+  if (series.value.length) {
+    candidates.push(series.value[0])
+    candidates.push(series.value[series.value.length - 1])
+  }
+  if (!candidates.length) return null
+
+  const min = Math.min(...candidates)
+  const max = Math.max(...candidates)
+  if (min === max) {
+    const oneHour = 3600 * 1000
+    return { min: min - oneHour, max: max + oneHour }
+  }
+  return { min, max }
+})
+
+const yMax = computed(() =>
+  Math.max(1, series.value.length, props.seatsAvailable ?? 0)
+)
+
+function xFor(timestamp: number) {
+  if (!domain.value) return PADDING.left
+  const { min, max } = domain.value
+  return PADDING.left + ((timestamp - min) / (max - min)) * plotWidth.value
+}
+
+function yFor(value: number) {
+  return PADDING.top + plotHeight - (value / yMax.value) * plotHeight
+}
+
+const pastSeries = computed(() => series.value.filter((ts) => ts <= now))
+const futureSeries = computed(() => series.value.filter((ts) => ts > now))
+
+const linePastPath = computed(() => {
+  if (!domain.value) return ''
+  const startX = xFor(domain.value.min)
+  const nowX = xFor(now)
+  if (nowX <= startX) return ''
+  const points: string[] = [`M ${startX} ${yFor(0)}`]
+  let count = 0
+  for (const ts of pastSeries.value) {
+    const x = xFor(ts)
+    points.push(`L ${x} ${yFor(count)}`)
+    count += 1
+    points.push(`L ${x} ${yFor(count)}`)
+  }
+  points.push(`L ${nowX} ${yFor(count)}`)
+  return points.join(' ')
+})
+
+const lineFuturePath = computed(() => {
+  if (!domain.value) return ''
+  const nowX = xFor(now)
+  const endX = xFor(domain.value.max)
+  if (endX <= nowX) return ''
+  let count = pastSeries.value.length
+  const points: string[] = [`M ${nowX} ${yFor(count)}`]
+  for (const ts of futureSeries.value) {
+    const x = xFor(ts)
+    points.push(`L ${x} ${yFor(count)}`)
+    count += 1
+    points.push(`L ${x} ${yFor(count)}`)
+  }
+  points.push(`L ${endX} ${yFor(count)}`)
+  return points.join(' ')
+})
+
+const areaPath = computed(() => {
+  if (!linePastPath.value || !domain.value) return ''
+  const baseline = yFor(0)
+  const startX = xFor(domain.value.min)
+  const nowX = xFor(now)
+  return `${linePastPath.value} L ${nowX} ${baseline} L ${startX} ${baseline} Z`
+})
+
+interface Marker {
+  label: string
+  timestamp: number
+  color: string
+  align: 'start' | 'end'
+}
+
+const markers = computed<Marker[]>(() => {
+  const out: Marker[] = []
+  if (props.rsvpCloseAt) {
+    out.push({
+      label: 'RSVP close',
+      timestamp: new Date(props.rsvpCloseAt).getTime(),
+      color: 'var(--color-coral-deep)',
+      align: 'start',
+    })
+  }
+  if (props.eventAt) {
+    out.push({
+      label: 'Event',
+      timestamp: new Date(props.eventAt).getTime(),
+      color: '#10b981',
+      align: 'end',
+    })
+  }
+  if (domain.value) {
+    const midpoint = domain.value.min + (domain.value.max - domain.value.min) / 2
+    out.push({
+      label: 'Today',
+      timestamp: now,
+      color: 'var(--color-coral-strong)',
+      align: now > midpoint ? 'end' : 'start',
+    })
+  }
+  return out
+})
+
+function fmtAxisDate(ts: number) {
+  return new Date(ts).toLocaleDateString('en-GB', {
+    day: '2-digit',
+    month: 'short',
+  })
+}
+
+const yTicks = computed(() => {
+  const max = yMax.value
+  const stepCount = max <= 4 ? max : 4
+  const step = Math.ceil(max / stepCount)
+  const ticks: number[] = []
+  for (let v = 0; v <= max; v += step) ticks.push(v)
+  if (ticks[ticks.length - 1] !== max) ticks.push(max)
+  return ticks
+})
+
+const xTicks = computed(() => {
+  if (!domain.value) return []
+  const { min, max } = domain.value
+  return [min, min + (max - min) / 2, max]
+})
+</script>
+
+<template>
+  <div
+    v-if="series.length || domain"
+    :class="
+      bare
+        ? ''
+        : 'bg-white dark:bg-verse-800/50 squircle rounded-xl border border-verse-200 dark:border-verse-700 p-4 mb-6'
+    "
+  >
+    <div class="flex items-start justify-between mb-3 flex-wrap gap-x-4 gap-y-2">
+      <h3
+        v-if="!bare"
+        class="text-sm font-semibold text-verse-900 dark:text-verse-100"
+      >
+        RSVP timeline
+      </h3>
+      <div class="flex flex-wrap items-center gap-x-4 gap-y-1.5 font-mono text-[10.5px] uppercase tracking-[0.12em] text-gray-500 dark:text-gray-300">
+        <span
+          v-for="m in markers"
+          :key="m.label"
+          class="inline-flex items-center gap-1.5"
+        >
+          <span
+            class="inline-block w-2 h-2 rounded-full"
+            :style="{ backgroundColor: m.color }"
+          />
+          {{ m.label }}
+        </span>
+      </div>
+    </div>
+
+    <svg
+      ref="svgEl"
+      :viewBox="`0 0 ${WIDTH} ${HEIGHT}`"
+      class="w-full block h-56"
+      role="img"
+      aria-label="Cumulative RSVPs over time"
+    >
+      <!-- Y-axis grid + inline labels -->
+      <g class="text-gray-400 dark:text-verse-300" font-size="9" font-family="var(--font-mono)" letter-spacing="1.2">
+        <g v-for="tick in yTicks" :key="`y-${tick}`">
+          <line
+            :x1="PADDING.left"
+            :x2="WIDTH - PADDING.right"
+            :y1="yFor(tick)"
+            :y2="yFor(tick)"
+            stroke="currentColor"
+            stroke-opacity="0.12"
+          />
+          <text
+            :x="PADDING.left + 2"
+            :y="yFor(tick) - 4"
+            text-anchor="start"
+            fill="currentColor"
+            opacity="0.7"
+          >
+            {{ tick }}
+          </text>
+        </g>
+      </g>
+
+      <!-- X-axis baseline -->
+      <line
+        :x1="PADDING.left"
+        :x2="WIDTH - PADDING.right"
+        :y1="HEIGHT - PADDING.bottom"
+        :y2="HEIGHT - PADDING.bottom"
+        class="text-gray-300 dark:text-verse-600"
+        stroke="currentColor"
+        stroke-width="1"
+      />
+
+      <!-- X-axis tick labels -->
+      <g class="text-gray-500 dark:text-gray-300" font-size="9" font-family="var(--font-mono)" letter-spacing="1.2">
+        <text
+          v-for="(tick, i) in xTicks"
+          :key="`x-${tick}`"
+          :x="xFor(tick)"
+          :y="HEIGHT - PADDING.bottom + 16"
+          :text-anchor="i === 0 ? 'start' : i === xTicks.length - 1 ? 'end' : 'middle'"
+          fill="currentColor"
+        >
+          {{ fmtAxisDate(tick).toUpperCase() }}
+        </text>
+      </g>
+
+      <!-- Capacity line -->
+      <g v-if="seatsAvailable && seatsAvailable > 0">
+        <line
+          :x1="PADDING.left"
+          :x2="WIDTH - PADDING.right"
+          :y1="yFor(seatsAvailable)"
+          :y2="yFor(seatsAvailable)"
+          stroke="var(--color-coral-deep)"
+          stroke-width="1"
+          stroke-dasharray="2 4"
+          opacity="0.55"
+        />
+        <text
+          :x="WIDTH - PADDING.right - 4"
+          :y="yFor(seatsAvailable) - 3"
+          text-anchor="end"
+          font-size="9"
+          font-family="var(--font-mono)"
+          letter-spacing="1.2"
+          fill="var(--color-coral-deep)"
+          font-weight="600"
+          opacity="0.75"
+        >
+          CAPACITY · {{ seatsAvailable }}
+        </text>
+      </g>
+
+      <!-- Area fill under line -->
+      <path
+        v-if="areaPath"
+        :d="areaPath"
+        fill="var(--color-verse-500)"
+        fill-opacity="0.12"
+      />
+
+      <!-- Past line (solid) -->
+      <path
+        v-if="linePastPath"
+        :d="linePastPath"
+        fill="none"
+        stroke="var(--color-verse-500)"
+        stroke-width="1.5"
+        stroke-linejoin="round"
+        stroke-linecap="round"
+      />
+
+      <!-- Future line (dashed, faded — projection from now to end) -->
+      <path
+        v-if="lineFuturePath"
+        :d="lineFuturePath"
+        fill="none"
+        stroke="var(--color-verse-500)"
+        stroke-width="1.25"
+        stroke-dasharray="4 4"
+        stroke-linejoin="round"
+        stroke-linecap="round"
+        opacity="0.45"
+      />
+
+      <!-- Markers -->
+      <g v-for="m in markers" :key="`marker-${m.label}`">
+        <line
+          :x1="xFor(m.timestamp)"
+          :x2="xFor(m.timestamp)"
+          :y1="PADDING.top"
+          :y2="HEIGHT - PADDING.bottom"
+          :stroke="m.color"
+          stroke-width="1"
+          :stroke-dasharray="m.label === 'Today' ? '0' : '3 3'"
+          opacity="0.7"
+        />
+        <text
+          :transform="`translate(${xFor(m.timestamp) + (m.align === 'start' ? 14 : -6)}, ${HEIGHT - PADDING.bottom - 6}) rotate(-90)`"
+          text-anchor="start"
+          font-size="9"
+          font-family="var(--font-mono)"
+          letter-spacing="1.2"
+          :fill="m.color"
+          font-weight="600"
+        >
+          {{ m.label.toUpperCase() }}
+        </text>
+      </g>
+    </svg>
+
+    <p
+      v-if="!series.length"
+      class="text-center text-xs text-verse-500 dark:text-verse-400 mt-2"
+    >
+      No RSVPs yet — markers shown for reference.
+    </p>
+  </div>
+</template>

--- a/packages/frontendmu-adonis/inertia/components/home/EventCardFeatured.vue
+++ b/packages/frontendmu-adonis/inertia/components/home/EventCardFeatured.vue
@@ -18,7 +18,7 @@ const props = withDefaults(defineProps<Props>(), {
 })
 
 const formattedDate = computed(() => {
-  if (!props.event.date) return ''
+  if (!props.event.date) return { full: '', short: '', day: '', month: '' }
   const date = new Date(props.event.date)
   return {
     full: date.toLocaleDateString('en-US', {
@@ -28,12 +28,16 @@ const formattedDate = computed(() => {
       day: 'numeric',
     }),
     short: date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
+    day: date.toLocaleDateString('en-US', { day: 'numeric' }),
+    month: date.toLocaleDateString('en-US', { month: 'short' }).toUpperCase(),
   }
 })
 
 const speakers = computed(() => {
   return props.event.sessions?.flatMap((session) => session.speakers).filter(Boolean) || []
 })
+
+const sponsors = computed(() => props.event.sponsors ?? [])
 </script>
 
 <template>
@@ -155,15 +159,41 @@ const speakers = computed(() => {
         </div>
       </div>
 
-      <!-- Date Large Display (hidden on mobile) -->
+      <!-- Sponsors (hidden on mobile, replaces date block on lg+) -->
       <div
-        v-if="event.date"
-        class="hidden lg:flex flex-col items-center justify-center w-28 h-28 rounded-lg bg-gray-50 dark:bg-verse-900 border border-gray-200 dark:border-verse-900"
+        v-if="sponsors.length > 0"
+        class="hidden lg:flex flex-col items-end gap-2 shrink-0"
       >
-        <span class="text-3xl font-bold text-verse-500 leading-none">{{ formattedDate.day }}</span>
-        <span class="text-sm font-medium uppercase tracking-wider text-gray-400 mt-1">{{
-          formattedDate.month
-        }}</span>
+        <span
+          class="font-mono text-[9.5px] uppercase tracking-[0.12em] text-gray-500 dark:text-gray-300"
+        >
+          Sponsored by
+        </span>
+        <div class="flex flex-wrap justify-end gap-2 max-w-[260px]">
+          <Link
+            v-for="sponsor in sponsors"
+            :key="sponsor.id"
+            :href="`/sponsor/${sponsor.id}`"
+            class="relative z-20 flex items-center justify-center h-14 min-w-[120px] px-4 rounded-lg border border-gray-200 dark:border-verse-900 hover:border-verse-300 dark:hover:border-verse-700 transition-colors"
+            :class="sponsor.logoBg ? '' : 'bg-white dark:bg-white'"
+            :style="sponsor.logoBg ? { backgroundColor: sponsor.logoBg } : {}"
+            :aria-label="sponsor.name"
+          >
+            <img
+              v-if="sponsor.logoUrl"
+              :src="sponsor.logoUrl"
+              :alt="sponsor.name"
+              class="max-h-8 w-auto object-contain"
+            />
+            <span
+              v-else
+              class="font-display text-[15px]"
+              :class="sponsor.logoBg && sponsor.logoBg !== '#ffffff' ? 'text-gray-100' : 'text-gray-900'"
+            >
+              {{ sponsor.name }}
+            </span>
+          </Link>
+        </div>
       </div>
     </div>
     <Link

--- a/packages/frontendmu-adonis/inertia/components/rsvp/RsvpPhoneModal.vue
+++ b/packages/frontendmu-adonis/inertia/components/rsvp/RsvpPhoneModal.vue
@@ -1,0 +1,169 @@
+<script setup lang="ts">
+import { nextTick, ref, watch } from 'vue'
+
+interface Props {
+  open: boolean
+  loading?: boolean
+  error?: string | null
+}
+
+const props = defineProps<Props>()
+const emit = defineEmits<{
+  submit: [phone: string]
+  close: []
+}>()
+
+const phone = ref('')
+const dialog = ref<HTMLElement | null>(null)
+const phoneInput = ref<HTMLInputElement | null>(null)
+
+watch(
+  () => props.open,
+  async (isOpen) => {
+    if (isOpen) {
+      phone.value = ''
+      await nextTick()
+      phoneInput.value?.focus()
+    }
+  }
+)
+
+function onKeydown(event: KeyboardEvent) {
+  if (event.key === 'Escape' && !props.loading) {
+    event.preventDefault()
+    emit('close')
+  }
+}
+
+function onBackdropClick() {
+  if (!props.loading) emit('close')
+}
+
+function onSubmit() {
+  const trimmed = phone.value.trim()
+  if (!trimmed || props.loading) return
+  emit('submit', trimmed)
+}
+</script>
+
+<template>
+  <Teleport to="body">
+    <Transition
+      enter-active-class="transition duration-150 ease-out"
+      enter-from-class="opacity-0"
+      enter-to-class="opacity-100"
+      leave-active-class="transition duration-150 ease-in"
+      leave-from-class="opacity-100"
+      leave-to-class="opacity-0"
+    >
+      <div
+        v-if="open"
+        class="fixed inset-0 z-[80] flex items-end md:items-center justify-center"
+        @keydown="onKeydown"
+      >
+        <button
+          type="button"
+          class="absolute inset-0 w-full h-full bg-black/55 backdrop-blur-sm cursor-default"
+          aria-label="Close dialog"
+          @click="onBackdropClick"
+        />
+
+        <Transition
+          enter-active-class="transition duration-200 ease-out"
+          enter-from-class="translate-y-8 opacity-0 md:translate-y-4 md:scale-95"
+          enter-to-class="translate-y-0 opacity-100 md:scale-100"
+          leave-active-class="transition duration-150 ease-in"
+          leave-from-class="translate-y-0 opacity-100 md:scale-100"
+          leave-to-class="translate-y-8 opacity-0 md:translate-y-4 md:scale-95"
+          appear
+        >
+          <div
+            v-if="open"
+            ref="dialog"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="rsvp-phone-title"
+            aria-describedby="rsvp-phone-desc"
+            class="relative w-full md:max-w-md md:mx-4 bg-white dark:bg-verse-950 border border-gray-200 dark:border-verse-800 rounded-t-2xl md:rounded-2xl shadow-2xl"
+            style="padding-bottom: env(safe-area-inset-bottom)"
+          >
+            <div class="px-5 pt-5 pb-4 md:p-6">
+              <!-- Mobile drag handle -->
+              <div
+                aria-hidden="true"
+                class="md:hidden mx-auto mb-3 h-1.5 w-10 rounded-full bg-gray-200 dark:bg-verse-800"
+              />
+
+              <h2
+                id="rsvp-phone-title"
+                class="text-lg font-semibold text-gray-900 dark:text-gray-100"
+              >
+                One last thing
+              </h2>
+              <p
+                id="rsvp-phone-desc"
+                class="mt-1 text-sm text-gray-500 dark:text-gray-400 leading-relaxed"
+              >
+                The organizers require your phone number to contact you via Whatsapp message if the event details change.
+              </p>
+
+              <form @submit.prevent="onSubmit" class="mt-5 space-y-4">
+                <div class="space-y-1.5">
+                  <label
+                    for="rsvp-phone-input"
+                    class="block text-xs font-medium text-gray-600 dark:text-gray-400"
+                  >
+                    Phone number
+                  </label>
+                  <input
+                    id="rsvp-phone-input"
+                    ref="phoneInput"
+                    v-model="phone"
+                    type="tel"
+                    inputmode="tel"
+                    autocomplete="tel"
+                    required
+                    minlength="7"
+                    maxlength="20"
+                    pattern="^\+?[0-9 \-()]+$"
+                    placeholder="+230 5 123 4567"
+                    :disabled="loading"
+                    class="w-full px-4 py-3 bg-white dark:bg-verse-900/60 border border-gray-200 dark:border-verse-800 rounded-xl text-base text-gray-900 dark:text-gray-100 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-verse-500/40 focus:border-verse-500 disabled:opacity-60 transition-colors"
+                  />
+                  <p
+                    v-if="error"
+                    role="alert"
+                    class="text-xs text-red-600 dark:text-red-400"
+                  >
+                    {{ error }}
+                  </p>
+                  <p v-else class="text-[11px] text-gray-400 dark:text-gray-500">
+                    You can edit this anytime from your profile.
+                  </p>
+                </div>
+
+                <div class="flex flex-col-reverse sm:flex-row sm:justify-end gap-2 pt-1">
+                  <button
+                    type="button"
+                    :disabled="loading"
+                    class="px-4 py-2.5 text-sm font-medium text-gray-700 dark:text-gray-200 bg-gray-100 dark:bg-verse-900 hover:bg-gray-200 dark:hover:bg-verse-800 rounded-xl transition-colors disabled:opacity-50"
+                    @click="$emit('close')"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="submit"
+                    :disabled="loading || !phone.trim()"
+                    class="px-4 py-2.5 text-sm font-semibold text-white bg-verse-600 hover:bg-verse-700 rounded-xl transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    {{ loading ? 'Saving…' : 'Save and RSVP' }}
+                  </button>
+                </div>
+              </form>
+            </div>
+          </div>
+        </Transition>
+      </div>
+    </Transition>
+  </Teleport>
+</template>

--- a/packages/frontendmu-adonis/inertia/pages/admin/events/attendees.vue
+++ b/packages/frontendmu-adonis/inertia/pages/admin/events/attendees.vue
@@ -1,0 +1,402 @@
+<script setup lang="ts">
+import { Head, Link } from '@inertiajs/vue3'
+import { computed, ref } from 'vue'
+import type { Data } from '@generated/data'
+import ContentBlock from '~/components/shared/ContentBlock.vue'
+import BaseHeading from '~/components/base/BaseHeading.vue'
+import RsvpTimelineChart from '~/components/admin/RsvpTimelineChart.vue'
+import { formatEventDate } from '~/utils/date'
+
+type RsvpStatus = 'confirmed' | 'waitlist' | 'cancelled'
+type StatusFilter = 'all' | RsvpStatus
+
+interface Attendee {
+  rsvpId: string
+  status: RsvpStatus
+  notes: string | null
+  rsvpedAt: string | null
+  user: {
+    id: string
+    name: string
+    email: string
+    githubUsername: string | null
+    avatarUrl: string | null
+  } | null
+}
+
+interface Timeline {
+  rsvpOpenAt: string | null
+  rsvpCloseAt: string | null
+  eventAt: string | null
+}
+
+interface Props {
+  event: Data.Event.Variants['detail']
+  attendees: Attendee[]
+  counts: {
+    total: number
+    confirmed: number
+    waitlist: number
+    cancelled: number
+  }
+  timeline: Timeline
+}
+
+const props = defineProps<Props>()
+
+const search = ref('')
+const statusFilter = ref<StatusFilter>('all')
+
+const activeRsvpedAtList = computed(() =>
+  props.attendees
+    .filter((a) => a.status !== 'cancelled' && a.rsvpedAt)
+    .map((a) => a.rsvpedAt as string)
+)
+
+const filtered = computed(() => {
+  const q = search.value.trim().toLowerCase()
+  return props.attendees.filter((a) => {
+    if (statusFilter.value !== 'all' && a.status !== statusFilter.value) return false
+    if (!q) return true
+    if (!a.user) return false
+    return (
+      a.user.name.toLowerCase().includes(q) ||
+      a.user.email.toLowerCase().includes(q) ||
+      (a.user.githubUsername?.toLowerCase().includes(q) ?? false)
+    )
+  })
+})
+
+const filterButtons = computed<
+  { key: StatusFilter; label: string; count: number; activeClass: string }[]
+>(() => [
+  { key: 'all', label: 'All', count: props.counts.total, activeClass: 'bg-verse-600 text-white' },
+  {
+    key: 'confirmed',
+    label: 'Confirmed',
+    count: props.counts.confirmed,
+    activeClass: 'bg-green-600 text-white',
+  },
+  {
+    key: 'waitlist',
+    label: 'Waitlist',
+    count: props.counts.waitlist,
+    activeClass: 'bg-yellow-600 text-white',
+  },
+  {
+    key: 'cancelled',
+    label: 'Cancelled',
+    count: props.counts.cancelled,
+    activeClass: 'bg-red-600 text-white',
+  },
+])
+
+function statusBadge(status: RsvpStatus) {
+  switch (status) {
+    case 'confirmed':
+      return 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300'
+    case 'waitlist':
+      return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300'
+    case 'cancelled':
+      return 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300'
+  }
+}
+
+function formatRsvpedAt(iso: string | null) {
+  if (!iso) return '—'
+  const d = new Date(iso)
+  return d.toLocaleString('en-GB', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+function exportCsv() {
+  const rows = [
+    ['Name', 'Email', 'GitHub', 'Status', 'RSVP’ed at', 'Notes'],
+    ...props.attendees.map((a) => [
+      a.user?.name ?? '',
+      a.user?.email ?? '',
+      a.user?.githubUsername ?? '',
+      a.status,
+      a.rsvpedAt ?? '',
+      (a.notes ?? '').replace(/\r?\n/g, ' '),
+    ]),
+  ]
+  const csv = rows
+    .map((row) =>
+      row
+        .map((cell) => {
+          const value = String(cell ?? '')
+          return /[",\n]/.test(value) ? `"${value.replace(/"/g, '""')}"` : value
+        })
+        .join(',')
+    )
+    .join('\n')
+
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' })
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement('a')
+  link.href = url
+  link.download = `attendees-${props.event.slug || props.event.id}.csv`
+  document.body.appendChild(link)
+  link.click()
+  document.body.removeChild(link)
+  URL.revokeObjectURL(url)
+}
+</script>
+
+<template>
+  <Head :title="`Attendees · ${event.title}`" />
+  <main class="relative min-h-screen pt-40 pb-20">
+    <ContentBlock>
+      <!-- Breadcrumb -->
+      <div class="mb-4 text-sm text-verse-500 dark:text-verse-400">
+        <Link href="/admin" class="hover:text-verse-700 dark:hover:text-verse-200">Admin</Link>
+        <span class="mx-1.5">/</span>
+        <Link
+          href="/admin/events"
+          class="hover:text-verse-700 dark:hover:text-verse-200"
+        >Events</Link>
+        <span class="mx-1.5">/</span>
+        <span class="text-verse-700 dark:text-verse-300">Attendees</span>
+      </div>
+
+      <!-- Header -->
+      <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4 mb-8">
+        <div class="min-w-0">
+          <BaseHeading :level="1">{{ event.title }}</BaseHeading>
+          <div
+            class="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-verse-600 dark:text-verse-400"
+          >
+            <span>{{ formatEventDate(event.date) }}</span>
+            <span v-if="event.startTime">{{ event.startTime }}<span v-if="event.endTime"> – {{ event.endTime }}</span></span>
+            <span v-if="event.venue">{{ event.venue }}</span>
+            <span
+              v-if="event.seatsAvailable !== null"
+              class="text-verse-500 dark:text-verse-400"
+            >Capacity: {{ counts.confirmed }} / {{ event.seatsAvailable }}</span>
+          </div>
+        </div>
+        <div class="flex flex-wrap gap-2 shrink-0">
+          <Link
+            :href="`/meetup/${event.slug || event.id}`"
+            class="inline-flex items-center gap-2 px-4 py-2 bg-verse-100 dark:bg-verse-800 hover:bg-verse-200 dark:hover:bg-verse-700 text-verse-700 dark:text-verse-200 text-sm font-medium squircle rounded-lg transition-colors"
+          >
+            View public page
+          </Link>
+          <Link
+            :href="`/admin/events/${event.id}/edit`"
+            class="inline-flex items-center gap-2 px-4 py-2 bg-verse-100 dark:bg-verse-800 hover:bg-verse-200 dark:hover:bg-verse-700 text-verse-700 dark:text-verse-200 text-sm font-medium squircle rounded-lg transition-colors"
+          >
+            Edit event
+          </Link>
+          <button
+            type="button"
+            :disabled="!attendees.length"
+            @click="exportCsv"
+            class="inline-flex items-center gap-2 px-4 py-2 bg-verse-600 hover:bg-verse-700 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-medium squircle rounded-lg transition-colors"
+          >
+            Export CSV
+          </button>
+        </div>
+      </div>
+
+      <!-- Stats -->
+      <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
+        <div
+          class="bg-white dark:bg-verse-800/50 squircle rounded-xl border border-verse-200 dark:border-verse-700 p-4"
+        >
+          <div class="text-2xl font-bold text-verse-900 dark:text-verse-100">{{ counts.total }}</div>
+          <div class="text-sm text-verse-600 dark:text-verse-400">Total RSVPs</div>
+        </div>
+        <div
+          class="bg-white dark:bg-verse-800/50 squircle rounded-xl border border-verse-200 dark:border-verse-700 p-4"
+        >
+          <div class="text-2xl font-bold text-green-600 dark:text-green-400">{{ counts.confirmed }}</div>
+          <div class="text-sm text-verse-600 dark:text-verse-400">Confirmed</div>
+        </div>
+        <div
+          class="bg-white dark:bg-verse-800/50 squircle rounded-xl border border-verse-200 dark:border-verse-700 p-4"
+        >
+          <div class="text-2xl font-bold text-yellow-600 dark:text-yellow-400">{{ counts.waitlist }}</div>
+          <div class="text-sm text-verse-600 dark:text-verse-400">Waitlist</div>
+        </div>
+        <div
+          class="bg-white dark:bg-verse-800/50 squircle rounded-xl border border-verse-200 dark:border-verse-700 p-4"
+        >
+          <div class="text-2xl font-bold text-red-600 dark:text-red-400">{{ counts.cancelled }}</div>
+          <div class="text-sm text-verse-600 dark:text-verse-400">Cancelled</div>
+        </div>
+      </div>
+
+      <!-- Timeline chart -->
+      <RsvpTimelineChart
+        :rsvped-at-list="activeRsvpedAtList"
+        :rsvp-open-at="timeline.rsvpOpenAt"
+        :rsvp-close-at="timeline.rsvpCloseAt"
+        :event-at="timeline.eventAt"
+        :seats-available="event.seatsAvailable"
+      />
+
+      <!-- Filters + search -->
+      <div class="flex flex-wrap items-center justify-between gap-3 mb-4">
+        <div class="flex flex-wrap gap-2">
+          <button
+            v-for="btn in filterButtons"
+            :key="btn.key"
+            type="button"
+            @click="statusFilter = btn.key"
+            :class="[
+              'px-3 py-1.5 squircle rounded-lg text-sm font-medium transition-colors',
+              statusFilter === btn.key
+                ? btn.activeClass
+                : 'bg-verse-100 dark:bg-verse-800 text-verse-700 dark:text-verse-300 hover:bg-verse-200 dark:hover:bg-verse-700',
+            ]"
+          >
+            {{ btn.label }}
+            <span class="ml-1 opacity-70">{{ btn.count }}</span>
+          </button>
+        </div>
+
+        <label class="relative w-full sm:w-72">
+          <span class="sr-only">Search attendees</span>
+          <input
+            v-model="search"
+            type="search"
+            placeholder="Search name, email or GitHub"
+            class="w-full px-3 py-2 bg-white dark:bg-verse-900 border border-verse-200 dark:border-verse-800 rounded-lg text-sm text-verse-900 dark:text-verse-100 placeholder-verse-400 focus:outline-none focus:ring-2 focus:ring-verse-500/40 focus:border-verse-500 transition-colors"
+          />
+        </label>
+      </div>
+
+      <!-- Table -->
+      <div
+        class="bg-white dark:bg-verse-800/50 squircle rounded-xl border border-verse-200 dark:border-verse-700 overflow-hidden"
+      >
+        <div class="overflow-x-auto">
+          <table class="w-full">
+            <thead class="bg-verse-50 dark:bg-verse-800 border-b border-verse-200 dark:border-verse-700">
+              <tr>
+                <th
+                  class="px-6 py-3 text-left text-xs font-semibold text-verse-600 dark:text-verse-400 uppercase tracking-wider"
+                >
+                  Attendee
+                </th>
+                <th
+                  class="px-6 py-3 text-left text-xs font-semibold text-verse-600 dark:text-verse-400 uppercase tracking-wider"
+                >
+                  Email
+                </th>
+                <th
+                  class="px-6 py-3 text-left text-xs font-semibold text-verse-600 dark:text-verse-400 uppercase tracking-wider"
+                >
+                  GitHub
+                </th>
+                <th
+                  class="px-6 py-3 text-left text-xs font-semibold text-verse-600 dark:text-verse-400 uppercase tracking-wider"
+                >
+                  Status
+                </th>
+                <th
+                  class="px-6 py-3 text-left text-xs font-semibold text-verse-600 dark:text-verse-400 uppercase tracking-wider"
+                >
+                  RSVP&rsquo;ed at
+                </th>
+                <th
+                  class="px-6 py-3 text-left text-xs font-semibold text-verse-600 dark:text-verse-400 uppercase tracking-wider"
+                >
+                  Notes
+                </th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-verse-200 dark:divide-verse-700">
+              <tr
+                v-for="attendee in filtered"
+                :key="attendee.rsvpId"
+                class="hover:bg-verse-50 dark:hover:bg-verse-800/80 transition-colors"
+              >
+                <td class="px-6 py-3">
+                  <div class="flex items-center gap-3 min-w-0">
+                    <img
+                      v-if="attendee.user?.avatarUrl"
+                      :src="attendee.user.avatarUrl"
+                      :alt="attendee.user.name"
+                      loading="lazy"
+                      class="w-8 h-8 rounded-full object-cover bg-verse-100 dark:bg-verse-700 shrink-0"
+                    />
+                    <div
+                      v-else
+                      class="w-8 h-8 rounded-full bg-verse-100 dark:bg-verse-700 flex items-center justify-center text-xs font-semibold text-verse-600 dark:text-verse-300 shrink-0"
+                    >
+                      {{ (attendee.user?.name ?? '?').charAt(0).toUpperCase() }}
+                    </div>
+                    <span class="font-medium text-verse-900 dark:text-verse-100 truncate">
+                      {{ attendee.user?.name ?? 'Deleted user' }}
+                    </span>
+                  </div>
+                </td>
+                <td class="px-6 py-3 text-sm text-verse-700 dark:text-verse-300">
+                  <a
+                    v-if="attendee.user?.email"
+                    :href="`mailto:${attendee.user.email}`"
+                    class="hover:underline"
+                  >{{ attendee.user.email }}</a>
+                  <span v-else>—</span>
+                </td>
+                <td class="px-6 py-3 text-sm text-verse-700 dark:text-verse-300">
+                  <a
+                    v-if="attendee.user?.githubUsername"
+                    :href="`https://github.com/${attendee.user.githubUsername}`"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="hover:underline"
+                  >@{{ attendee.user.githubUsername }}</a>
+                  <span v-else class="text-verse-400 dark:text-verse-500">—</span>
+                </td>
+                <td class="px-6 py-3">
+                  <span
+                    :class="[
+                      'px-2.5 py-1 rounded-full text-xs font-medium capitalize',
+                      statusBadge(attendee.status),
+                    ]"
+                  >
+                    {{ attendee.status }}
+                  </span>
+                </td>
+                <td class="px-6 py-3 text-sm text-verse-600 dark:text-verse-400 whitespace-nowrap">
+                  {{ formatRsvpedAt(attendee.rsvpedAt) }}
+                </td>
+                <td class="px-6 py-3 text-sm text-verse-600 dark:text-verse-400 max-w-xs">
+                  <span v-if="attendee.notes" class="line-clamp-2">{{ attendee.notes }}</span>
+                  <span v-else class="text-verse-400 dark:text-verse-500">—</span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <!-- Empty state -->
+        <div v-if="!filtered.length" class="px-6 py-12 text-center">
+          <p class="text-verse-500 dark:text-verse-400">
+            <span v-if="!attendees.length">No RSVPs yet for this event.</span>
+            <span v-else-if="search || statusFilter !== 'all'"
+              >No attendees match the current filters.</span
+            >
+          </p>
+          <button
+            v-if="attendees.length && (search || statusFilter !== 'all')"
+            type="button"
+            @click="search = ''; statusFilter = 'all'"
+            class="inline-block mt-2 text-verse-600 hover:text-verse-800 dark:text-verse-400 dark:hover:text-verse-200 underline"
+          >
+            Clear filters
+          </button>
+        </div>
+      </div>
+    </ContentBlock>
+  </main>
+</template>

--- a/packages/frontendmu-adonis/inertia/pages/admin/events/index.vue
+++ b/packages/frontendmu-adonis/inertia/pages/admin/events/index.vue
@@ -236,6 +236,23 @@ function doDelete() {
                       </svg>
                     </Link>
                     <Link
+                      :href="`/admin/events/${event.slug || event.id}/attendees`"
+                      class="p-2 text-verse-500 hover:text-verse-700 dark:text-verse-400 dark:hover:text-verse-200 transition-colors"
+                      title="Attendees"
+                      aria-label="View attendees"
+                    >
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        class="h-5 w-5"
+                        viewBox="0 0 20 20"
+                        fill="currentColor"
+                      >
+                        <path
+                          d="M9 6a3 3 0 11-6 0 3 3 0 016 0zM17 6a3 3 0 11-6 0 3 3 0 016 0zM12.93 17c.046-.327.07-.66.07-1a6.97 6.97 0 00-1.5-4.33A5 5 0 0119 16v1h-6.07zM6 11a5 5 0 015 5v1H1v-1a5 5 0 015-5z"
+                        />
+                      </svg>
+                    </Link>
+                    <Link
                       :href="`/admin/events/${event.id}/edit`"
                       class="p-2 text-verse-500 hover:text-verse-700 dark:text-verse-400 dark:hover:text-verse-200 transition-colors"
                       title="Edit"

--- a/packages/frontendmu-adonis/inertia/pages/meetups/show.vue
+++ b/packages/frontendmu-adonis/inertia/pages/meetups/show.vue
@@ -6,6 +6,7 @@ import { Link } from '@inertiajs/vue3'
 import type { Data } from '@generated/data'
 import SpeakerAvatar from '~/components/shared/SpeakerAvatar.vue'
 import RsvpPhoneModal from '~/components/rsvp/RsvpPhoneModal.vue'
+import RsvpTimelineChart from '~/components/admin/RsvpTimelineChart.vue'
 import { sanitizeHtml } from '~/composables/use_sanitize'
 import { useApi } from '~/composables/use_api'
 
@@ -15,6 +16,12 @@ interface Props {
   rsvpCount: number
   canEdit: boolean
   attendees: Data.PublicAttendee[]
+  rsvpedAtList: string[]
+  timeline: {
+    rsvpOpenAt: string | null
+    rsvpCloseAt: string | null
+    eventAt: string | null
+  }
 }
 
 const props = defineProps<Props>()
@@ -762,12 +769,23 @@ const calendarUrl = computed(() => {
             </section>
 
             <!-- Attendees -->
-            <section v-if="attendees.length > 0" class="py-12 border-b border-gray-200 dark:border-verse-900">
+            <section
+              v-if="attendees.length > 0 || rsvpedAtList.length > 0"
+              class="py-12 border-b border-gray-200 dark:border-verse-900"
+            >
               <h2 class="section-label">{{ isPast ? 'Who came' : "Who's coming" }}</h2>
-              <div class="mt-6 flex items-center gap-4 flex-wrap">
+              <div v-if="attendees.length > 0" class="mt-6 flex items-center gap-4 flex-wrap">
                 <div class="flex -space-x-2.5">
                   <template v-for="attendee in attendees.slice(0, 8)" :key="attendee.id">
+                    <div
+                      v-if="!attendee.avatarUrl && !attendee.githubUsername"
+                      :title="attendee.name"
+                      class="w-12 h-12 rounded-2xl border-2 border-white dark:border-verse-950 bg-verse-100 dark:bg-verse-800 flex items-center justify-center text-sm font-bold text-verse-700 dark:text-verse-200 shrink-0"
+                    >
+                      {{ attendee.name.charAt(0).toUpperCase() }}
+                    </div>
                     <SpeakerAvatar
+                      v-else
                       size="md"
                       :name="attendee.name"
                       :github-username="attendee.githubUsername"
@@ -777,7 +795,7 @@ const calendarUrl = computed(() => {
                   </template>
                   <div
                     v-if="attendees.length > 8"
-                    class="w-10 h-10 rounded-full bg-gray-100 dark:bg-verse-900 border-2 border-white dark:border-verse-950 flex items-center justify-center text-[11px] font-bold text-gray-600 dark:text-gray-300"
+                    class="w-12 h-12 rounded-2xl bg-gray-100 dark:bg-verse-900 border-2 border-white dark:border-verse-950 flex items-center justify-center text-[12px] font-bold text-gray-600 dark:text-gray-300 shrink-0"
                   >
                     +{{ attendees.length - 8 }}
                   </div>
@@ -787,6 +805,16 @@ const calendarUrl = computed(() => {
                   <template v-if="spotsRemaining !== null && !isPast"> · {{ spotsRemaining }} spots left</template>
                 </p>
               </div>
+              <RsvpTimelineChart
+                v-if="rsvpedAtList.length > 0"
+                bare
+                class="mt-8"
+                :rsvped-at-list="rsvpedAtList"
+                :rsvp-open-at="timeline.rsvpOpenAt"
+                :rsvp-close-at="timeline.rsvpCloseAt"
+                :event-at="timeline.eventAt"
+                :seats-available="meetup?.seatsAvailable ?? null"
+              />
             </section>
 
             <!-- Share bar -->

--- a/packages/frontendmu-adonis/inertia/pages/meetups/show.vue
+++ b/packages/frontendmu-adonis/inertia/pages/meetups/show.vue
@@ -5,6 +5,7 @@ import { Head, usePage, router } from '@inertiajs/vue3'
 import { Link } from '@inertiajs/vue3'
 import type { Data } from '@generated/data'
 import SpeakerAvatar from '~/components/shared/SpeakerAvatar.vue'
+import RsvpPhoneModal from '~/components/rsvp/RsvpPhoneModal.vue'
 import { sanitizeHtml } from '~/composables/use_sanitize'
 import { useApi } from '~/composables/use_api'
 
@@ -29,6 +30,9 @@ const isRsvpLoading = ref(false)
 const rsvpError = ref<string | null>(null)
 const rsvpSuccess = ref<string | null>(null)
 const showMobileRsvp = ref(false)
+const showPhoneModal = ref(false)
+const phoneModalError = ref<string | null>(null)
+const userHasPhone = computed(() => Boolean(page.props.auth?.user?.hasPhone))
 
 // Check if user has an active RSVP
 const hasRsvp = computed(() => !!props.userRsvp)
@@ -70,29 +74,62 @@ const allSpeakers = computed(() => props.meetup?.speakers ?? [])
 async function handleRsvp() {
   if (!props.meetup) return
 
+  if (!userHasPhone.value) {
+    phoneModalError.value = null
+    showPhoneModal.value = true
+    return
+  }
+
+  await submitRsvp()
+}
+
+async function submitRsvp(phone?: string) {
+  if (!props.meetup) return
+
   isRsvpLoading.value = true
   rsvpError.value = null
   rsvpSuccess.value = null
+  phoneModalError.value = null
 
   try {
-    const { ok, data } = await apiFetch<{ message: string }>(
-      `/api/events/${props.meetup.id}/rsvp`,
-      {
-        method: 'POST',
-      }
-    )
+    const { ok, data, response } = await apiFetch<{
+      message: string
+      code?: string
+      errors?: Record<string, string>
+    }>(`/api/events/${props.meetup.id}/rsvp`, {
+      method: 'POST',
+      body: phone ? JSON.stringify({ phone }) : undefined,
+    })
 
     if (ok) {
       rsvpSuccess.value = data.message
+      showPhoneModal.value = false
       router.reload()
-    } else {
-      rsvpError.value = data.message || 'Failed to RSVP'
+      return
     }
+
+    if (response.status === 422 && (data.code === 'PHONE_REQUIRED' || data.errors?.phone)) {
+      phoneModalError.value = data.errors?.phone || data.message || 'Please enter a valid phone number.'
+      showPhoneModal.value = true
+      return
+    }
+
+    rsvpError.value = data.message || 'Failed to RSVP'
   } catch (error) {
     rsvpError.value = 'An error occurred. Please try again.'
   } finally {
     isRsvpLoading.value = false
   }
+}
+
+function onPhoneModalSubmit(phone: string) {
+  submitRsvp(phone)
+}
+
+function onPhoneModalClose() {
+  if (isRsvpLoading.value) return
+  showPhoneModal.value = false
+  phoneModalError.value = null
 }
 
 async function handleCancelRsvp() {
@@ -1149,6 +1186,14 @@ const calendarUrl = computed(() => {
       </div>
     </Transition>
   </Teleport>
+
+  <RsvpPhoneModal
+    :open="showPhoneModal"
+    :loading="isRsvpLoading"
+    :error="phoneModalError"
+    @submit="onPhoneModalSubmit"
+    @close="onPhoneModalClose"
+  />
 </template>
 
 <style scoped>

--- a/packages/frontendmu-adonis/inertia/pages/profile.vue
+++ b/packages/frontendmu-adonis/inertia/pages/profile.vue
@@ -52,6 +52,7 @@ const form = useForm({
   twitterUrl: props.user?.twitterUrl || '',
   linkedinUrl: props.user?.linkedinUrl || '',
   websiteUrl: props.user?.websiteUrl || '',
+  phone: props.user?.phone || '',
 })
 
 function handleSubmit() {
@@ -211,6 +212,23 @@ function getUserRoles() {
                   />
                 </div>
               </div>
+            </div>
+
+            <div class="space-y-2">
+              <label for="phone" class="text-xs font-medium text-gray-400">
+                Phone number
+                <span class="text-gray-300 dark:text-verse-700"> · used to verify you’re a real human when you RSVP</span>
+              </label>
+              <input
+                id="phone"
+                v-model="form.phone"
+                type="tel"
+                inputmode="tel"
+                autocomplete="tel"
+                placeholder="+230 5 123 4567"
+                class="w-full px-4 py-3 bg-white dark:bg-verse-900/40 border border-gray-100 dark:border-verse-800 rounded-xl text-gray-900 dark:text-white focus:outline-none focus:border-verse-500 transition-colors"
+              />
+              <p v-if="form.errors.phone" class="text-xs text-red-500">{{ form.errors.phone }}</p>
             </div>
 
             <div class="space-y-2">

--- a/packages/frontendmu-adonis/start/routes.ts
+++ b/packages/frontendmu-adonis/start/routes.ts
@@ -176,6 +176,14 @@ router
       .where('id', UUID_REGEX)
       .as('admin.events.destroy')
 
+    // Event attendees (full RSVP roster — admin only)
+    router
+      .get('/admin/events/:idOrSlug/attendees', [
+        () => import('#controllers/admin/event_attendees_controller'),
+        'show',
+      ])
+      .as('admin.events.attendees')
+
     // Session management (nested under events)
     router
       .get('/admin/events/:eventId/sessions', [


### PR DESCRIPTION
## Summary

Five focused commits:

1. **`fix: cast SQLite boolean columns`** — `Event.acceptingRsvp` and `User.featured/isOrganizer/isCommunityMember` now `consume: Boolean(v)`. SQLite stores booleans as ints; Vue checkbox v-model strict-equals `true`, so the admin event edit form was rendering `accepting_rsvp = 1` as unchecked. Fix is one decorator change per column.
2. **`feat: require phone number before RSVP`** — adds nullable `phone` to users (migration), exposes `auth.user.hasPhone: boolean` (number stays server-side), gates `POST /api/events/:id/rsvp` (422 `PHONE_REQUIRED` when missing), interrupts the RSVP flow with an accessible modal (mobile bottom-sheet, desktop card), and adds a phone field to `/profile`.
3. **`feat: admin event attendees page + RSVP timeline chart`** — new `GET /admin/events/:idOrSlug/attendees` (gated by `EventPolicy.viewAny`), full attendee table with name/email/GitHub/status/RSVP'd-at/notes, search + status filter + CSV export. Embeds an inline-SVG cumulative RSVP timeline with markers for RSVP close, event date, today, and a horizontal capacity line; the line is solid for past, dashed for the future projection.
4. **`feat: show timeline + Who's coming publicly`** — `EventsController.show` now always returns the day-rounded cumulative timestamps and timeline payload. The chart embeds inside the existing "Who's coming" section. Anonymous viewers get a stripped attendee list (truncated name only — no avatar URL, no GitHub handle), rendered as initial-based colored circles instead of `<img>` tags. No PII flows to anon viewers. Fixes the +N overflow chip alignment.
5. **`fix: empty date block on home featured card`** — `formattedDate.day/month` were undefined (computed only exposed `full`/`short`), leaving a 112×112 empty box on lg+ viewports. Repurposes the slot for a "Sponsored by" stack with the same logo-tile pattern used on the meetup detail page.

## Migration
- `1777500000000_add_phone_to_users.ts` — nullable `phone` column on `users`. Idempotent up/down. Run `node ace migration:run --force` on the server.

## Privacy notes
- Public timestamps are rounded to UTC start-of-day before being sent to the browser.
- Anonymous attendee list contains only truncated names; no avatar URL, no GitHub handle.
- `auth.user.hasPhone` is a boolean, the actual phone number is never sent to anonymous viewers and only sent on the user's own profile page.

## Test plan
- [ ] Run `node ace migration:run --force` on staging/prod
- [ ] As admin (`sandeep@ramgolam.com`), open an event in `/admin/events/:id/edit`: "Accepting RSVPs" checkbox now reflects DB value
- [ ] Visit `/admin/events/2026-may/attendees`: full table, chart with markers + capacity, CSV export works
- [ ] Anonymous user → `/admin/events/:id/attendees` redirects to `/login`
- [ ] Non-admin authed user → `/admin/events/:id/attendees` returns 403
- [ ] As a logged-in user with no phone, click RSVP: modal interrupts; submit fills phone and creates RSVP
- [ ] Phone persists in `/profile`; can be edited there
- [ ] Anonymous viewer on `/meetup/2026-may`: sees timeline chart and initial-circle "Who's coming" row, no real avatars or GitHub handles in the page payload (verify via Network tab)
- [ ] Home page next-event card: right side now shows the sponsor logo (was empty)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added phone number field to user profiles with validation and management.
  * Implemented phone verification flow during RSVP to ensure contact information capture.
  * Added admin event attendees page with RSVP status filtering, search, timeline visualization, and CSV export functionality.
  * Added RSVP timeline chart to visualize attendee registration patterns over time.
  * Introduced sponsors display section on featured event cards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->