### PR TITLE
Admin UI redesign on a coherent design system

### DIFF
--- a/packages/frontendmu-adonis/inertia/components/admin/RsvpTimelineChart.vue
+++ b/packages/frontendmu-adonis/inertia/components/admin/RsvpTimelineChart.vue
@@ -367,7 +367,7 @@ const xTicks = computed(() => {
 
     <p
       v-if="!series.length"
-      class="text-center text-xs text-verse-500 dark:text-verse-400 mt-2"
+      class="text-center text-xs text-verse-500 dark:text-verse-300 mt-2"
     >
       No RSVPs yet — markers shown for reference.
     </p>

--- a/packages/frontendmu-adonis/inertia/components/admin/SponsorFormFields.vue
+++ b/packages/frontendmu-adonis/inertia/components/admin/SponsorFormFields.vue
@@ -142,7 +142,7 @@ function toggleSponsorType(type: string) {
           </label>
           <span
             v-if="form.logoBg && !['#ffffff', '#111827', ''].includes(form.logoBg)"
-            class="text-xs font-mono text-verse-500 dark:text-verse-400"
+            class="text-xs font-mono text-verse-500 dark:text-verse-300"
           >
             {{ form.logoBg }}
           </span>

--- a/packages/frontendmu-adonis/inertia/components/admin/SponsorFormFields.vue
+++ b/packages/frontendmu-adonis/inertia/components/admin/SponsorFormFields.vue
@@ -1,0 +1,184 @@
+<script setup lang="ts">
+import AdminCard from '~/components/admin/ui/AdminCard.vue'
+import AdminInput from '~/components/admin/ui/AdminInput.vue'
+import AdminTextarea from '~/components/admin/ui/AdminTextarea.vue'
+import AdminSelect from '~/components/admin/ui/AdminSelect.vue'
+import BaseImageUpload from '~/components/base/BaseImageUpload.vue'
+
+interface SponsorFormState {
+  name: string
+  website: string
+  description: string
+  logoUrl: string
+  logomarkUrl: string
+  logoFile: File | null
+  logomarkFile: File | null
+  clearLogo?: boolean
+  clearLogomark?: boolean
+  sponsorTypes: string[]
+  logoBg: string
+  status: 'active' | 'inactive'
+}
+
+const props = defineProps<{
+  form: SponsorFormState & { errors: Record<string, string> }
+  currentLogoUrl?: string | null
+  currentLogomarkUrl?: string | null
+}>()
+
+const sponsorTypeOptions = [
+  'venue',
+  'food',
+  'drinks',
+  'swag',
+  'gold',
+  'silver',
+  'bronze',
+  'platinum',
+]
+
+const presetBackgrounds: Array<{ value: string; label: string; swatch: string }> = [
+  { value: '', label: 'Transparent', swatch: 'transparent' },
+  { value: '#ffffff', label: 'White', swatch: '#ffffff' },
+  { value: '#111827', label: 'Black', swatch: '#111827' },
+]
+
+function toggleSponsorType(type: string) {
+  const idx = props.form.sponsorTypes.indexOf(type)
+  if (idx === -1) props.form.sponsorTypes.push(type)
+  else props.form.sponsorTypes.splice(idx, 1)
+}
+</script>
+
+<template>
+  <div class="space-y-6">
+    <AdminCard title="Basics">
+      <div class="space-y-5">
+        <AdminInput v-model="form.name" label="Name" required :error="form.errors.name" />
+        <AdminInput
+          v-model="form.website"
+          label="Website"
+          type="url"
+          placeholder="https://…"
+          :error="form.errors.website"
+        />
+        <AdminTextarea
+          v-model="form.description"
+          label="Description"
+          :error="form.errors.description"
+        />
+      </div>
+    </AdminCard>
+
+    <AdminCard title="Logo & branding" description="Logo is the primary mark; logomark is a compact symbol used in tight spaces.">
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <div>
+          <span class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-1.5">Logo</span>
+          <BaseImageUpload
+            v-model="form.logoFile"
+            :current-url="currentLogoUrl ?? undefined"
+            :dark-preview="!!form.logoBg"
+            :error="form.errors.logoFile || form.errors.logoUrl"
+            @update:url="(v) => { form.logoUrl = v; if ('clearLogo' in form) form.clearLogo = false }"
+            @update:model-value="() => { if ('clearLogo' in form) form.clearLogo = false }"
+            @clear="() => { if ('clearLogo' in form) form.clearLogo = true }"
+          />
+        </div>
+        <div>
+          <span class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-1.5">Logomark</span>
+          <BaseImageUpload
+            v-model="form.logomarkFile"
+            :current-url="currentLogomarkUrl ?? undefined"
+            :dark-preview="!!form.logoBg"
+            :error="form.errors.logomarkFile || form.errors.logomarkUrl"
+            @update:url="(v) => { form.logomarkUrl = v; if ('clearLogomark' in form) form.clearLogomark = false }"
+            @update:model-value="() => { if ('clearLogomark' in form) form.clearLogomark = false }"
+            @clear="() => { if ('clearLogomark' in form) form.clearLogomark = true }"
+          />
+        </div>
+      </div>
+
+      <div class="mt-6">
+        <span class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-2">
+          Logo background
+        </span>
+        <div class="flex flex-wrap items-center gap-2">
+          <button
+            v-for="preset in presetBackgrounds"
+            :key="preset.label"
+            type="button"
+            :class="[
+              'inline-flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium border transition-colors',
+              form.logoBg === preset.value
+                ? 'bg-verse-900 dark:bg-verse-50 border-verse-900 dark:border-verse-50 text-white dark:text-verse-900'
+                : 'bg-white dark:bg-verse-900/40 border-verse-200 dark:border-verse-800 text-verse-700 dark:text-verse-200 hover:border-verse-400 dark:hover:border-verse-600',
+            ]"
+            @click="form.logoBg = preset.value"
+          >
+            <span
+              class="w-3 h-3 rounded-full border border-verse-300 dark:border-verse-700"
+              :style="{
+                backgroundColor: preset.swatch === 'transparent' ? undefined : preset.swatch,
+                backgroundImage:
+                  preset.swatch === 'transparent'
+                    ? 'linear-gradient(45deg, #ddd 25%, transparent 25%, transparent 50%, #ddd 50%, #ddd 75%, transparent 75%)'
+                    : undefined,
+                backgroundSize: '6px 6px',
+              }"
+              aria-hidden="true"
+            />
+            {{ preset.label }}
+          </button>
+          <label
+            class="inline-flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium border bg-white dark:bg-verse-900/40 border-verse-200 dark:border-verse-800 text-verse-700 dark:text-verse-200 cursor-pointer hover:border-verse-400 dark:hover:border-verse-600 transition-colors"
+          >
+            Custom
+            <input
+              type="color"
+              :value="form.logoBg || '#ffffff'"
+              class="w-5 h-5 rounded cursor-pointer border-0 p-0"
+              @input="form.logoBg = ($event.target as HTMLInputElement).value"
+            />
+          </label>
+          <span
+            v-if="form.logoBg && !['#ffffff', '#111827', ''].includes(form.logoBg)"
+            class="text-xs font-mono text-verse-500 dark:text-verse-400"
+          >
+            {{ form.logoBg }}
+          </span>
+        </div>
+      </div>
+    </AdminCard>
+
+    <AdminCard title="Tags & status">
+      <div class="space-y-5">
+        <div>
+          <span class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-2">
+            Sponsor types
+          </span>
+          <div class="flex flex-wrap gap-1.5">
+            <button
+              v-for="type in sponsorTypeOptions"
+              :key="type"
+              type="button"
+              :class="[
+                'px-3 py-1.5 rounded-full text-sm font-medium border transition-colors capitalize',
+                form.sponsorTypes.includes(type)
+                  ? 'bg-verse-900 dark:bg-verse-50 border-verse-900 dark:border-verse-50 text-white dark:text-verse-900'
+                  : 'bg-white dark:bg-verse-900/40 border-verse-200 dark:border-verse-800 text-verse-700 dark:text-verse-200 hover:border-verse-400 dark:hover:border-verse-600',
+              ]"
+              @click="toggleSponsorType(type)"
+            >
+              {{ type }}
+            </button>
+          </div>
+        </div>
+
+        <AdminSelect v-model="form.status" label="Status">
+          <option value="active">Active</option>
+          <option value="inactive">Inactive</option>
+        </AdminSelect>
+      </div>
+    </AdminCard>
+  </div>
+</template>

--- a/packages/frontendmu-adonis/inertia/components/admin/ui/AdminAvatar.vue
+++ b/packages/frontendmu-adonis/inertia/components/admin/ui/AdminAvatar.vue
@@ -1,0 +1,69 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+
+const props = withDefaults(
+  defineProps<{
+    src?: string | null
+    name?: string | null
+    size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl'
+    rounded?: 'full' | 'lg' | 'xl' | '2xl'
+  }>(),
+  {
+    src: null,
+    name: '',
+    size: 'md',
+    rounded: 'full',
+  }
+)
+
+const sizeClasses = computed(() => {
+  switch (props.size) {
+    case 'xs':
+      return 'w-7 h-7 text-[10px]'
+    case 'sm':
+      return 'w-9 h-9 text-xs'
+    case 'md':
+      return 'w-10 h-10 text-sm'
+    case 'lg':
+      return 'w-14 h-14 text-base'
+    case 'xl':
+      return 'w-20 h-20 text-lg'
+  }
+})
+
+const roundedClasses = computed(() => {
+  switch (props.rounded) {
+    case 'full':
+      return 'rounded-full'
+    case 'lg':
+      return 'rounded-lg'
+    case 'xl':
+      return 'rounded-xl'
+    case '2xl':
+      return 'rounded-2xl'
+  }
+})
+
+const initial = computed(() => (props.name?.trim()?.charAt(0).toUpperCase() ?? '?'))
+</script>
+
+<template>
+  <img
+    v-if="src"
+    :src="src"
+    :alt="name ?? ''"
+    loading="lazy"
+    :class="[sizeClasses, roundedClasses, 'object-cover bg-verse-100 dark:bg-verse-800 shrink-0']"
+  />
+  <div
+    v-else
+    :class="[
+      sizeClasses,
+      roundedClasses,
+      'bg-verse-100 dark:bg-verse-800 text-verse-700 dark:text-verse-200 flex items-center justify-center font-semibold shrink-0',
+    ]"
+    :aria-label="name ?? 'avatar'"
+  >
+    {{ initial }}
+  </div>
+</template>

--- a/packages/frontendmu-adonis/inertia/components/admin/ui/AdminBadge.vue
+++ b/packages/frontendmu-adonis/inertia/components/admin/ui/AdminBadge.vue
@@ -1,0 +1,73 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+
+type Tone =
+  | 'neutral'
+  | 'success'
+  | 'warning'
+  | 'danger'
+  | 'info'
+  | 'accent'
+  | 'muted'
+
+const props = withDefaults(
+  defineProps<{
+    tone?: Tone
+    dot?: boolean
+  }>(),
+  {
+    tone: 'neutral',
+    dot: false,
+  }
+)
+
+const toneClasses = computed(() => {
+  switch (props.tone) {
+    case 'success':
+      return 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300'
+    case 'warning':
+      return 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300'
+    case 'danger':
+      return 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300'
+    case 'info':
+      return 'bg-sky-100 text-sky-800 dark:bg-sky-900/30 dark:text-sky-300'
+    case 'accent':
+      return 'bg-coral-soft text-coral-deep dark:bg-coral-strong/15 dark:text-coral-strong'
+    case 'muted':
+      return 'bg-verse-100 text-verse-600 dark:bg-verse-800 dark:text-verse-400'
+    default:
+      return 'bg-verse-100 text-verse-700 dark:bg-verse-800 dark:text-verse-200'
+  }
+})
+
+const dotClasses = computed(() => {
+  switch (props.tone) {
+    case 'success':
+      return 'bg-emerald-500'
+    case 'warning':
+      return 'bg-amber-500'
+    case 'danger':
+      return 'bg-red-500'
+    case 'info':
+      return 'bg-sky-500'
+    case 'accent':
+      return 'bg-coral-strong'
+    case 'muted':
+      return 'bg-verse-400'
+    default:
+      return 'bg-verse-500'
+  }
+})
+</script>
+
+<template>
+  <span
+    :class="[
+      'inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-[11px] font-medium capitalize',
+      toneClasses,
+    ]"
+  >
+    <span v-if="dot" :class="['w-1.5 h-1.5 rounded-full', dotClasses]" aria-hidden="true" />
+    <slot />
+  </span>
+</template>

--- a/packages/frontendmu-adonis/inertia/components/admin/ui/AdminBadge.vue
+++ b/packages/frontendmu-adonis/inertia/components/admin/ui/AdminBadge.vue
@@ -34,7 +34,7 @@ const toneClasses = computed(() => {
     case 'accent':
       return 'bg-coral-soft text-coral-deep dark:bg-coral-strong/15 dark:text-coral-strong'
     case 'muted':
-      return 'bg-verse-100 text-verse-600 dark:bg-verse-800 dark:text-verse-400'
+      return 'bg-verse-100 text-verse-600 dark:bg-verse-800 dark:text-verse-300'
     default:
       return 'bg-verse-100 text-verse-700 dark:bg-verse-800 dark:text-verse-200'
   }

--- a/packages/frontendmu-adonis/inertia/components/admin/ui/AdminBreadcrumb.vue
+++ b/packages/frontendmu-adonis/inertia/components/admin/ui/AdminBreadcrumb.vue
@@ -1,0 +1,28 @@
+<script setup lang="ts">
+import { Link } from '@inertiajs/vue3'
+
+interface Crumb {
+  label: string
+  href?: string
+}
+
+defineProps<{
+  trail: Crumb[]
+}>()
+</script>
+
+<template>
+  <nav aria-label="Breadcrumb" class="mono-eyebrow flex flex-wrap items-center gap-2">
+    <template v-for="(crumb, index) in trail" :key="`${index}-${crumb.label}`">
+      <Link
+        v-if="crumb.href && index < trail.length - 1"
+        :href="crumb.href"
+        class="hover:text-verse-700 dark:hover:text-verse-200 transition-colors"
+      >
+        {{ crumb.label }}
+      </Link>
+      <span v-else class="text-verse-700 dark:text-verse-200">{{ crumb.label }}</span>
+      <span v-if="index < trail.length - 1" class="sep" aria-hidden="true">/</span>
+    </template>
+  </nav>
+</template>

--- a/packages/frontendmu-adonis/inertia/components/admin/ui/AdminButton.vue
+++ b/packages/frontendmu-adonis/inertia/components/admin/ui/AdminButton.vue
@@ -44,7 +44,7 @@ const variantClasses = computed(() => {
     case 'secondary':
       return 'bg-white dark:bg-verse-900/40 text-verse-700 dark:text-verse-200 border border-verse-200 dark:border-verse-800 hover:border-verse-400 dark:hover:border-verse-600 hover:bg-verse-50 dark:hover:bg-verse-900'
     case 'ghost':
-      return 'bg-transparent text-verse-600 dark:text-verse-400 hover:text-verse-900 dark:hover:text-verse-100 hover:bg-verse-100/60 dark:hover:bg-verse-800/60 border border-transparent'
+      return 'bg-transparent text-verse-600 dark:text-verse-300 hover:text-verse-900 dark:hover:text-verse-100 hover:bg-verse-100/60 dark:hover:bg-verse-800/60 border border-transparent'
     case 'danger':
       return 'bg-red-600 hover:bg-red-700 text-white border border-red-600 hover:border-red-700'
     case 'subtle':

--- a/packages/frontendmu-adonis/inertia/components/admin/ui/AdminButton.vue
+++ b/packages/frontendmu-adonis/inertia/components/admin/ui/AdminButton.vue
@@ -1,0 +1,125 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { Link } from '@inertiajs/vue3'
+
+type Variant = 'primary' | 'secondary' | 'ghost' | 'danger' | 'subtle'
+type Size = 'sm' | 'md'
+
+const props = withDefaults(
+  defineProps<{
+    variant?: Variant
+    size?: Size
+    href?: string
+    type?: 'button' | 'submit' | 'reset'
+    disabled?: boolean
+    loading?: boolean
+    external?: boolean
+    iconOnly?: boolean
+    title?: string
+  }>(),
+  {
+    variant: 'secondary',
+    size: 'md',
+    href: undefined,
+    type: 'button',
+    disabled: false,
+    loading: false,
+    external: false,
+    iconOnly: false,
+    title: undefined,
+  }
+)
+
+const sizeClasses = computed(() => {
+  if (props.iconOnly) {
+    return props.size === 'sm' ? 'p-1.5' : 'p-2'
+  }
+  return props.size === 'sm' ? 'px-3 py-1.5 text-xs' : 'px-4 py-2 text-sm'
+})
+
+const variantClasses = computed(() => {
+  switch (props.variant) {
+    case 'primary':
+      return 'bg-verse-900 dark:bg-verse-50 text-white dark:text-verse-900 hover:bg-verse-800 dark:hover:bg-white border border-verse-900 dark:border-verse-50'
+    case 'secondary':
+      return 'bg-white dark:bg-verse-900/40 text-verse-700 dark:text-verse-200 border border-verse-200 dark:border-verse-800 hover:border-verse-400 dark:hover:border-verse-600 hover:bg-verse-50 dark:hover:bg-verse-900'
+    case 'ghost':
+      return 'bg-transparent text-verse-600 dark:text-verse-400 hover:text-verse-900 dark:hover:text-verse-100 hover:bg-verse-100/60 dark:hover:bg-verse-800/60 border border-transparent'
+    case 'danger':
+      return 'bg-red-600 hover:bg-red-700 text-white border border-red-600 hover:border-red-700'
+    case 'subtle':
+      return 'bg-verse-100 dark:bg-verse-800 text-verse-700 dark:text-verse-200 border border-transparent hover:bg-verse-200 dark:hover:bg-verse-700'
+  }
+})
+
+const classes = computed(() => [
+  'inline-flex items-center justify-center gap-2 rounded-lg font-medium transition-colors',
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-verse-500/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-verse-950',
+  'disabled:opacity-50 disabled:cursor-not-allowed',
+  sizeClasses.value,
+  variantClasses.value,
+])
+</script>
+
+<template>
+  <a
+    v-if="href && external"
+    :href="href"
+    target="_blank"
+    rel="noopener noreferrer"
+    :class="classes"
+    :title="title"
+    :aria-label="iconOnly ? title : undefined"
+  >
+    <svg
+      v-if="loading"
+      class="w-4 h-4 animate-spin"
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-hidden="true"
+    >
+      <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+      <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z" />
+    </svg>
+    <slot />
+  </a>
+  <Link
+    v-else-if="href"
+    :href="href"
+    :class="classes"
+    :title="title"
+    :aria-label="iconOnly ? title : undefined"
+  >
+    <svg
+      v-if="loading"
+      class="w-4 h-4 animate-spin"
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-hidden="true"
+    >
+      <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+      <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z" />
+    </svg>
+    <slot />
+  </Link>
+  <button
+    v-else
+    :type="type"
+    :disabled="disabled || loading"
+    :class="classes"
+    :title="title"
+    :aria-label="iconOnly ? title : undefined"
+  >
+    <svg
+      v-if="loading"
+      class="w-4 h-4 animate-spin"
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-hidden="true"
+    >
+      <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+      <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z" />
+    </svg>
+    <slot />
+  </button>
+</template>

--- a/packages/frontendmu-adonis/inertia/components/admin/ui/AdminCard.vue
+++ b/packages/frontendmu-adonis/inertia/components/admin/ui/AdminCard.vue
@@ -1,0 +1,61 @@
+<script setup lang="ts">
+withDefaults(
+  defineProps<{
+    title?: string
+    description?: string
+    padded?: boolean
+    interactive?: boolean
+  }>(),
+  {
+    title: undefined,
+    description: undefined,
+    padded: true,
+    interactive: false,
+  }
+)
+</script>
+
+<template>
+  <div
+    :class="[
+      'bg-white dark:bg-verse-900/50 squircle rounded-2xl border border-verse-200 dark:border-verse-800',
+      interactive && 'hover:border-verse-300 dark:hover:border-verse-700 transition-colors',
+    ]"
+  >
+    <div
+      v-if="title || $slots.header"
+      class="flex flex-wrap items-start justify-between gap-3 px-5 sm:px-6 pt-5 sm:pt-6"
+      :class="!$slots.default && !padded ? 'pb-5 sm:pb-6' : ''"
+    >
+      <div class="min-w-0">
+        <h2 v-if="title" class="text-base font-semibold text-verse-900 dark:text-verse-50">
+          {{ title }}
+        </h2>
+        <p v-if="description" class="text-sm text-verse-500 dark:text-verse-400 mt-1">
+          {{ description }}
+        </p>
+        <slot name="header" />
+      </div>
+      <div v-if="$slots.headerActions" class="shrink-0">
+        <slot name="headerActions" />
+      </div>
+    </div>
+
+    <div
+      v-if="$slots.default"
+      :class="[
+        padded ? 'px-5 sm:px-6 pb-5 sm:pb-6' : '',
+        (title || $slots.header) && padded ? 'pt-4' : padded ? 'pt-5 sm:pt-6' : '',
+      ]"
+    >
+      <slot />
+    </div>
+
+    <div
+      v-if="$slots.footer"
+      class="flex items-center justify-between gap-3 px-5 sm:px-6 py-4 border-t border-verse-100 dark:border-verse-800"
+    >
+      <slot name="footer" />
+    </div>
+  </div>
+</template>

--- a/packages/frontendmu-adonis/inertia/components/admin/ui/AdminCard.vue
+++ b/packages/frontendmu-adonis/inertia/components/admin/ui/AdminCard.vue
@@ -31,7 +31,7 @@ withDefaults(
         <h2 v-if="title" class="text-base font-semibold text-verse-900 dark:text-verse-50">
           {{ title }}
         </h2>
-        <p v-if="description" class="text-sm text-verse-500 dark:text-verse-400 mt-1">
+        <p v-if="description" class="text-sm text-verse-500 dark:text-verse-300 mt-1">
           {{ description }}
         </p>
         <slot name="header" />

--- a/packages/frontendmu-adonis/inertia/components/admin/ui/AdminCheckbox.vue
+++ b/packages/frontendmu-adonis/inertia/components/admin/ui/AdminCheckbox.vue
@@ -48,7 +48,7 @@ const fieldId = computed(() => props.id || `cb-${Math.random().toString(36).slic
       <span v-if="label" class="block text-sm font-medium text-verse-900 dark:text-verse-100">
         {{ label }}
       </span>
-      <span v-if="description" class="block text-xs text-verse-500 dark:text-verse-400 mt-0.5">
+      <span v-if="description" class="block text-xs text-verse-500 dark:text-verse-300 mt-0.5">
         {{ description }}
       </span>
       <slot />

--- a/packages/frontendmu-adonis/inertia/components/admin/ui/AdminCheckbox.vue
+++ b/packages/frontendmu-adonis/inertia/components/admin/ui/AdminCheckbox.vue
@@ -1,0 +1,57 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+
+const props = withDefaults(
+  defineProps<{
+    modelValue?: boolean
+    label?: string
+    description?: string
+    disabled?: boolean
+    id?: string
+  }>(),
+  {
+    modelValue: false,
+    label: undefined,
+    description: undefined,
+    disabled: false,
+    id: undefined,
+  }
+)
+
+const emit = defineEmits<{
+  'update:modelValue': [value: boolean]
+}>()
+
+const fieldId = computed(() => props.id || `cb-${Math.random().toString(36).slice(2, 9)}`)
+</script>
+
+<template>
+  <label
+    :for="fieldId"
+    :class="[
+      'flex items-start gap-3 p-3.5 rounded-lg border cursor-pointer transition-colors',
+      modelValue
+        ? 'border-verse-400 dark:border-verse-600 bg-verse-50/50 dark:bg-verse-900/40'
+        : 'border-verse-200 dark:border-verse-800 hover:border-verse-300 dark:hover:border-verse-700',
+      disabled && 'opacity-50 cursor-not-allowed',
+    ]"
+  >
+    <input
+      :id="fieldId"
+      type="checkbox"
+      :checked="modelValue"
+      :disabled="disabled"
+      class="mt-0.5 h-4 w-4 text-verse-600 border-verse-300 dark:border-verse-700 rounded focus:ring-verse-500 cursor-pointer"
+      @change="emit('update:modelValue', ($event.target as HTMLInputElement).checked)"
+    />
+    <span class="min-w-0">
+      <span v-if="label" class="block text-sm font-medium text-verse-900 dark:text-verse-100">
+        {{ label }}
+      </span>
+      <span v-if="description" class="block text-xs text-verse-500 dark:text-verse-400 mt-0.5">
+        {{ description }}
+      </span>
+      <slot />
+    </span>
+  </label>
+</template>

--- a/packages/frontendmu-adonis/inertia/components/admin/ui/AdminConfirmModal.vue
+++ b/packages/frontendmu-adonis/inertia/components/admin/ui/AdminConfirmModal.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted, onUnmounted, watch } from 'vue'
+import { nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 
 const props = withDefaults(
   defineProps<{
@@ -25,6 +25,8 @@ const emit = defineEmits<{
   confirm: []
 }>()
 
+const confirmButton = ref<HTMLButtonElement | null>(null)
+
 function onKey(event: KeyboardEvent) {
   if (event.key === 'Escape' && props.open && !props.loading) emit('cancel')
 }
@@ -33,6 +35,9 @@ watch(
   () => props.open,
   (open) => {
     document.body.style.overflow = open ? 'hidden' : ''
+    if (open) {
+      nextTick(() => confirmButton.value?.focus())
+    }
   }
 )
 
@@ -72,13 +77,13 @@ onUnmounted(() => {
         >
           <div class="p-5 sm:p-6">
             <h3 class="text-lg font-semibold text-verse-900 dark:text-verse-50">{{ title }}</h3>
-            <p
+            <div
               v-if="description || $slots.default"
               class="mt-2 text-sm text-verse-600 dark:text-verse-300"
             >
-              <template v-if="description">{{ description }}</template>
+              <p v-if="description">{{ description }}</p>
               <slot />
-            </p>
+            </div>
           </div>
           <div
             class="flex flex-col-reverse sm:flex-row sm:justify-end gap-2 px-5 sm:px-6 pb-5 sm:pb-6"
@@ -92,13 +97,15 @@ onUnmounted(() => {
               {{ cancelLabel }}
             </button>
             <button
+              ref="confirmButton"
               type="button"
               :disabled="loading"
               :class="[
                 'inline-flex items-center justify-center px-4 py-2 text-sm font-medium rounded-lg text-white transition-colors disabled:opacity-50',
+                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-verse-900',
                 confirmVariant === 'danger'
-                  ? 'bg-red-600 hover:bg-red-700'
-                  : 'bg-verse-900 hover:bg-verse-800 dark:bg-verse-50 dark:text-verse-900 dark:hover:bg-white',
+                  ? 'bg-red-600 hover:bg-red-700 focus-visible:ring-red-500/60'
+                  : 'bg-verse-900 hover:bg-verse-800 dark:bg-verse-50 dark:text-verse-900 dark:hover:bg-white focus-visible:ring-verse-500/60',
               ]"
               @click="emit('confirm')"
             >

--- a/packages/frontendmu-adonis/inertia/components/admin/ui/AdminConfirmModal.vue
+++ b/packages/frontendmu-adonis/inertia/components/admin/ui/AdminConfirmModal.vue
@@ -74,7 +74,7 @@ onUnmounted(() => {
             <h3 class="text-lg font-semibold text-verse-900 dark:text-verse-50">{{ title }}</h3>
             <p
               v-if="description || $slots.default"
-              class="mt-2 text-sm text-verse-600 dark:text-verse-400"
+              class="mt-2 text-sm text-verse-600 dark:text-verse-300"
             >
               <template v-if="description">{{ description }}</template>
               <slot />

--- a/packages/frontendmu-adonis/inertia/components/admin/ui/AdminConfirmModal.vue
+++ b/packages/frontendmu-adonis/inertia/components/admin/ui/AdminConfirmModal.vue
@@ -1,0 +1,113 @@
+<script setup lang="ts">
+import { onMounted, onUnmounted, watch } from 'vue'
+
+const props = withDefaults(
+  defineProps<{
+    open: boolean
+    title: string
+    description?: string
+    confirmLabel?: string
+    cancelLabel?: string
+    confirmVariant?: 'primary' | 'danger'
+    loading?: boolean
+  }>(),
+  {
+    description: undefined,
+    confirmLabel: 'Confirm',
+    cancelLabel: 'Cancel',
+    confirmVariant: 'danger',
+    loading: false,
+  }
+)
+
+const emit = defineEmits<{
+  cancel: []
+  confirm: []
+}>()
+
+function onKey(event: KeyboardEvent) {
+  if (event.key === 'Escape' && props.open && !props.loading) emit('cancel')
+}
+
+watch(
+  () => props.open,
+  (open) => {
+    document.body.style.overflow = open ? 'hidden' : ''
+  }
+)
+
+onMounted(() => {
+  window.addEventListener('keydown', onKey)
+})
+
+onUnmounted(() => {
+  window.removeEventListener('keydown', onKey)
+  document.body.style.overflow = ''
+})
+</script>
+
+<template>
+  <Teleport to="body">
+    <Transition
+      enter-active-class="transition-opacity duration-150"
+      enter-from-class="opacity-0"
+      enter-to-class="opacity-100"
+      leave-active-class="transition-opacity duration-100"
+      leave-from-class="opacity-100"
+      leave-to-class="opacity-0"
+    >
+      <div
+        v-if="open"
+        class="fixed inset-0 z-50 flex items-end sm:items-center justify-center p-4 sm:p-6"
+        role="dialog"
+        aria-modal="true"
+        :aria-label="title"
+      >
+        <div
+          class="absolute inset-0 bg-verse-950/60 backdrop-blur-sm"
+          @click="!loading && emit('cancel')"
+        />
+        <div
+          class="relative w-full sm:max-w-md bg-white dark:bg-verse-900 squircle rounded-2xl border border-verse-200 dark:border-verse-800 shadow-xl"
+        >
+          <div class="p-5 sm:p-6">
+            <h3 class="text-lg font-semibold text-verse-900 dark:text-verse-50">{{ title }}</h3>
+            <p
+              v-if="description || $slots.default"
+              class="mt-2 text-sm text-verse-600 dark:text-verse-400"
+            >
+              <template v-if="description">{{ description }}</template>
+              <slot />
+            </p>
+          </div>
+          <div
+            class="flex flex-col-reverse sm:flex-row sm:justify-end gap-2 px-5 sm:px-6 pb-5 sm:pb-6"
+          >
+            <button
+              type="button"
+              :disabled="loading"
+              class="inline-flex items-center justify-center px-4 py-2 text-sm font-medium rounded-lg border border-verse-200 dark:border-verse-700 text-verse-700 dark:text-verse-200 hover:bg-verse-50 dark:hover:bg-verse-800 transition-colors disabled:opacity-50"
+              @click="emit('cancel')"
+            >
+              {{ cancelLabel }}
+            </button>
+            <button
+              type="button"
+              :disabled="loading"
+              :class="[
+                'inline-flex items-center justify-center px-4 py-2 text-sm font-medium rounded-lg text-white transition-colors disabled:opacity-50',
+                confirmVariant === 'danger'
+                  ? 'bg-red-600 hover:bg-red-700'
+                  : 'bg-verse-900 hover:bg-verse-800 dark:bg-verse-50 dark:text-verse-900 dark:hover:bg-white',
+              ]"
+              @click="emit('confirm')"
+            >
+              <span v-if="loading">Working...</span>
+              <span v-else>{{ confirmLabel }}</span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>

--- a/packages/frontendmu-adonis/inertia/components/admin/ui/AdminEmptyState.vue
+++ b/packages/frontendmu-adonis/inertia/components/admin/ui/AdminEmptyState.vue
@@ -1,0 +1,48 @@
+<script setup lang="ts">
+withDefaults(
+  defineProps<{
+    title: string
+    description?: string
+    icon?: string
+  }>(),
+  {
+    description: undefined,
+    icon: undefined,
+  }
+)
+</script>
+
+<template>
+  <div class="px-6 py-16 text-center">
+    <div
+      v-if="icon || $slots.icon"
+      class="mx-auto mb-4 w-12 h-12 rounded-2xl bg-verse-100 dark:bg-verse-800 flex items-center justify-center text-verse-400"
+    >
+      <slot name="icon">
+        <svg
+          v-if="icon"
+          class="w-6 h-6"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.75"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <path :d="icon" />
+        </svg>
+      </slot>
+    </div>
+    <h3 class="text-base font-semibold text-verse-900 dark:text-verse-100">{{ title }}</h3>
+    <p
+      v-if="description"
+      class="mt-1.5 text-sm text-verse-500 dark:text-verse-400 max-w-md mx-auto"
+    >
+      {{ description }}
+    </p>
+    <div v-if="$slots.actions" class="mt-5 flex flex-wrap justify-center gap-2">
+      <slot name="actions" />
+    </div>
+  </div>
+</template>

--- a/packages/frontendmu-adonis/inertia/components/admin/ui/AdminEmptyState.vue
+++ b/packages/frontendmu-adonis/inertia/components/admin/ui/AdminEmptyState.vue
@@ -37,7 +37,7 @@ withDefaults(
     <h3 class="text-base font-semibold text-verse-900 dark:text-verse-100">{{ title }}</h3>
     <p
       v-if="description"
-      class="mt-1.5 text-sm text-verse-500 dark:text-verse-400 max-w-md mx-auto"
+      class="mt-1.5 text-sm text-verse-500 dark:text-verse-300 max-w-md mx-auto"
     >
       {{ description }}
     </p>

--- a/packages/frontendmu-adonis/inertia/components/admin/ui/AdminFilterChips.vue
+++ b/packages/frontendmu-adonis/inertia/components/admin/ui/AdminFilterChips.vue
@@ -44,7 +44,7 @@ const emit = defineEmits<{
           'inline-flex items-center justify-center min-w-[1.25rem] px-1 text-[10px] font-mono rounded-full',
           modelValue === chip.key
             ? 'bg-white/20 dark:bg-verse-900/20 text-white dark:text-verse-900'
-            : 'bg-verse-100 dark:bg-verse-800 text-verse-500 dark:text-verse-400',
+            : 'bg-verse-100 dark:bg-verse-800 text-verse-500 dark:text-verse-300',
         ]"
       >
         {{ chip.count }}

--- a/packages/frontendmu-adonis/inertia/components/admin/ui/AdminFilterChips.vue
+++ b/packages/frontendmu-adonis/inertia/components/admin/ui/AdminFilterChips.vue
@@ -22,13 +22,12 @@ const emit = defineEmits<{
 </script>
 
 <template>
-  <div :aria-label="ariaLabel" role="tablist" class="flex flex-wrap gap-1.5">
+  <div :aria-label="ariaLabel" role="group" class="flex flex-wrap gap-1.5">
     <button
       v-for="chip in chips"
       :key="chip.key"
       type="button"
-      role="tab"
-      :aria-selected="modelValue === chip.key"
+      :aria-pressed="modelValue === chip.key"
       :class="[
         'inline-flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium border transition-colors',
         modelValue === chip.key

--- a/packages/frontendmu-adonis/inertia/components/admin/ui/AdminFilterChips.vue
+++ b/packages/frontendmu-adonis/inertia/components/admin/ui/AdminFilterChips.vue
@@ -1,0 +1,54 @@
+<script setup lang="ts">
+interface Chip {
+  key: string
+  label: string
+  count?: number
+}
+
+withDefaults(
+  defineProps<{
+    chips: Chip[]
+    modelValue: string
+    ariaLabel?: string
+  }>(),
+  {
+    ariaLabel: 'Filter',
+  }
+)
+
+const emit = defineEmits<{
+  'update:modelValue': [value: string]
+}>()
+</script>
+
+<template>
+  <div :aria-label="ariaLabel" role="tablist" class="flex flex-wrap gap-1.5">
+    <button
+      v-for="chip in chips"
+      :key="chip.key"
+      type="button"
+      role="tab"
+      :aria-selected="modelValue === chip.key"
+      :class="[
+        'inline-flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium border transition-colors',
+        modelValue === chip.key
+          ? 'bg-verse-900 dark:bg-verse-50 border-verse-900 dark:border-verse-50 text-white dark:text-verse-900'
+          : 'bg-white dark:bg-verse-900/40 border-verse-200 dark:border-verse-800 text-verse-700 dark:text-verse-200 hover:border-verse-400 dark:hover:border-verse-600',
+      ]"
+      @click="emit('update:modelValue', chip.key)"
+    >
+      <span>{{ chip.label }}</span>
+      <span
+        v-if="chip.count !== undefined"
+        :class="[
+          'inline-flex items-center justify-center min-w-[1.25rem] px-1 text-[10px] font-mono rounded-full',
+          modelValue === chip.key
+            ? 'bg-white/20 dark:bg-verse-900/20 text-white dark:text-verse-900'
+            : 'bg-verse-100 dark:bg-verse-800 text-verse-500 dark:text-verse-400',
+        ]"
+      >
+        {{ chip.count }}
+      </span>
+    </button>
+  </div>
+</template>

--- a/packages/frontendmu-adonis/inertia/components/admin/ui/AdminInput.vue
+++ b/packages/frontendmu-adonis/inertia/components/admin/ui/AdminInput.vue
@@ -1,0 +1,90 @@
+<script setup lang="ts">
+import { computed, useAttrs } from 'vue'
+
+defineOptions({ inheritAttrs: false })
+
+const props = withDefaults(
+  defineProps<{
+    modelValue?: string | number | null
+    type?: string
+    error?: string
+    hint?: string
+    label?: string
+    required?: boolean
+    leadingText?: string
+    id?: string
+  }>(),
+  {
+    modelValue: '',
+    type: 'text',
+    error: undefined,
+    hint: undefined,
+    label: undefined,
+    required: false,
+    leadingText: undefined,
+    id: undefined,
+  }
+)
+
+const emit = defineEmits<{
+  'update:modelValue': [value: string | number | null]
+}>()
+
+const attrs = useAttrs()
+
+const fieldId = computed(() => props.id || `field-${Math.random().toString(36).slice(2, 9)}`)
+
+function onInput(event: Event) {
+  const target = event.target as HTMLInputElement
+  if (props.type === 'number') {
+    const num = target.value === '' ? null : Number(target.value)
+    emit('update:modelValue', Number.isNaN(num as number) ? null : num)
+  } else {
+    emit('update:modelValue', target.value)
+  }
+}
+</script>
+
+<template>
+  <div>
+    <label
+      v-if="label"
+      :for="fieldId"
+      class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-1.5"
+    >
+      {{ label }}
+      <span v-if="required" class="text-red-500" aria-hidden="true">*</span>
+    </label>
+    <div class="relative">
+      <span
+        v-if="leadingText"
+        class="absolute inset-y-0 left-0 inline-flex items-center px-3 text-sm text-verse-500 dark:text-verse-400 border-r border-verse-200 dark:border-verse-700 bg-verse-50/60 dark:bg-verse-900/40 rounded-l-lg pointer-events-none"
+      >
+        {{ leadingText }}
+      </span>
+      <input
+        :id="fieldId"
+        :type="type"
+        :value="modelValue ?? ''"
+        v-bind="attrs"
+        :class="[
+          'w-full rounded-lg border bg-white dark:bg-verse-900/40 text-verse-900 dark:text-verse-100 placeholder-verse-400 dark:placeholder-verse-500',
+          'focus:outline-none focus:ring-2 focus:ring-verse-500/40 focus:border-verse-500 transition-colors',
+          'px-3.5 py-2 text-sm',
+          leadingText ? 'pl-[3.5rem]' : '',
+          error
+            ? 'border-red-300 dark:border-red-800 focus:border-red-500 focus:ring-red-500/40'
+            : 'border-verse-200 dark:border-verse-800',
+        ]"
+        @input="onInput"
+      />
+    </div>
+    <p v-if="error" class="mt-1.5 text-xs text-red-600 dark:text-red-400">{{ error }}</p>
+    <p
+      v-else-if="hint"
+      class="mt-1.5 text-xs text-verse-500 dark:text-verse-400"
+    >
+      {{ hint }}
+    </p>
+  </div>
+</template>

--- a/packages/frontendmu-adonis/inertia/components/admin/ui/AdminInput.vue
+++ b/packages/frontendmu-adonis/inertia/components/admin/ui/AdminInput.vue
@@ -58,7 +58,7 @@ function onInput(event: Event) {
     <div class="relative">
       <span
         v-if="leadingText"
-        class="absolute inset-y-0 left-0 inline-flex items-center px-3 text-sm text-verse-500 dark:text-verse-400 border-r border-verse-200 dark:border-verse-700 bg-verse-50/60 dark:bg-verse-900/40 rounded-l-lg pointer-events-none"
+        class="absolute inset-y-0 left-0 inline-flex items-center px-3 text-sm text-verse-500 dark:text-verse-300 border-r border-verse-200 dark:border-verse-700 bg-verse-50/60 dark:bg-verse-900/40 rounded-l-lg pointer-events-none"
       >
         {{ leadingText }}
       </span>
@@ -82,7 +82,7 @@ function onInput(event: Event) {
     <p v-if="error" class="mt-1.5 text-xs text-red-600 dark:text-red-400">{{ error }}</p>
     <p
       v-else-if="hint"
-      class="mt-1.5 text-xs text-verse-500 dark:text-verse-400"
+      class="mt-1.5 text-xs text-verse-500 dark:text-verse-300"
     >
       {{ hint }}
     </p>

--- a/packages/frontendmu-adonis/inertia/components/admin/ui/AdminNav.vue
+++ b/packages/frontendmu-adonis/inertia/components/admin/ui/AdminNav.vue
@@ -118,7 +118,7 @@ const icons: Record<string, string> = {
               'group relative flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium transition-colors',
               item.match(currentPath)
                 ? 'bg-verse-100 dark:bg-verse-800/70 text-verse-900 dark:text-verse-50'
-                : 'text-verse-600 dark:text-verse-400 hover:bg-verse-50 dark:hover:bg-verse-900/40 hover:text-verse-900 dark:hover:text-verse-100',
+                : 'text-verse-600 dark:text-verse-300 hover:bg-verse-50 dark:hover:bg-verse-900/40 hover:text-verse-900 dark:hover:text-verse-100',
             ]"
           >
             <span

--- a/packages/frontendmu-adonis/inertia/components/admin/ui/AdminNav.vue
+++ b/packages/frontendmu-adonis/inertia/components/admin/ui/AdminNav.vue
@@ -1,0 +1,147 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { Link, usePage } from '@inertiajs/vue3'
+import type { Data } from '@generated/data'
+import { useAuth } from '~/composables/use_auth'
+
+interface NavItem {
+  label: string
+  href: string
+  match: (path: string) => boolean
+  icon: string
+  superadminOnly?: boolean
+}
+
+const page = usePage<Data.SharedProps>()
+const { isSuperadmin } = useAuth()
+
+const currentPath = computed(() => {
+  const url = page.url ?? ''
+  return url.split('?')[0] || '/'
+})
+
+const items: NavItem[] = [
+  {
+    label: 'Overview',
+    href: '/admin',
+    match: (p) => p === '/admin' || p === '/admin/',
+    icon: 'overview',
+  },
+  {
+    label: 'Events',
+    href: '/admin/events',
+    match: (p) => p.startsWith('/admin/events'),
+    icon: 'events',
+  },
+  {
+    label: 'Speakers',
+    href: '/admin/speakers',
+    match: (p) => p.startsWith('/admin/speakers'),
+    icon: 'speakers',
+  },
+  {
+    label: 'Sponsors',
+    href: '/admin/sponsors',
+    match: (p) => p.startsWith('/admin/sponsors'),
+    icon: 'sponsors',
+  },
+  {
+    label: 'Users',
+    href: '/admin/users',
+    match: (p) => p.startsWith('/admin/users'),
+    icon: 'users',
+    superadminOnly: true,
+  },
+]
+
+const visibleItems = computed(() =>
+  items.filter((item) => !item.superadminOnly || isSuperadmin.value)
+)
+
+const icons: Record<string, string> = {
+  overview:
+    'M3 12l2-2 4 4 8-8 4 4M3 19h18',
+  events:
+    'M8 2v4M16 2v4M3 10h18M5 4h14a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2z',
+  speakers:
+    'M3 21v-2a4 4 0 0 1 4-4h4a4 4 0 0 1 4 4v2M9 11a4 4 0 1 0 0-8 4 4 0 0 0 0 8zM21 21v-2a4 4 0 0 0-3-3.87M17 3.13a4 4 0 0 1 0 7.75',
+  sponsors:
+    'M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z',
+  users:
+    'M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2M9 11a4 4 0 1 0 0-8 4 4 0 0 0 0 8zM23 21v-2a4 4 0 0 0-3-3.87M19 3.13a4 4 0 0 1 0 7.75',
+}
+</script>
+
+<template>
+  <nav aria-label="Admin sections" class="w-full">
+    <!-- Mobile / tablet: horizontal scroll rail -->
+    <div class="lg:hidden -mx-4 px-4 sm:-mx-6 sm:px-6 overflow-x-auto">
+      <ul class="flex items-center gap-1.5 min-w-max pb-2">
+        <li v-for="item in visibleItems" :key="item.href">
+          <Link
+            :href="item.href"
+            :class="[
+              'inline-flex items-center gap-2 px-3.5 py-2 rounded-full border text-sm font-medium transition-colors whitespace-nowrap',
+              item.match(currentPath)
+                ? 'bg-verse-900 dark:bg-verse-50 border-verse-900 dark:border-verse-50 text-white dark:text-verse-900'
+                : 'bg-white dark:bg-verse-900/40 border-verse-200 dark:border-verse-800 text-verse-700 dark:text-verse-200 hover:border-verse-400 dark:hover:border-verse-600',
+            ]"
+          >
+            <svg
+              class="w-4 h-4"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.75"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <path :d="icons[item.icon]" />
+            </svg>
+            <span>{{ item.label }}</span>
+          </Link>
+        </li>
+      </ul>
+    </div>
+
+    <!-- Desktop: vertical sidebar -->
+    <div class="hidden lg:block">
+      <div class="mono-eyebrow mb-4">
+        <span>Admin</span>
+      </div>
+      <ul class="flex flex-col gap-1">
+        <li v-for="item in visibleItems" :key="item.href">
+          <Link
+            :href="item.href"
+            :class="[
+              'group relative flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium transition-colors',
+              item.match(currentPath)
+                ? 'bg-verse-100 dark:bg-verse-800/70 text-verse-900 dark:text-verse-50'
+                : 'text-verse-600 dark:text-verse-400 hover:bg-verse-50 dark:hover:bg-verse-900/40 hover:text-verse-900 dark:hover:text-verse-100',
+            ]"
+          >
+            <span
+              v-if="item.match(currentPath)"
+              class="absolute -left-2 top-2 bottom-2 w-0.5 rounded-full bg-coral-strong"
+              aria-hidden="true"
+            />
+            <svg
+              class="w-4 h-4 shrink-0"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.75"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <path :d="icons[item.icon]" />
+            </svg>
+            <span>{{ item.label }}</span>
+          </Link>
+        </li>
+      </ul>
+    </div>
+  </nav>
+</template>

--- a/packages/frontendmu-adonis/inertia/components/admin/ui/AdminPageHeader.vue
+++ b/packages/frontendmu-adonis/inertia/components/admin/ui/AdminPageHeader.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+withDefaults(
+  defineProps<{
+    title: string
+    description?: string
+  }>(),
+  {
+    description: undefined,
+  }
+)
+</script>
+
+<template>
+  <header class="flex flex-col gap-5 sm:flex-row sm:items-end sm:justify-between mb-8">
+    <div class="min-w-0 flex items-start gap-4">
+      <div v-if="$slots.media" class="shrink-0">
+        <slot name="media" />
+      </div>
+      <div class="min-w-0">
+        <h1
+          class="font-display text-3xl sm:text-4xl text-verse-900 dark:text-verse-50 leading-tight tracking-tight"
+        >
+          {{ title }}
+        </h1>
+        <p v-if="description" class="text-verse-500 dark:text-verse-400 mt-2 max-w-2xl">
+          {{ description }}
+        </p>
+        <div v-if="$slots.meta" class="mt-3">
+          <slot name="meta" />
+        </div>
+      </div>
+    </div>
+    <div v-if="$slots.actions" class="flex flex-wrap gap-2 shrink-0">
+      <slot name="actions" />
+    </div>
+  </header>
+</template>

--- a/packages/frontendmu-adonis/inertia/components/admin/ui/AdminPageHeader.vue
+++ b/packages/frontendmu-adonis/inertia/components/admin/ui/AdminPageHeader.vue
@@ -22,7 +22,7 @@ withDefaults(
         >
           {{ title }}
         </h1>
-        <p v-if="description" class="text-verse-500 dark:text-verse-400 mt-2 max-w-2xl">
+        <p v-if="description" class="text-verse-500 dark:text-verse-300 mt-2 max-w-2xl">
           {{ description }}
         </p>
         <div v-if="$slots.meta" class="mt-3">

--- a/packages/frontendmu-adonis/inertia/components/admin/ui/AdminSearchInput.vue
+++ b/packages/frontendmu-adonis/inertia/components/admin/ui/AdminSearchInput.vue
@@ -1,0 +1,46 @@
+<script setup lang="ts">
+withDefaults(
+  defineProps<{
+    modelValue?: string
+    placeholder?: string
+    label?: string
+  }>(),
+  {
+    modelValue: '',
+    placeholder: 'Search...',
+    label: 'Search',
+  }
+)
+
+const emit = defineEmits<{
+  'update:modelValue': [value: string]
+  submit: []
+}>()
+</script>
+
+<template>
+  <label class="relative block w-full">
+    <span class="sr-only">{{ label }}</span>
+    <svg
+      class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-verse-400 pointer-events-none"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="11" cy="11" r="8" />
+      <line x1="21" y1="21" x2="16.65" y2="16.65" />
+    </svg>
+    <input
+      type="search"
+      :value="modelValue"
+      :placeholder="placeholder"
+      class="w-full pl-10 pr-3.5 py-2 text-sm bg-white dark:bg-verse-900/40 border border-verse-200 dark:border-verse-800 rounded-lg text-verse-900 dark:text-verse-100 placeholder-verse-400 focus:outline-none focus:ring-2 focus:ring-verse-500/40 focus:border-verse-500 transition-colors"
+      @input="emit('update:modelValue', ($event.target as HTMLInputElement).value)"
+      @keydown.enter.prevent="emit('submit')"
+    />
+  </label>
+</template>

--- a/packages/frontendmu-adonis/inertia/components/admin/ui/AdminSelect.vue
+++ b/packages/frontendmu-adonis/inertia/components/admin/ui/AdminSelect.vue
@@ -73,7 +73,7 @@ const fieldId = computed(() => props.id || `field-${Math.random().toString(36).s
     <p v-if="error" class="mt-1.5 text-xs text-red-600 dark:text-red-400">{{ error }}</p>
     <p
       v-else-if="hint"
-      class="mt-1.5 text-xs text-verse-500 dark:text-verse-400"
+      class="mt-1.5 text-xs text-verse-500 dark:text-verse-300"
     >
       {{ hint }}
     </p>

--- a/packages/frontendmu-adonis/inertia/components/admin/ui/AdminSelect.vue
+++ b/packages/frontendmu-adonis/inertia/components/admin/ui/AdminSelect.vue
@@ -1,0 +1,81 @@
+<script setup lang="ts">
+import { computed, useAttrs } from 'vue'
+
+defineOptions({ inheritAttrs: false })
+
+const props = withDefaults(
+  defineProps<{
+    modelValue?: string | number | null
+    error?: string
+    hint?: string
+    label?: string
+    required?: boolean
+    id?: string
+  }>(),
+  {
+    modelValue: '',
+    error: undefined,
+    hint: undefined,
+    label: undefined,
+    required: false,
+    id: undefined,
+  }
+)
+
+const emit = defineEmits<{
+  'update:modelValue': [value: string]
+}>()
+
+const attrs = useAttrs()
+const fieldId = computed(() => props.id || `field-${Math.random().toString(36).slice(2, 9)}`)
+</script>
+
+<template>
+  <div>
+    <label
+      v-if="label"
+      :for="fieldId"
+      class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-1.5"
+    >
+      {{ label }}
+      <span v-if="required" class="text-red-500" aria-hidden="true">*</span>
+    </label>
+    <div class="relative">
+      <select
+        :id="fieldId"
+        :value="modelValue ?? ''"
+        v-bind="attrs"
+        :class="[
+          'w-full appearance-none rounded-lg border bg-white dark:bg-verse-900/40 text-verse-900 dark:text-verse-100',
+          'focus:outline-none focus:ring-2 focus:ring-verse-500/40 focus:border-verse-500 transition-colors',
+          'px-3.5 py-2 pr-10 text-sm',
+          error
+            ? 'border-red-300 dark:border-red-800 focus:border-red-500 focus:ring-red-500/40'
+            : 'border-verse-200 dark:border-verse-800',
+        ]"
+        @change="emit('update:modelValue', ($event.target as HTMLSelectElement).value)"
+      >
+        <slot />
+      </select>
+      <svg
+        class="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-verse-400 pointer-events-none"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        aria-hidden="true"
+      >
+        <polyline points="6 9 12 15 18 9" />
+      </svg>
+    </div>
+    <p v-if="error" class="mt-1.5 text-xs text-red-600 dark:text-red-400">{{ error }}</p>
+    <p
+      v-else-if="hint"
+      class="mt-1.5 text-xs text-verse-500 dark:text-verse-400"
+    >
+      {{ hint }}
+    </p>
+  </div>
+</template>

--- a/packages/frontendmu-adonis/inertia/components/admin/ui/AdminShell.vue
+++ b/packages/frontendmu-adonis/inertia/components/admin/ui/AdminShell.vue
@@ -1,0 +1,52 @@
+<script setup lang="ts">
+import AdminNav from './AdminNav.vue'
+import AdminBreadcrumb from './AdminBreadcrumb.vue'
+import AdminPageHeader from './AdminPageHeader.vue'
+
+interface Crumb {
+  label: string
+  href?: string
+}
+
+withDefaults(
+  defineProps<{
+    title?: string
+    description?: string
+    breadcrumbs?: Crumb[]
+    /** When true, the page header is omitted (page renders its own custom header inside the body). */
+    bareHeader?: boolean
+  }>(),
+  {
+    title: undefined,
+    description: undefined,
+    breadcrumbs: () => [],
+    bareHeader: false,
+  }
+)
+</script>
+
+<template>
+  <main class="relative min-h-screen pt-32 pb-20">
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+      <div class="flex flex-col lg:flex-row lg:gap-10">
+        <aside class="lg:w-56 lg:shrink-0">
+          <div class="lg:sticky lg:top-32">
+            <AdminNav />
+          </div>
+        </aside>
+
+        <div class="flex-1 min-w-0 mt-6 lg:mt-0">
+          <AdminBreadcrumb v-if="breadcrumbs.length" :trail="breadcrumbs" class="mb-5" />
+
+          <AdminPageHeader v-if="!bareHeader && title" :title="title" :description="description">
+            <template v-if="$slots.media" #media><slot name="media" /></template>
+            <template v-if="$slots.meta" #meta><slot name="meta" /></template>
+            <template v-if="$slots.actions" #actions><slot name="actions" /></template>
+          </AdminPageHeader>
+
+          <slot />
+        </div>
+      </div>
+    </div>
+  </main>
+</template>

--- a/packages/frontendmu-adonis/inertia/components/admin/ui/AdminStatGrid.vue
+++ b/packages/frontendmu-adonis/inertia/components/admin/ui/AdminStatGrid.vue
@@ -29,7 +29,7 @@ const toneClasses: Record<NonNullable<Stat['tone']>, string> = {
       :key="stat.label"
       class="bg-white dark:bg-verse-900/50 squircle rounded-2xl border border-verse-200 dark:border-verse-800 px-4 py-4 sm:px-5 sm:py-5"
     >
-      <div class="text-[11px] font-mono uppercase tracking-[0.14em] text-verse-500 dark:text-verse-400">
+      <div class="text-[11px] font-mono uppercase tracking-[0.14em] text-verse-500 dark:text-verse-300">
         {{ stat.label }}
       </div>
       <div
@@ -40,7 +40,7 @@ const toneClasses: Record<NonNullable<Stat['tone']>, string> = {
       >
         {{ stat.value }}
       </div>
-      <p v-if="stat.hint" class="mt-1 text-xs text-verse-500 dark:text-verse-400">
+      <p v-if="stat.hint" class="mt-1 text-xs text-verse-500 dark:text-verse-300">
         {{ stat.hint }}
       </p>
     </div>

--- a/packages/frontendmu-adonis/inertia/components/admin/ui/AdminStatGrid.vue
+++ b/packages/frontendmu-adonis/inertia/components/admin/ui/AdminStatGrid.vue
@@ -1,0 +1,48 @@
+<script setup lang="ts">
+interface Stat {
+  label: string
+  value: string | number
+  hint?: string
+  tone?: 'default' | 'success' | 'warning' | 'danger' | 'info'
+}
+
+withDefaults(
+  defineProps<{
+    stats: Stat[]
+  }>(),
+  {}
+)
+
+const toneClasses: Record<NonNullable<Stat['tone']>, string> = {
+  default: 'text-verse-900 dark:text-verse-50',
+  success: 'text-emerald-600 dark:text-emerald-400',
+  warning: 'text-amber-600 dark:text-amber-400',
+  danger: 'text-red-600 dark:text-red-400',
+  info: 'text-coral-deep dark:text-coral-strong',
+}
+</script>
+
+<template>
+  <div class="grid grid-cols-2 lg:grid-cols-4 gap-3 sm:gap-4">
+    <div
+      v-for="stat in stats"
+      :key="stat.label"
+      class="bg-white dark:bg-verse-900/50 squircle rounded-2xl border border-verse-200 dark:border-verse-800 px-4 py-4 sm:px-5 sm:py-5"
+    >
+      <div class="text-[11px] font-mono uppercase tracking-[0.14em] text-verse-500 dark:text-verse-400">
+        {{ stat.label }}
+      </div>
+      <div
+        :class="[
+          'mt-1.5 text-3xl font-display tracking-tight',
+          toneClasses[stat.tone ?? 'default'],
+        ]"
+      >
+        {{ stat.value }}
+      </div>
+      <p v-if="stat.hint" class="mt-1 text-xs text-verse-500 dark:text-verse-400">
+        {{ stat.hint }}
+      </p>
+    </div>
+  </div>
+</template>

--- a/packages/frontendmu-adonis/inertia/components/admin/ui/AdminTable.vue
+++ b/packages/frontendmu-adonis/inertia/components/admin/ui/AdminTable.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+withDefaults(
+  defineProps<{
+    columns: { label: string; align?: 'left' | 'right' | 'center'; class?: string }[]
+  }>(),
+  {}
+)
+</script>
+
+<template>
+  <div
+    class="bg-white dark:bg-verse-900/50 squircle rounded-2xl border border-verse-200 dark:border-verse-800 overflow-hidden"
+  >
+    <div class="overflow-x-auto">
+      <table class="w-full text-sm">
+        <thead class="bg-verse-50/60 dark:bg-verse-900/70 border-b border-verse-200 dark:border-verse-800">
+          <tr>
+            <th
+              v-for="col in columns"
+              :key="col.label"
+              :class="[
+                'px-5 py-2.5 text-[11px] font-mono font-semibold uppercase tracking-[0.12em] text-verse-500 dark:text-verse-400',
+                col.align === 'right' ? 'text-right' : col.align === 'center' ? 'text-center' : 'text-left',
+                col.class,
+              ]"
+            >
+              {{ col.label }}
+            </th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-verse-100 dark:divide-verse-800">
+          <slot />
+        </tbody>
+      </table>
+    </div>
+    <slot name="footer" />
+  </div>
+</template>

--- a/packages/frontendmu-adonis/inertia/components/admin/ui/AdminTable.vue
+++ b/packages/frontendmu-adonis/inertia/components/admin/ui/AdminTable.vue
@@ -19,7 +19,7 @@ withDefaults(
               v-for="col in columns"
               :key="col.label"
               :class="[
-                'px-5 py-2.5 text-[11px] font-mono font-semibold uppercase tracking-[0.12em] text-verse-500 dark:text-verse-400',
+                'px-5 py-2.5 text-[11px] font-mono font-semibold uppercase tracking-[0.12em] text-verse-500 dark:text-verse-300',
                 col.align === 'right' ? 'text-right' : col.align === 'center' ? 'text-center' : 'text-left',
                 col.class,
               ]"

--- a/packages/frontendmu-adonis/inertia/components/admin/ui/AdminTextarea.vue
+++ b/packages/frontendmu-adonis/inertia/components/admin/ui/AdminTextarea.vue
@@ -60,7 +60,7 @@ const fieldId = computed(() => props.id || `field-${Math.random().toString(36).s
     <p v-if="error" class="mt-1.5 text-xs text-red-600 dark:text-red-400">{{ error }}</p>
     <p
       v-else-if="hint"
-      class="mt-1.5 text-xs text-verse-500 dark:text-verse-400"
+      class="mt-1.5 text-xs text-verse-500 dark:text-verse-300"
     >
       {{ hint }}
     </p>

--- a/packages/frontendmu-adonis/inertia/components/admin/ui/AdminTextarea.vue
+++ b/packages/frontendmu-adonis/inertia/components/admin/ui/AdminTextarea.vue
@@ -1,0 +1,68 @@
+<script setup lang="ts">
+import { computed, useAttrs } from 'vue'
+
+defineOptions({ inheritAttrs: false })
+
+const props = withDefaults(
+  defineProps<{
+    modelValue?: string
+    error?: string
+    hint?: string
+    label?: string
+    required?: boolean
+    rows?: number
+    id?: string
+  }>(),
+  {
+    modelValue: '',
+    error: undefined,
+    hint: undefined,
+    label: undefined,
+    required: false,
+    rows: 4,
+    id: undefined,
+  }
+)
+
+const emit = defineEmits<{
+  'update:modelValue': [value: string]
+}>()
+
+const attrs = useAttrs()
+const fieldId = computed(() => props.id || `field-${Math.random().toString(36).slice(2, 9)}`)
+</script>
+
+<template>
+  <div>
+    <label
+      v-if="label"
+      :for="fieldId"
+      class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-1.5"
+    >
+      {{ label }}
+      <span v-if="required" class="text-red-500" aria-hidden="true">*</span>
+    </label>
+    <textarea
+      :id="fieldId"
+      :value="modelValue"
+      :rows="rows"
+      v-bind="attrs"
+      :class="[
+        'w-full rounded-lg border bg-white dark:bg-verse-900/40 text-verse-900 dark:text-verse-100 placeholder-verse-400 dark:placeholder-verse-500',
+        'focus:outline-none focus:ring-2 focus:ring-verse-500/40 focus:border-verse-500 transition-colors',
+        'px-3.5 py-2 text-sm',
+        error
+          ? 'border-red-300 dark:border-red-800 focus:border-red-500 focus:ring-red-500/40'
+          : 'border-verse-200 dark:border-verse-800',
+      ]"
+      @input="emit('update:modelValue', ($event.target as HTMLTextAreaElement).value)"
+    />
+    <p v-if="error" class="mt-1.5 text-xs text-red-600 dark:text-red-400">{{ error }}</p>
+    <p
+      v-else-if="hint"
+      class="mt-1.5 text-xs text-verse-500 dark:text-verse-400"
+    >
+      {{ hint }}
+    </p>
+  </div>
+</template>

--- a/packages/frontendmu-adonis/inertia/pages/admin/events/attendees.vue
+++ b/packages/frontendmu-adonis/inertia/pages/admin/events/attendees.vue
@@ -161,7 +161,7 @@ function exportCsv() {
           }}<span v-if="event.endTime"> – {{ event.endTime }}</span>
         </span>
         <span v-if="event.venue">{{ event.venue }}</span>
-        <span v-if="event.seatsAvailable !== null" class="text-verse-500 dark:text-verse-400">
+        <span v-if="event.seatsAvailable !== null" class="text-verse-500 dark:text-verse-300">
           Capacity {{ counts.confirmed }} / {{ event.seatsAvailable }}
         </span>
       </div>
@@ -262,10 +262,10 @@ function exportCsv() {
           <td class="px-5 py-3">
             <AdminBadge :tone="statusTone(attendee.status)" dot>{{ attendee.status }}</AdminBadge>
           </td>
-          <td class="px-5 py-3 text-sm text-verse-600 dark:text-verse-400 whitespace-nowrap">
+          <td class="px-5 py-3 text-sm text-verse-600 dark:text-verse-300 whitespace-nowrap">
             {{ formatRsvpedAt(attendee.rsvpedAt) }}
           </td>
-          <td class="px-5 py-3 text-sm text-verse-600 dark:text-verse-400 max-w-xs">
+          <td class="px-5 py-3 text-sm text-verse-600 dark:text-verse-300 max-w-xs">
             <span v-if="attendee.notes" class="line-clamp-2">{{ attendee.notes }}</span>
             <span v-else class="text-verse-400 dark:text-verse-500">—</span>
           </td>

--- a/packages/frontendmu-adonis/inertia/pages/admin/events/attendees.vue
+++ b/packages/frontendmu-adonis/inertia/pages/admin/events/attendees.vue
@@ -1,9 +1,17 @@
 <script setup lang="ts">
-import { Head, Link } from '@inertiajs/vue3'
 import { computed, ref } from 'vue'
+import { Head } from '@inertiajs/vue3'
 import type { Data } from '@generated/data'
-import ContentBlock from '~/components/shared/ContentBlock.vue'
-import BaseHeading from '~/components/base/BaseHeading.vue'
+import AdminShell from '~/components/admin/ui/AdminShell.vue'
+import AdminCard from '~/components/admin/ui/AdminCard.vue'
+import AdminButton from '~/components/admin/ui/AdminButton.vue'
+import AdminBadge from '~/components/admin/ui/AdminBadge.vue'
+import AdminAvatar from '~/components/admin/ui/AdminAvatar.vue'
+import AdminTable from '~/components/admin/ui/AdminTable.vue'
+import AdminFilterChips from '~/components/admin/ui/AdminFilterChips.vue'
+import AdminSearchInput from '~/components/admin/ui/AdminSearchInput.vue'
+import AdminStatGrid from '~/components/admin/ui/AdminStatGrid.vue'
+import AdminEmptyState from '~/components/admin/ui/AdminEmptyState.vue'
 import RsvpTimelineChart from '~/components/admin/RsvpTimelineChart.vue'
 import { formatEventDate } from '~/utils/date'
 
@@ -67,39 +75,24 @@ const filtered = computed(() => {
   })
 })
 
-const filterButtons = computed<
-  { key: StatusFilter; label: string; count: number; activeClass: string }[]
->(() => [
-  { key: 'all', label: 'All', count: props.counts.total, activeClass: 'bg-verse-600 text-white' },
-  {
-    key: 'confirmed',
-    label: 'Confirmed',
-    count: props.counts.confirmed,
-    activeClass: 'bg-green-600 text-white',
-  },
-  {
-    key: 'waitlist',
-    label: 'Waitlist',
-    count: props.counts.waitlist,
-    activeClass: 'bg-yellow-600 text-white',
-  },
-  {
-    key: 'cancelled',
-    label: 'Cancelled',
-    count: props.counts.cancelled,
-    activeClass: 'bg-red-600 text-white',
-  },
+const stats = computed(() => [
+  { label: 'Total', value: props.counts.total },
+  { label: 'Confirmed', value: props.counts.confirmed, tone: 'success' as const },
+  { label: 'Waitlist', value: props.counts.waitlist, tone: 'warning' as const },
+  { label: 'Cancelled', value: props.counts.cancelled, tone: 'danger' as const },
 ])
 
-function statusBadge(status: RsvpStatus) {
-  switch (status) {
-    case 'confirmed':
-      return 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300'
-    case 'waitlist':
-      return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300'
-    case 'cancelled':
-      return 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300'
-  }
+const filterChips = computed(() => [
+  { key: 'all', label: 'All', count: props.counts.total },
+  { key: 'confirmed', label: 'Confirmed', count: props.counts.confirmed },
+  { key: 'waitlist', label: 'Waitlist', count: props.counts.waitlist },
+  { key: 'cancelled', label: 'Cancelled', count: props.counts.cancelled },
+])
+
+function statusTone(status: RsvpStatus) {
+  if (status === 'confirmed') return 'success'
+  if (status === 'waitlist') return 'warning'
+  return 'danger'
 }
 
 function formatRsvpedAt(iso: string | null) {
@@ -136,7 +129,6 @@ function exportCsv() {
         .join(',')
     )
     .join('\n')
-
   const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' })
   const url = URL.createObjectURL(blob)
   const link = document.createElement('a')
@@ -151,252 +143,162 @@ function exportCsv() {
 
 <template>
   <Head :title="`Attendees · ${event.title}`" />
-  <main class="relative min-h-screen pt-40 pb-20">
-    <ContentBlock>
-      <!-- Breadcrumb -->
-      <div class="mb-4 text-sm text-verse-500 dark:text-verse-400">
-        <Link href="/admin" class="hover:text-verse-700 dark:hover:text-verse-200">Admin</Link>
-        <span class="mx-1.5">/</span>
-        <Link
-          href="/admin/events"
-          class="hover:text-verse-700 dark:hover:text-verse-200"
-        >Events</Link>
-        <span class="mx-1.5">/</span>
-        <span class="text-verse-700 dark:text-verse-300">Attendees</span>
+  <AdminShell
+    :title="event.title"
+    description="Who has RSVP'd, when they signed up, and how to reach them."
+    :breadcrumbs="[
+      { label: 'Admin', href: '/admin' },
+      { label: 'Events', href: '/admin/events' },
+      { label: event.title, href: `/admin/events/${event.id}/edit` },
+      { label: 'Attendees' },
+    ]"
+  >
+    <template #meta>
+      <div class="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-verse-600 dark:text-verse-300">
+        <span>{{ formatEventDate(event.date) }}</span>
+        <span v-if="event.startTime">
+          {{ event.startTime
+          }}<span v-if="event.endTime"> – {{ event.endTime }}</span>
+        </span>
+        <span v-if="event.venue">{{ event.venue }}</span>
+        <span v-if="event.seatsAvailable !== null" class="text-verse-500 dark:text-verse-400">
+          Capacity {{ counts.confirmed }} / {{ event.seatsAvailable }}
+        </span>
       </div>
+    </template>
+    <template #actions>
+      <AdminButton :href="`/meetup/${event.slug || event.id}`" variant="secondary">
+        View public
+      </AdminButton>
+      <AdminButton :href="`/admin/events/${event.id}/edit`" variant="secondary">
+        Edit event
+      </AdminButton>
+      <AdminButton
+        variant="primary"
+        :disabled="!attendees.length"
+        @click="exportCsv"
+      >
+        Export CSV
+      </AdminButton>
+    </template>
 
-      <!-- Header -->
-      <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4 mb-8">
-        <div class="min-w-0">
-          <BaseHeading :level="1">{{ event.title }}</BaseHeading>
-          <div
-            class="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-verse-600 dark:text-verse-400"
-          >
-            <span>{{ formatEventDate(event.date) }}</span>
-            <span v-if="event.startTime">{{ event.startTime }}<span v-if="event.endTime"> – {{ event.endTime }}</span></span>
-            <span v-if="event.venue">{{ event.venue }}</span>
-            <span
-              v-if="event.seatsAvailable !== null"
-              class="text-verse-500 dark:text-verse-400"
-            >Capacity: {{ counts.confirmed }} / {{ event.seatsAvailable }}</span>
-          </div>
-        </div>
-        <div class="flex flex-wrap gap-2 shrink-0">
-          <Link
-            :href="`/meetup/${event.slug || event.id}`"
-            class="inline-flex items-center gap-2 px-4 py-2 bg-verse-100 dark:bg-verse-800 hover:bg-verse-200 dark:hover:bg-verse-700 text-verse-700 dark:text-verse-200 text-sm font-medium squircle rounded-lg transition-colors"
-          >
-            View public page
-          </Link>
-          <Link
-            :href="`/admin/events/${event.id}/edit`"
-            class="inline-flex items-center gap-2 px-4 py-2 bg-verse-100 dark:bg-verse-800 hover:bg-verse-200 dark:hover:bg-verse-700 text-verse-700 dark:text-verse-200 text-sm font-medium squircle rounded-lg transition-colors"
-          >
-            Edit event
-          </Link>
-          <button
-            type="button"
-            :disabled="!attendees.length"
-            @click="exportCsv"
-            class="inline-flex items-center gap-2 px-4 py-2 bg-verse-600 hover:bg-verse-700 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-medium squircle rounded-lg transition-colors"
-          >
-            Export CSV
-          </button>
-        </div>
-      </div>
+    <section class="mb-6">
+      <AdminStatGrid :stats="stats" />
+    </section>
 
-      <!-- Stats -->
-      <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
-        <div
-          class="bg-white dark:bg-verse-800/50 squircle rounded-xl border border-verse-200 dark:border-verse-700 p-4"
-        >
-          <div class="text-2xl font-bold text-verse-900 dark:text-verse-100">{{ counts.total }}</div>
-          <div class="text-sm text-verse-600 dark:text-verse-400">Total RSVPs</div>
-        </div>
-        <div
-          class="bg-white dark:bg-verse-800/50 squircle rounded-xl border border-verse-200 dark:border-verse-700 p-4"
-        >
-          <div class="text-2xl font-bold text-green-600 dark:text-green-400">{{ counts.confirmed }}</div>
-          <div class="text-sm text-verse-600 dark:text-verse-400">Confirmed</div>
-        </div>
-        <div
-          class="bg-white dark:bg-verse-800/50 squircle rounded-xl border border-verse-200 dark:border-verse-700 p-4"
-        >
-          <div class="text-2xl font-bold text-yellow-600 dark:text-yellow-400">{{ counts.waitlist }}</div>
-          <div class="text-sm text-verse-600 dark:text-verse-400">Waitlist</div>
-        </div>
-        <div
-          class="bg-white dark:bg-verse-800/50 squircle rounded-xl border border-verse-200 dark:border-verse-700 p-4"
-        >
-          <div class="text-2xl font-bold text-red-600 dark:text-red-400">{{ counts.cancelled }}</div>
-          <div class="text-sm text-verse-600 dark:text-verse-400">Cancelled</div>
-        </div>
-      </div>
-
-      <!-- Timeline chart -->
+    <AdminCard title="RSVP timeline" description="Sign-ups over time, plus event date and capacity." class="mb-6">
       <RsvpTimelineChart
         :rsvped-at-list="activeRsvpedAtList"
         :rsvp-open-at="timeline.rsvpOpenAt"
         :rsvp-close-at="timeline.rsvpCloseAt"
         :event-at="timeline.eventAt"
         :seats-available="event.seatsAvailable"
+        bare
       />
+    </AdminCard>
 
-      <!-- Filters + search -->
-      <div class="flex flex-wrap items-center justify-between gap-3 mb-4">
-        <div class="flex flex-wrap gap-2">
-          <button
-            v-for="btn in filterButtons"
-            :key="btn.key"
-            type="button"
-            @click="statusFilter = btn.key"
-            :class="[
-              'px-3 py-1.5 squircle rounded-lg text-sm font-medium transition-colors',
-              statusFilter === btn.key
-                ? btn.activeClass
-                : 'bg-verse-100 dark:bg-verse-800 text-verse-700 dark:text-verse-300 hover:bg-verse-200 dark:hover:bg-verse-700',
-            ]"
-          >
-            {{ btn.label }}
-            <span class="ml-1 opacity-70">{{ btn.count }}</span>
-          </button>
-        </div>
-
-        <label class="relative w-full sm:w-72">
-          <span class="sr-only">Search attendees</span>
-          <input
-            v-model="search"
-            type="search"
-            placeholder="Search name, email or GitHub"
-            class="w-full px-3 py-2 bg-white dark:bg-verse-900 border border-verse-200 dark:border-verse-800 rounded-lg text-sm text-verse-900 dark:text-verse-100 placeholder-verse-400 focus:outline-none focus:ring-2 focus:ring-verse-500/40 focus:border-verse-500 transition-colors"
-          />
-        </label>
+    <div class="flex flex-col gap-4 mb-4 lg:flex-row lg:items-center lg:justify-between">
+      <AdminFilterChips
+        v-model="statusFilter"
+        :chips="filterChips"
+        aria-label="Filter by RSVP status"
+      />
+      <div class="lg:w-72">
+        <AdminSearchInput
+          v-model="search"
+          placeholder="Search name, email or GitHub"
+          label="Search attendees"
+        />
       </div>
+    </div>
 
-      <!-- Table -->
-      <div
-        class="bg-white dark:bg-verse-800/50 squircle rounded-xl border border-verse-200 dark:border-verse-700 overflow-hidden"
+    <AdminCard :padded="false">
+      <AdminTable
+        v-if="filtered.length"
+        :columns="[
+          { label: 'Attendee' },
+          { label: 'Email' },
+          { label: 'GitHub' },
+          { label: 'Status' },
+          { label: 'RSVP’ed at' },
+          { label: 'Notes' },
+        ]"
       >
-        <div class="overflow-x-auto">
-          <table class="w-full">
-            <thead class="bg-verse-50 dark:bg-verse-800 border-b border-verse-200 dark:border-verse-700">
-              <tr>
-                <th
-                  class="px-6 py-3 text-left text-xs font-semibold text-verse-600 dark:text-verse-400 uppercase tracking-wider"
-                >
-                  Attendee
-                </th>
-                <th
-                  class="px-6 py-3 text-left text-xs font-semibold text-verse-600 dark:text-verse-400 uppercase tracking-wider"
-                >
-                  Email
-                </th>
-                <th
-                  class="px-6 py-3 text-left text-xs font-semibold text-verse-600 dark:text-verse-400 uppercase tracking-wider"
-                >
-                  GitHub
-                </th>
-                <th
-                  class="px-6 py-3 text-left text-xs font-semibold text-verse-600 dark:text-verse-400 uppercase tracking-wider"
-                >
-                  Status
-                </th>
-                <th
-                  class="px-6 py-3 text-left text-xs font-semibold text-verse-600 dark:text-verse-400 uppercase tracking-wider"
-                >
-                  RSVP&rsquo;ed at
-                </th>
-                <th
-                  class="px-6 py-3 text-left text-xs font-semibold text-verse-600 dark:text-verse-400 uppercase tracking-wider"
-                >
-                  Notes
-                </th>
-              </tr>
-            </thead>
-            <tbody class="divide-y divide-verse-200 dark:divide-verse-700">
-              <tr
-                v-for="attendee in filtered"
-                :key="attendee.rsvpId"
-                class="hover:bg-verse-50 dark:hover:bg-verse-800/80 transition-colors"
-              >
-                <td class="px-6 py-3">
-                  <div class="flex items-center gap-3 min-w-0">
-                    <img
-                      v-if="attendee.user?.avatarUrl"
-                      :src="attendee.user.avatarUrl"
-                      :alt="attendee.user.name"
-                      loading="lazy"
-                      class="w-8 h-8 rounded-full object-cover bg-verse-100 dark:bg-verse-700 shrink-0"
-                    />
-                    <div
-                      v-else
-                      class="w-8 h-8 rounded-full bg-verse-100 dark:bg-verse-700 flex items-center justify-center text-xs font-semibold text-verse-600 dark:text-verse-300 shrink-0"
-                    >
-                      {{ (attendee.user?.name ?? '?').charAt(0).toUpperCase() }}
-                    </div>
-                    <span class="font-medium text-verse-900 dark:text-verse-100 truncate">
-                      {{ attendee.user?.name ?? 'Deleted user' }}
-                    </span>
-                  </div>
-                </td>
-                <td class="px-6 py-3 text-sm text-verse-700 dark:text-verse-300">
-                  <a
-                    v-if="attendee.user?.email"
-                    :href="`mailto:${attendee.user.email}`"
-                    class="hover:underline"
-                  >{{ attendee.user.email }}</a>
-                  <span v-else>—</span>
-                </td>
-                <td class="px-6 py-3 text-sm text-verse-700 dark:text-verse-300">
-                  <a
-                    v-if="attendee.user?.githubUsername"
-                    :href="`https://github.com/${attendee.user.githubUsername}`"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    class="hover:underline"
-                  >@{{ attendee.user.githubUsername }}</a>
-                  <span v-else class="text-verse-400 dark:text-verse-500">—</span>
-                </td>
-                <td class="px-6 py-3">
-                  <span
-                    :class="[
-                      'px-2.5 py-1 rounded-full text-xs font-medium capitalize',
-                      statusBadge(attendee.status),
-                    ]"
-                  >
-                    {{ attendee.status }}
-                  </span>
-                </td>
-                <td class="px-6 py-3 text-sm text-verse-600 dark:text-verse-400 whitespace-nowrap">
-                  {{ formatRsvpedAt(attendee.rsvpedAt) }}
-                </td>
-                <td class="px-6 py-3 text-sm text-verse-600 dark:text-verse-400 max-w-xs">
-                  <span v-if="attendee.notes" class="line-clamp-2">{{ attendee.notes }}</span>
-                  <span v-else class="text-verse-400 dark:text-verse-500">—</span>
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
+        <tr
+          v-for="attendee in filtered"
+          :key="attendee.rsvpId"
+          class="hover:bg-verse-50/50 dark:hover:bg-verse-800/40 transition-colors"
+        >
+          <td class="px-5 py-3">
+            <div class="flex items-center gap-3 min-w-0">
+              <AdminAvatar
+                :src="attendee.user?.avatarUrl"
+                :name="attendee.user?.name ?? '?'"
+                size="sm"
+              />
+              <span class="font-medium text-verse-900 dark:text-verse-50 truncate">
+                {{ attendee.user?.name ?? 'Deleted user' }}
+              </span>
+            </div>
+          </td>
+          <td class="px-5 py-3 text-sm text-verse-700 dark:text-verse-300">
+            <a
+              v-if="attendee.user?.email"
+              :href="`mailto:${attendee.user.email}`"
+              class="hover:underline decoration-coral-strong decoration-2 underline-offset-4"
+            >{{ attendee.user.email }}</a>
+            <span v-else class="text-verse-400 dark:text-verse-500">—</span>
+          </td>
+          <td class="px-5 py-3 text-sm text-verse-700 dark:text-verse-300">
+            <a
+              v-if="attendee.user?.githubUsername"
+              :href="`https://github.com/${attendee.user.githubUsername}`"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="hover:underline"
+            >@{{ attendee.user.githubUsername }}</a>
+            <span v-else class="text-verse-400 dark:text-verse-500">—</span>
+          </td>
+          <td class="px-5 py-3">
+            <AdminBadge :tone="statusTone(attendee.status)" dot>{{ attendee.status }}</AdminBadge>
+          </td>
+          <td class="px-5 py-3 text-sm text-verse-600 dark:text-verse-400 whitespace-nowrap">
+            {{ formatRsvpedAt(attendee.rsvpedAt) }}
+          </td>
+          <td class="px-5 py-3 text-sm text-verse-600 dark:text-verse-400 max-w-xs">
+            <span v-if="attendee.notes" class="line-clamp-2">{{ attendee.notes }}</span>
+            <span v-else class="text-verse-400 dark:text-verse-500">—</span>
+          </td>
+        </tr>
+      </AdminTable>
 
-        <!-- Empty state -->
-        <div v-if="!filtered.length" class="px-6 py-12 text-center">
-          <p class="text-verse-500 dark:text-verse-400">
-            <span v-if="!attendees.length">No RSVPs yet for this event.</span>
-            <span v-else-if="search || statusFilter !== 'all'"
-              >No attendees match the current filters.</span
-            >
-          </p>
-          <button
+      <AdminEmptyState
+        v-else
+        :title="
+          !attendees.length ? 'No RSVPs yet' : 'No attendees match your filters'
+        "
+        :description="
+          !attendees.length
+            ? 'Once people RSVP, they will show up here.'
+            : 'Try a different filter or clear your search.'
+        "
+        icon="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2M9 11a4 4 0 1 0 0-8 4 4 0 0 0 0 8z"
+      >
+        <template #actions>
+          <AdminButton
             v-if="attendees.length && (search || statusFilter !== 'all')"
-            type="button"
-            @click="search = ''; statusFilter = 'all'"
-            class="inline-block mt-2 text-verse-600 hover:text-verse-800 dark:text-verse-400 dark:hover:text-verse-200 underline"
+            variant="secondary"
+            @click="
+              () => {
+                search = ''
+                statusFilter = 'all'
+              }
+            "
           >
             Clear filters
-          </button>
-        </div>
-      </div>
-    </ContentBlock>
-  </main>
+          </AdminButton>
+        </template>
+      </AdminEmptyState>
+    </AdminCard>
+  </AdminShell>
 </template>

--- a/packages/frontendmu-adonis/inertia/pages/admin/events/create.vue
+++ b/packages/frontendmu-adonis/inertia/pages/admin/events/create.vue
@@ -1,10 +1,13 @@
 <script setup lang="ts">
 import { Head, useForm } from '@inertiajs/vue3'
-import { Link } from '@inertiajs/vue3'
-import ContentBlock from '~/components/shared/ContentBlock.vue'
-import BaseHeading from '~/components/base/BaseHeading.vue'
+import AdminShell from '~/components/admin/ui/AdminShell.vue'
+import AdminCard from '~/components/admin/ui/AdminCard.vue'
+import AdminButton from '~/components/admin/ui/AdminButton.vue'
+import AdminInput from '~/components/admin/ui/AdminInput.vue'
+import AdminTextarea from '~/components/admin/ui/AdminTextarea.vue'
+import AdminSelect from '~/components/admin/ui/AdminSelect.vue'
+import AdminCheckbox from '~/components/admin/ui/AdminCheckbox.vue'
 
-// Form state
 const form = useForm({
   title: '',
   eventDate: '',
@@ -22,288 +25,119 @@ const form = useForm({
 })
 
 function handleSubmit() {
-  form.post('/admin/events', {
-    preserveScroll: true,
-  })
+  form.post('/admin/events', { preserveScroll: true })
 }
 </script>
 
 <template>
-  <Head title="Create Event" />
-  <main class="relative min-h-screen pt-40 pb-20">
-      <ContentBlock>
-        <div class="max-w-4xl mx-auto">
-        <!-- Breadcrumb -->
-        <nav class="mb-6 flex items-center gap-2 text-sm">
-          <Link
-            href="/meetups"
-            class="text-verse-600 hover:text-verse-800 dark:text-verse-400 dark:hover:text-verse-200"
-          >
-            Meetups
-          </Link>
-          <span class="text-verse-400">/</span>
-          <span class="text-verse-500 dark:text-verse-400">Create Event</span>
-        </nav>
+  <Head title="New event · Admin" />
+  <AdminShell
+    title="New event"
+    description="Set the basic details now — you can add sessions and sponsors after creation."
+    :breadcrumbs="[
+      { label: 'Admin', href: '/admin' },
+      { label: 'Events', href: '/admin/events' },
+      { label: 'New event' },
+    ]"
+  >
+    <form class="space-y-6 max-w-3xl" @submit.prevent="handleSubmit">
+      <AdminCard title="Basics" description="The essentials that define your event.">
+        <div class="space-y-5">
+          <AdminInput
+            v-model="form.title"
+            label="Title"
+            required
+            placeholder="e.g. The October Meetup"
+            :error="form.errors.title"
+          />
+          <AdminInput
+            v-model="form.eventDate"
+            label="Event date"
+            type="date"
+            required
+            :error="form.errors.eventDate"
+          />
+          <AdminTextarea
+            v-model="form.description"
+            label="Description"
+            placeholder="What is this meetup about? Who is it for?"
+            :error="form.errors.description"
+          />
+        </div>
+      </AdminCard>
 
-        <BaseHeading :level="1" class="mb-8">Create New Event</BaseHeading>
-
-        <!-- Create Form -->
-        <form @submit.prevent="handleSubmit" class="space-y-6">
-          <!-- Title -->
-          <div>
-            <label
-              for="title"
-              class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-2"
-            >
-              Title *
-            </label>
-            <input
-              id="title"
-              v-model="form.title"
-              type="text"
-              required
-              placeholder="e.g., The October Meetup"
-              class="w-full px-4 py-2 border border-verse-300 dark:border-verse-600 squircle rounded-lg bg-white dark:bg-verse-800 text-verse-900 dark:text-verse-100 focus:ring-2 focus:ring-verse-500 focus:border-transparent"
+      <AdminCard title="Where & when">
+        <div class="space-y-5">
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <AdminInput
+              v-model="form.location"
+              label="Location"
+              placeholder="e.g. Port Louis, Mauritius"
             />
-            <p v-if="form.errors.title" class="mt-1 text-sm text-red-600 dark:text-red-400">
-              {{ form.errors.title }}
-            </p>
+            <AdminInput
+              v-model="form.venue"
+              label="Venue"
+              placeholder="e.g. Caudan Arts Centre"
+            />
           </div>
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <AdminInput v-model="form.startTime" label="Start time" type="time" />
+            <AdminInput v-model="form.endTime" label="End time" type="time" />
+          </div>
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <AdminInput v-model="form.mapUrl" label="Map URL" type="url" placeholder="https://maps.google.com/…" />
+            <AdminInput
+              v-model="form.parkingLocation"
+              label="Parking URL"
+              type="url"
+              placeholder="https://maps.google.com/…"
+            />
+          </div>
+        </div>
+      </AdminCard>
 
-          <!-- Event Date -->
-          <div>
-            <label
-              for="eventDate"
-              class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-2"
-            >
-              Event Date *
-            </label>
-            <input
-              id="eventDate"
-              v-model="form.eventDate"
+      <AdminCard title="RSVPs" description="Open RSVPs only when you're ready to receive them.">
+        <div class="space-y-5">
+          <AdminCheckbox
+            v-model="form.acceptingRsvp"
+            label="Accept RSVPs"
+            description="Members can sign up for this event right away."
+          />
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <AdminInput
+              v-model="form.seatsAvailable"
+              label="Seats available"
+              type="number"
+              min="0"
+              hint="Leave empty for unlimited"
+            />
+            <AdminInput
+              v-model="form.rsvpClosingDate"
+              label="RSVP closing date"
               type="date"
-              required
-              class="w-full px-4 py-2 border border-verse-300 dark:border-verse-600 squircle rounded-lg bg-white dark:bg-verse-800 text-verse-900 dark:text-verse-100 focus:ring-2 focus:ring-verse-500 focus:border-transparent"
             />
-            <p v-if="form.errors.eventDate" class="mt-1 text-sm text-red-600 dark:text-red-400">
-              {{ form.errors.eventDate }}
-            </p>
           </div>
+        </div>
+      </AdminCard>
 
-          <!-- Description -->
-          <div>
-            <label
-              for="description"
-              class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-2"
-            >
-              Description
-            </label>
-            <textarea
-              id="description"
-              v-model="form.description"
-              rows="4"
-              placeholder="Describe the event..."
-              class="w-full px-4 py-2 border border-verse-300 dark:border-verse-600 squircle rounded-lg bg-white dark:bg-verse-800 text-verse-900 dark:text-verse-100 focus:ring-2 focus:ring-verse-500 focus:border-transparent"
-            />
-            <p v-if="form.errors.description" class="mt-1 text-sm text-red-600 dark:text-red-400">
-              {{ form.errors.description }}
-            </p>
-          </div>
+      <AdminCard title="Visibility">
+        <AdminSelect
+          v-model="form.status"
+          label="Status"
+          hint="Draft events stay hidden from the public."
+        >
+          <option value="draft">Draft</option>
+          <option value="published">Published</option>
+          <option value="cancelled">Cancelled</option>
+        </AdminSelect>
+      </AdminCard>
 
-          <!-- Location & Venue -->
-          <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-            <div>
-              <label
-                for="location"
-                class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-2"
-              >
-                Location
-              </label>
-              <input
-                id="location"
-                v-model="form.location"
-                type="text"
-                placeholder="e.g., Port Louis, Mauritius"
-                class="w-full px-4 py-2 border border-verse-300 dark:border-verse-600 squircle rounded-lg bg-white dark:bg-verse-800 text-verse-900 dark:text-verse-100 focus:ring-2 focus:ring-verse-500 focus:border-transparent"
-              />
-            </div>
-            <div>
-              <label
-                for="venue"
-                class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-2"
-              >
-                Venue
-              </label>
-              <input
-                id="venue"
-                v-model="form.venue"
-                type="text"
-                placeholder="e.g., Caudan Arts Centre"
-                class="w-full px-4 py-2 border border-verse-300 dark:border-verse-600 squircle rounded-lg bg-white dark:bg-verse-800 text-verse-900 dark:text-verse-100 focus:ring-2 focus:ring-verse-500 focus:border-transparent"
-              />
-            </div>
-          </div>
-
-          <!-- Start Time & End Time -->
-          <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-            <div>
-              <label
-                for="startTime"
-                class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-2"
-              >
-                Start Time
-              </label>
-              <input
-                id="startTime"
-                v-model="form.startTime"
-                type="time"
-                class="w-full px-4 py-2 border border-verse-300 dark:border-verse-600 squircle rounded-lg bg-white dark:bg-verse-800 text-verse-900 dark:text-verse-100 focus:ring-2 focus:ring-verse-500 focus:border-transparent"
-              />
-            </div>
-            <div>
-              <label
-                for="endTime"
-                class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-2"
-              >
-                End Time
-              </label>
-              <input
-                id="endTime"
-                v-model="form.endTime"
-                type="time"
-                class="w-full px-4 py-2 border border-verse-300 dark:border-verse-600 squircle rounded-lg bg-white dark:bg-verse-800 text-verse-900 dark:text-verse-100 focus:ring-2 focus:ring-verse-500 focus:border-transparent"
-              />
-            </div>
-          </div>
-
-          <!-- RSVP Settings -->
-          <div class="p-4 bg-verse-50 dark:bg-verse-800/50 squircle rounded-lg border border-verse-200 dark:border-verse-700">
-            <h3 class="text-lg font-medium text-verse-900 dark:text-verse-100 mb-4">
-              RSVP Settings
-            </h3>
-            <div class="space-y-4">
-              <div class="flex items-center gap-3">
-                <input
-                  id="acceptingRsvp"
-                  v-model="form.acceptingRsvp"
-                  type="checkbox"
-                  class="w-4 h-4 text-verse-600 border-verse-300 rounded focus:ring-verse-500"
-                />
-                <label for="acceptingRsvp" class="text-sm text-verse-700 dark:text-verse-300">
-                  Accepting RSVPs
-                </label>
-              </div>
-
-              <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-                <div>
-                  <label
-                    for="seatsAvailable"
-                    class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-2"
-                  >
-                    Seats Available
-                  </label>
-                  <input
-                    id="seatsAvailable"
-                    v-model.number="form.seatsAvailable"
-                    type="number"
-                    min="0"
-                    placeholder="Leave empty for unlimited"
-                    class="w-full px-4 py-2 border border-verse-300 dark:border-verse-600 squircle rounded-lg bg-white dark:bg-verse-800 text-verse-900 dark:text-verse-100 focus:ring-2 focus:ring-verse-500 focus:border-transparent"
-                  />
-                </div>
-                <div>
-                  <label
-                    for="rsvpClosingDate"
-                    class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-2"
-                  >
-                    RSVP Closing Date
-                  </label>
-                  <input
-                    id="rsvpClosingDate"
-                    v-model="form.rsvpClosingDate"
-                    type="date"
-                    class="w-full px-4 py-2 border border-verse-300 dark:border-verse-600 squircle rounded-lg bg-white dark:bg-verse-800 text-verse-900 dark:text-verse-100 focus:ring-2 focus:ring-verse-500 focus:border-transparent"
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <!-- Map & Parking -->
-          <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-            <div>
-              <label
-                for="mapUrl"
-                class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-2"
-              >
-                Map URL
-              </label>
-              <input
-                id="mapUrl"
-                v-model="form.mapUrl"
-                type="url"
-                placeholder="https://maps.google.com/..."
-                class="w-full px-4 py-2 border border-verse-300 dark:border-verse-600 squircle rounded-lg bg-white dark:bg-verse-800 text-verse-900 dark:text-verse-100 focus:ring-2 focus:ring-verse-500 focus:border-transparent"
-              />
-            </div>
-            <div>
-              <label
-                for="parkingLocation"
-                class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-2"
-              >
-                Parking Location URL
-              </label>
-              <input
-                id="parkingLocation"
-                v-model="form.parkingLocation"
-                type="url"
-                placeholder="https://maps.google.com/..."
-                class="w-full px-4 py-2 border border-verse-300 dark:border-verse-600 squircle rounded-lg bg-white dark:bg-verse-800 text-verse-900 dark:text-verse-100 focus:ring-2 focus:ring-verse-500 focus:border-transparent"
-              />
-            </div>
-          </div>
-
-          <!-- Status -->
-          <div>
-            <label
-              for="status"
-              class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-2"
-            >
-              Status
-            </label>
-            <select
-              id="status"
-              v-model="form.status"
-              class="w-full px-4 py-2 border border-verse-300 dark:border-verse-600 squircle rounded-lg bg-white dark:bg-verse-800 text-verse-900 dark:text-verse-100 focus:ring-2 focus:ring-verse-500 focus:border-transparent"
-            >
-              <option value="draft">Draft</option>
-              <option value="published">Published</option>
-              <option value="cancelled">Cancelled</option>
-            </select>
-            <p class="mt-1 text-sm text-verse-500 dark:text-verse-400">
-              Draft events are not visible to the public.
-            </p>
-          </div>
-
-          <!-- Actions -->
-          <div class="flex items-center gap-4 pt-4">
-            <button
-              type="submit"
-              :disabled="form.processing"
-              class="px-6 py-2.5 bg-verse-600 hover:bg-verse-700 disabled:bg-verse-400 text-white font-medium squircle rounded-lg transition-colors"
-            >
-              <span v-if="form.processing">Creating...</span>
-              <span v-else>Create Event</span>
-            </button>
-            <Link
-              href="/meetups"
-              class="px-6 py-2.5 border border-verse-300 dark:border-verse-600 text-verse-700 dark:text-verse-300 hover:bg-verse-50 dark:hover:bg-verse-800 font-medium squircle rounded-lg transition-colors"
-            >
-              Cancel
-            </Link>
-          </div>
-        </form>
+      <div class="sticky bottom-3 z-10 flex justify-end gap-2 bg-white/85 dark:bg-verse-950/85 backdrop-blur-md p-3 rounded-xl border border-verse-200 dark:border-verse-800">
+        <AdminButton href="/admin/events" variant="secondary">Cancel</AdminButton>
+        <AdminButton type="submit" variant="primary" :loading="form.processing">
+          {{ form.processing ? 'Creating…' : 'Create event' }}
+        </AdminButton>
       </div>
-    </ContentBlock>
-  </main>
+    </form>
+  </AdminShell>
 </template>

--- a/packages/frontendmu-adonis/inertia/pages/admin/events/edit.vue
+++ b/packages/frontendmu-adonis/inertia/pages/admin/events/edit.vue
@@ -13,7 +13,6 @@ import AdminCheckbox from '~/components/admin/ui/AdminCheckbox.vue'
 import AdminBadge from '~/components/admin/ui/AdminBadge.vue'
 import AdminAvatar from '~/components/admin/ui/AdminAvatar.vue'
 import AdminSearchInput from '~/components/admin/ui/AdminSearchInput.vue'
-import AdminEmptyState from '~/components/admin/ui/AdminEmptyState.vue'
 import AdminConfirmModal from '~/components/admin/ui/AdminConfirmModal.vue'
 import { useApi } from '~/composables/use_api'
 

--- a/packages/frontendmu-adonis/inertia/pages/admin/events/edit.vue
+++ b/packages/frontendmu-adonis/inertia/pages/admin/events/edit.vue
@@ -506,7 +506,7 @@ async function removeSponsor(sponsorId: string) {
             class="space-y-2"
             aria-label="Sessions list"
           >
-            <p class="text-[11px] font-mono text-verse-500 dark:text-verse-400 mb-2 uppercase tracking-wide">
+            <p class="text-[11px] font-mono text-verse-500 dark:text-verse-300 mb-2 uppercase tracking-wide">
               Drag to reorder
             </p>
             <div
@@ -539,7 +539,7 @@ async function removeSponsor(sponsorId: string) {
                 </div>
                 <div class="flex-1 min-w-0">
                   <div class="flex items-center gap-1.5 flex-wrap mb-1">
-                    <span class="text-[10px] font-mono text-verse-500 dark:text-verse-400 tabular-nums">
+                    <span class="text-[10px] font-mono text-verse-500 dark:text-verse-300 tabular-nums">
                       #{{ index + 1 }}
                     </span>
                     <AdminBadge v-if="session.kind && session.kind !== 'talk'" tone="accent">
@@ -547,7 +547,7 @@ async function removeSponsor(sponsorId: string) {
                     </AdminBadge>
                     <span
                       v-if="session.durationMinutes"
-                      class="text-[10px] font-mono text-verse-500 dark:text-verse-400"
+                      class="text-[10px] font-mono text-verse-500 dark:text-verse-300"
                     >
                       {{ session.durationMinutes }}m
                     </span>
@@ -557,7 +557,7 @@ async function removeSponsor(sponsorId: string) {
                   </p>
                   <p
                     v-if="session.speakers?.length"
-                    class="text-xs text-verse-500 dark:text-verse-400 truncate mt-0.5"
+                    class="text-xs text-verse-500 dark:text-verse-300 truncate mt-0.5"
                   >
                     {{ getSpeakerNames(session.speakers) }}
                   </p>
@@ -591,12 +591,12 @@ async function removeSponsor(sponsorId: string) {
               </div>
             </div>
           </div>
-          <p v-else class="text-sm text-verse-500 dark:text-verse-400 py-3 text-center">
+          <p v-else class="text-sm text-verse-500 dark:text-verse-300 py-3 text-center">
             No sessions yet.
           </p>
 
           <template #footer>
-            <div class="flex flex-wrap gap-1.5 text-[11px] font-mono text-verse-500 dark:text-verse-400 uppercase tracking-wide">
+            <div class="flex flex-wrap gap-1.5 text-[11px] font-mono text-verse-500 dark:text-verse-300 uppercase tracking-wide">
               <span class="self-center mr-1">Quick add</span>
               <button
                 v-for="preset in [
@@ -662,7 +662,7 @@ async function removeSponsor(sponsorId: string) {
               </button>
               <p
                 v-if="filteredAvailableSponsors.length === 0"
-                class="text-xs text-verse-500 dark:text-verse-400 py-2 text-center"
+                class="text-xs text-verse-500 dark:text-verse-300 py-2 text-center"
               >
                 {{ sponsorSearch ? `No matches for "${sponsorSearch}"` : 'All sponsors attached' }}
               </p>
@@ -687,7 +687,7 @@ async function removeSponsor(sponsorId: string) {
                 </p>
                 <p
                   v-if="sponsor.sponsorTypes?.length"
-                  class="text-xs text-verse-500 dark:text-verse-400 truncate"
+                  class="text-xs text-verse-500 dark:text-verse-300 truncate"
                 >
                   {{ sponsor.sponsorTypes.join(', ') }}
                 </p>
@@ -706,7 +706,7 @@ async function removeSponsor(sponsorId: string) {
               </button>
             </div>
           </div>
-          <p v-else class="text-sm text-verse-500 dark:text-verse-400 py-3 text-center">
+          <p v-else class="text-sm text-verse-500 dark:text-verse-300 py-3 text-center">
             No sponsors attached.
           </p>
         </AdminCard>
@@ -818,7 +818,7 @@ async function removeSponsor(sponsorId: string) {
                   </p>
                   <p
                     v-if="speaker.email"
-                    class="text-xs text-verse-500 dark:text-verse-400 truncate"
+                    class="text-xs text-verse-500 dark:text-verse-300 truncate"
                   >
                     {{ speaker.email }}
                   </p>
@@ -826,19 +826,19 @@ async function removeSponsor(sponsorId: string) {
               </button>
               <p
                 v-if="filteredSpeakers.length === 0"
-                class="text-sm text-verse-500 dark:text-verse-400 py-3 text-center"
+                class="text-sm text-verse-500 dark:text-verse-300 py-3 text-center"
               >
                 No speakers found.
               </p>
             </div>
             <p
               v-if="sessionForm.speakerIds.length > 0"
-              class="mt-2 text-xs text-verse-500 dark:text-verse-400"
+              class="mt-2 text-xs text-verse-500 dark:text-verse-300"
             >
               {{ sessionForm.speakerIds.length }} speaker(s) selected
             </p>
           </div>
-          <p v-else class="text-sm text-verse-500 dark:text-verse-400 py-3 text-center">
+          <p v-else class="text-sm text-verse-500 dark:text-verse-300 py-3 text-center">
             No speakers available. Members can be assigned as speakers.
           </p>
         </div>

--- a/packages/frontendmu-adonis/inertia/pages/admin/events/edit.vue
+++ b/packages/frontendmu-adonis/inertia/pages/admin/events/edit.vue
@@ -1,11 +1,20 @@
 <script setup lang="ts">
 import { ref, computed, watch, onUnmounted } from 'vue'
 import { Head, useForm, usePage } from '@inertiajs/vue3'
-import { Link } from '@inertiajs/vue3'
 import type { Data } from '@generated/data'
 import { DateTime } from 'luxon'
-import ContentBlock from '~/components/shared/ContentBlock.vue'
-import BaseHeading from '~/components/base/BaseHeading.vue'
+import AdminShell from '~/components/admin/ui/AdminShell.vue'
+import AdminCard from '~/components/admin/ui/AdminCard.vue'
+import AdminButton from '~/components/admin/ui/AdminButton.vue'
+import AdminInput from '~/components/admin/ui/AdminInput.vue'
+import AdminTextarea from '~/components/admin/ui/AdminTextarea.vue'
+import AdminSelect from '~/components/admin/ui/AdminSelect.vue'
+import AdminCheckbox from '~/components/admin/ui/AdminCheckbox.vue'
+import AdminBadge from '~/components/admin/ui/AdminBadge.vue'
+import AdminAvatar from '~/components/admin/ui/AdminAvatar.vue'
+import AdminSearchInput from '~/components/admin/ui/AdminSearchInput.vue'
+import AdminEmptyState from '~/components/admin/ui/AdminEmptyState.vue'
+import AdminConfirmModal from '~/components/admin/ui/AdminConfirmModal.vue'
 import { useApi } from '~/composables/use_api'
 
 interface Props {
@@ -24,19 +33,16 @@ const props = defineProps<Props>()
 const page = usePage<Data.SharedProps>()
 const { apiFetch } = useApi()
 
-// Flash messages
 const successMessage = computed(() => page.props.flash?.success)
 
-// Sessions state
+// ─── Sessions ──────────────────────────────────────────────────────────
 const sessions = ref<Data.Session[]>(props.event.sessions || [])
 const availableSpeakers = ref<Speaker[]>([])
 const loadingSpeakers = ref(false)
 
-// Dialog ref
 const sessionDialog = ref<HTMLDialogElement | null>(null)
 const isDialogOpen = ref(false)
 
-// Lock body scroll when dialog is open
 watch(isDialogOpen, (open) => {
   document.body.style.overflow = open ? 'hidden' : ''
 })
@@ -44,7 +50,6 @@ onUnmounted(() => {
   document.body.style.overflow = ''
 })
 
-// Session form state
 type SessionKind = 'talk' | 'intro' | 'sponsored' | 'break' | 'photo' | 'quiz' | 'other'
 
 const SESSION_KIND_OPTIONS: Array<{ value: SessionKind; label: string; hint: string }> = [
@@ -72,11 +77,13 @@ const sessionForm = ref({
 const sessionFormErrors = ref<Record<string, string>>({})
 const sessionFormProcessing = ref(false)
 const speakerSearch = ref('')
+const sessionToDelete = ref<Data.Session | null>(null)
+const isDeletingSession = ref(false)
 
 const showSpeakers = computed(() => KINDS_WITH_SPEAKERS.includes(sessionForm.value.kind))
 const showSponsor = computed(() => KINDS_WITH_SPONSOR.includes(sessionForm.value.kind))
 
-// Form state for event
+// ─── Event form ────────────────────────────────────────────────────────
 const formEventDate = computed(() => {
   if (!props.event.date) return ''
   return DateTime.fromISO(props.event.date).toISODate()
@@ -101,21 +108,15 @@ const form = useForm({
 })
 
 function handleSubmit() {
-  form.put(`/admin/events/${props.event.id}`, {
-    preserveScroll: true,
-  })
+  form.put(`/admin/events/${props.event.id}`, { preserveScroll: true })
 }
 
-// Load available speakers
 async function loadAvailableSpeakers() {
   if (availableSpeakers.value.length > 0) return
-
   loadingSpeakers.value = true
   try {
     const { ok, data } = await apiFetch<{ speakers: Speaker[] }>('/admin/speakers/available')
-    if (ok) {
-      availableSpeakers.value = data.speakers
-    }
+    if (ok) availableSpeakers.value = data.speakers
   } catch (error) {
     console.error('Failed to load speakers:', error)
   } finally {
@@ -123,11 +124,10 @@ async function loadAvailableSpeakers() {
   }
 }
 
-// Drag and drop state
+// ─── Drag and drop ─────────────────────────────────────────────────────
 const draggedSession = ref<Data.Session | null>(null)
 const dragOverIndex = ref<number | null>(null)
 
-// Session management functions
 const QUICK_ADD_PRESETS: Record<string, { kind: SessionKind; title: string }> = {
   intro: { kind: 'intro', title: 'Welcome & intro' },
   break: { kind: 'break', title: 'Lunch' },
@@ -175,18 +175,9 @@ function closeSessionForm() {
   sessionDialog.value?.close()
   isDialogOpen.value = false
   editingSession.value = null
-  sessionForm.value = {
-    title: '',
-    description: '',
-    kind: 'talk',
-    sponsorId: null,
-    durationMinutes: null,
-    speakerIds: [],
-  }
   sessionFormErrors.value = {}
 }
 
-// Drag and drop handlers
 function onDragStart(session: Data.Session) {
   draggedSession.value = session
 }
@@ -202,23 +193,17 @@ function onDragLeave() {
 
 function onDrop(targetIndex: number) {
   if (!draggedSession.value) return
-
   const draggedIndex = sessions.value.findIndex((s) => s.id === draggedSession.value!.id)
   if (draggedIndex === -1 || draggedIndex === targetIndex) {
     draggedSession.value = null
     dragOverIndex.value = null
     return
   }
-
-  // Reorder the array
   const newSessions = [...sessions.value]
   const [removed] = newSessions.splice(draggedIndex, 1)
   newSessions.splice(targetIndex, 0, removed)
-
-  // Update order values and save
   sessions.value = newSessions
   saveSessionOrder()
-
   draggedSession.value = null
   dragOverIndex.value = null
 }
@@ -229,11 +214,7 @@ function onDragEnd() {
 }
 
 async function saveSessionOrder() {
-  const updates = sessions.value.map((session, index) => ({
-    id: session.id,
-    order: index + 1,
-  }))
-
+  const updates = sessions.value.map((session, index) => ({ id: session.id, order: index + 1 }))
   for (const update of updates) {
     try {
       await apiFetch(`/admin/sessions/${update.id}`, {
@@ -252,14 +233,11 @@ async function saveSessionOrder() {
 async function saveSession() {
   sessionFormProcessing.value = true
   sessionFormErrors.value = {}
-
   try {
     const url = editingSession.value
       ? `/admin/sessions/${editingSession.value.id}`
       : `/admin/events/${props.event.id}/sessions`
-
     const method = editingSession.value ? 'PUT' : 'POST'
-
     const kind = sessionForm.value.kind
     const payload = {
       title: sessionForm.value.title,
@@ -270,21 +248,14 @@ async function saveSession() {
       speakerIds: KINDS_WITH_SPEAKERS.includes(kind) ? sessionForm.value.speakerIds : [],
       order: editingSession.value?.order ?? sessions.value.length + 1,
     }
-
-    const { ok, data } = await apiFetch<{
-      session: Data.Session
-      errors?: Record<string, string>
-    }>(url, {
-      method,
-      body: JSON.stringify(payload),
-    })
-
+    const { ok, data } = await apiFetch<{ session: Data.Session; errors?: Record<string, string> }>(
+      url,
+      { method, body: JSON.stringify(payload) }
+    )
     if (ok) {
       if (editingSession.value) {
         const index = sessions.value.findIndex((s) => s.id === editingSession.value!.id)
-        if (index !== -1) {
-          sessions.value[index] = data.session
-        }
+        if (index !== -1) sessions.value[index] = data.session
       } else {
         sessions.value.push(data.session)
       }
@@ -299,38 +270,33 @@ async function saveSession() {
   }
 }
 
-async function deleteSession(session: Data.Session) {
-  if (!session.id) {
-    console.error('Cannot delete a session without an id:', session)
-    return
-  }
+function confirmDeleteSession(session: Data.Session) {
+  sessionToDelete.value = session
+}
 
-  if (!confirm(`Are you sure you want to delete "${session.title}"?`)) {
-    return
-  }
-
+async function deleteSession() {
+  const session = sessionToDelete.value
+  if (!session?.id) return
+  isDeletingSession.value = true
   try {
-    const { ok, data } = await apiFetch<{ message?: string }>(`/admin/sessions/${session.id}`, {
+    const { ok } = await apiFetch<{ message?: string }>(`/admin/sessions/${session.id}`, {
       method: 'DELETE',
     })
-
     if (ok) {
       sessions.value = sessions.value.filter((s) => s.id !== session.id)
-    } else {
-      console.error('Failed to delete session:', data.message || 'Unknown server error')
+      sessionToDelete.value = null
     }
   } catch (error) {
     console.error('Failed to delete session:', error)
+  } finally {
+    isDeletingSession.value = false
   }
 }
 
 function toggleSpeaker(speakerId: string) {
   const index = sessionForm.value.speakerIds.indexOf(speakerId)
-  if (index === -1) {
-    sessionForm.value.speakerIds.push(speakerId)
-  } else {
-    sessionForm.value.speakerIds.splice(index, 1)
-  }
+  if (index === -1) sessionForm.value.speakerIds.push(speakerId)
+  else sessionForm.value.speakerIds.splice(index, 1)
 }
 
 function isSpeakerSelected(speakerId: string): boolean {
@@ -342,11 +308,8 @@ function getSpeakerNames(speakers: Data.Speaker.Variants['summary'][]): string {
   return speakers.map((s) => s.name).join(', ')
 }
 
-// Filtered speakers based on search
 const filteredSpeakers = computed(() => {
-  if (!speakerSearch.value.trim()) {
-    return availableSpeakers.value
-  }
+  if (!speakerSearch.value.trim()) return availableSpeakers.value
   const search = speakerSearch.value.toLowerCase()
   return availableSpeakers.value.filter(
     (speaker) =>
@@ -356,7 +319,7 @@ const filteredSpeakers = computed(() => {
   )
 })
 
-// Sponsors state
+// ─── Sponsors ──────────────────────────────────────────────────────────
 const sponsors = ref<Data.Sponsor.Variants['summary'][]>(props.event.sponsors || [])
 const availableSponsors = ref<Data.Sponsor.Variants['summary'][]>([])
 const loadingSponsors = ref(false)
@@ -380,9 +343,7 @@ async function loadAvailableSponsors() {
     const { ok, data } = await apiFetch<{ sponsors: Data.Sponsor.Variants['summary'][] }>(
       '/admin/sponsors/available'
     )
-    if (ok) {
-      availableSponsors.value = data.sponsors
-    }
+    if (ok) availableSponsors.value = data.sponsors
   } catch (error) {
     console.error('Failed to load sponsors:', error)
   } finally {
@@ -402,9 +363,7 @@ async function attachSponsor(sponsor: Data.Sponsor.Variants['summary']) {
       `/admin/events/${props.event.id}/sponsors/${sponsor.id}`,
       { method: 'POST' }
     )
-    if (ok) {
-      sponsors.value = data.sponsors
-    }
+    if (ok) sponsors.value = data.sponsors
   } catch (error) {
     console.error('Failed to attach sponsor:', error)
   }
@@ -416,9 +375,7 @@ async function removeSponsor(sponsorId: string) {
       `/admin/events/${props.event.id}/sponsors/${sponsorId}`,
       { method: 'DELETE' }
     )
-    if (ok) {
-      sponsors.value = data.sponsors
-    }
+    if (ok) sponsors.value = data.sponsors
   } catch (error) {
     console.error('Failed to remove sponsor:', error)
   }
@@ -426,591 +383,141 @@ async function removeSponsor(sponsorId: string) {
 </script>
 
 <template>
-  <Head :title="`Edit: ${event.title}`" />
-  <main class="relative min-h-screen pt-40 pb-20">
-    <ContentBlock>
-      <div class="max-w-4xl mx-auto">
-        <!-- Breadcrumb -->
-        <nav class="mb-6 flex items-center gap-2 text-sm">
-          <Link
-            href="/meetups"
-            class="text-verse-600 hover:text-verse-800 dark:text-verse-400 dark:hover:text-verse-200"
-          >
-            Meetups
-          </Link>
-          <span class="text-verse-400">/</span>
-          <Link
-            :href="`/meetup/${event.slug || event.id}`"
-            class="text-verse-600 hover:text-verse-800 dark:text-verse-400 dark:hover:text-verse-200"
-          >
-            {{ event.title }}
-          </Link>
-          <span class="text-verse-400">/</span>
-          <span class="text-verse-500 dark:text-verse-400">Edit</span>
-        </nav>
+  <Head :title="`${event.title} · Admin`" />
+  <AdminShell
+    :title="event.title"
+    description="Edit details, schedule sessions and attach sponsors."
+    :breadcrumbs="[
+      { label: 'Admin', href: '/admin' },
+      { label: 'Events', href: '/admin/events' },
+      { label: event.title },
+    ]"
+  >
+    <template #actions>
+      <AdminButton :href="`/meetup/${event.slug || event.id}`" variant="secondary">
+        View public page
+      </AdminButton>
+      <AdminButton :href="`/admin/events/${event.slug || event.id}/attendees`" variant="secondary">
+        Attendees
+      </AdminButton>
+    </template>
 
-        <BaseHeading :level="1" class="mb-8">Edit Event</BaseHeading>
+    <!-- Flash -->
+    <div
+      v-if="successMessage"
+      class="mb-6 px-4 py-3 rounded-lg border border-emerald-200 dark:border-emerald-900/50 bg-emerald-50 dark:bg-emerald-900/20 text-sm text-emerald-800 dark:text-emerald-200"
+      role="status"
+    >
+      {{ successMessage }}
+    </div>
 
-        <!-- Success Message -->
-        <div
-          v-if="successMessage"
-          class="mb-6 p-4 bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-200 squircle rounded-lg"
-        >
-          {{ successMessage }}
-        </div>
-
-        <!-- Session Form Modal (Native Dialog) -->
-        <dialog
-          ref="sessionDialog"
-          class="w-full max-w-2xl squircle rounded-lg shadow-xl bg-white dark:bg-verse-800 max-h-[85vh] overflow-hidden"
-          @close="isDialogOpen = false"
-        >
-          <div
-            class="flex items-center justify-between p-4 border-b border-verse-200 dark:border-verse-700"
-          >
-            <h3 class="text-lg font-medium text-verse-900 dark:text-verse-100">
-              {{ editingSession ? 'Edit Session' : 'New Session' }}
-            </h3>
-            <button
-              type="button"
-              @click="closeSessionForm"
-              class="p-2 text-verse-500 hover:text-verse-700 dark:text-verse-400 dark:hover:text-verse-200 squircle rounded-lg transition-colors"
-            >
-              <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M6 18L18 6M6 6l12 12"
-                />
-              </svg>
-            </button>
-          </div>
-          <form
-            @submit.prevent="saveSession"
-            class="p-4 space-y-4 overflow-y-auto max-h-[calc(90vh-80px)]"
-          >
-            <!-- Title -->
-            <div>
-              <label
-                for="sessionTitle"
-                class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-2"
-              >
-                Title *
-              </label>
-              <input
-                id="sessionTitle"
-                v-model="sessionForm.title"
-                type="text"
-                required
-                placeholder="e.g., Introduction to Vue 3"
-                class="w-full px-4 py-2 border border-verse-300 dark:border-verse-600 squircle rounded-lg bg-white dark:bg-verse-700 text-verse-900 dark:text-verse-100 focus:ring-2 focus:ring-verse-500 focus:border-transparent"
-              />
-              <p v-if="sessionFormErrors.title" class="mt-1 text-sm text-red-600 dark:text-red-400">
-                {{ sessionFormErrors.title }}
-              </p>
-            </div>
-
-            <!-- Description -->
-            <div>
-              <label
-                for="sessionDescription"
-                class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-2"
-              >
-                Description
-              </label>
-              <textarea
-                id="sessionDescription"
-                v-model="sessionForm.description"
-                rows="3"
-                placeholder="Describe what this session is about..."
-                class="w-full px-4 py-2 border border-verse-300 dark:border-verse-600 squircle rounded-lg bg-white dark:bg-verse-700 text-verse-900 dark:text-verse-100 focus:ring-2 focus:ring-verse-500 focus:border-transparent"
-              />
-            </div>
-
-            <!-- Type + Duration -->
-            <div class="grid grid-cols-[1fr_140px] gap-3">
-              <div>
-                <label
-                  for="sessionKind"
-                  class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-2"
-                >
-                  Type
-                </label>
-                <select
-                  id="sessionKind"
-                  v-model="sessionForm.kind"
-                  class="w-full px-4 py-2 border border-verse-300 dark:border-verse-600 squircle rounded-lg bg-white dark:bg-verse-700 text-verse-900 dark:text-verse-100 focus:ring-2 focus:ring-verse-500 focus:border-transparent"
-                >
-                  <option v-for="opt in SESSION_KIND_OPTIONS" :key="opt.value" :value="opt.value">
-                    {{ opt.label }} — {{ opt.hint }}
-                  </option>
-                </select>
-              </div>
-              <div>
-                <label
-                  for="sessionDuration"
-                  class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-2"
-                >
-                  Duration (min)
-                </label>
-                <input
-                  id="sessionDuration"
-                  v-model.number="sessionForm.durationMinutes"
-                  type="number"
-                  min="1"
-                  max="1440"
-                  placeholder="—"
-                  class="w-full px-4 py-2 border border-verse-300 dark:border-verse-600 squircle rounded-lg bg-white dark:bg-verse-700 text-verse-900 dark:text-verse-100 focus:ring-2 focus:ring-verse-500 focus:border-transparent"
-                />
-              </div>
-            </div>
-
-            <!-- Sponsor (sponsored kind only) -->
-            <div v-if="showSponsor">
-              <label
-                for="sessionSponsor"
-                class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-2"
-              >
-                Sponsor *
-              </label>
-              <select
-                id="sessionSponsor"
-                v-model="sessionForm.sponsorId"
-                class="w-full px-4 py-2 border border-verse-300 dark:border-verse-600 squircle rounded-lg bg-white dark:bg-verse-700 text-verse-900 dark:text-verse-100 focus:ring-2 focus:ring-verse-500 focus:border-transparent"
-              >
-                <option :value="null">— Pick a sponsor —</option>
-                <option v-for="sp in sponsors" :key="sp.id" :value="sp.id">
-                  {{ sp.name }}
-                </option>
-              </select>
-              <p
-                v-if="sponsors.length === 0"
-                class="mt-2 text-xs text-verse-500 dark:text-verse-400"
-              >
-                Attach sponsors to this event first (below the Sessions section).
-              </p>
-            </div>
-
-            <!-- Speakers -->
-            <div v-if="showSpeakers">
-              <label class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-2">
-                Speakers
-              </label>
-              <div v-if="loadingSpeakers" class="text-center py-4">
-                <span class="text-verse-500 dark:text-verse-400">Loading speakers...</span>
-              </div>
-              <div v-else-if="availableSpeakers.length > 0">
-                <!-- Search input -->
-                <div class="relative mb-2">
-                  <input
-                    v-model="speakerSearch"
-                    type="text"
-                    placeholder="Search speakers..."
-                    class="w-full px-4 py-2 pl-10 border border-verse-300 dark:border-verse-600 squircle rounded-lg bg-white dark:bg-verse-700 text-verse-900 dark:text-verse-100 focus:ring-2 focus:ring-verse-500 focus:border-transparent text-sm"
-                  />
-                  <svg
-                    class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-verse-400"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
-                    />
-                  </svg>
-                </div>
-                <!-- Speaker list -->
-                <div
-                  class="max-h-48 overflow-y-auto border border-verse-300 dark:border-verse-600 squircle rounded-lg"
-                >
-                  <div
-                    v-for="speaker in filteredSpeakers"
-                    :key="speaker.id"
-                    @click="toggleSpeaker(speaker.id)"
-                    class="flex items-center gap-3 p-3 cursor-pointer hover:bg-verse-50 dark:hover:bg-verse-700 transition-colors"
-                    :class="{ 'bg-verse-100 dark:bg-verse-600': isSpeakerSelected(speaker.id) }"
-                  >
-                    <input
-                      type="checkbox"
-                      :checked="isSpeakerSelected(speaker.id)"
-                      class="w-4 h-4 text-verse-600 border-verse-300 rounded focus:ring-verse-500"
-                      @click.stop
-                      @change="toggleSpeaker(speaker.id)"
-                    />
-                    <img
-                      v-if="speaker.avatarUrl"
-                      :src="speaker.avatarUrl"
-                      :alt="speaker.name"
-                      class="w-8 h-8 rounded-full object-cover"
-                    />
-                    <div
-                      v-else
-                      class="w-8 h-8 rounded-full bg-verse-300 dark:bg-verse-600 flex items-center justify-center text-verse-600 dark:text-verse-300 text-sm font-medium"
-                    >
-                      {{ speaker.name.charAt(0).toUpperCase() }}
-                    </div>
-                    <div class="flex-1 min-w-0">
-                      <p class="text-sm font-medium text-verse-900 dark:text-verse-100 truncate">
-                        {{ speaker.name }}
-                      </p>
-                      <p
-                        v-if="speaker.email"
-                        class="text-xs text-verse-500 dark:text-verse-400 truncate"
-                      >
-                        {{ speaker.email }}
-                      </p>
-                    </div>
-                  </div>
-                  <p
-                    v-if="filteredSpeakers.length === 0"
-                    class="text-sm text-verse-500 dark:text-verse-400 py-4 text-center"
-                  >
-                    No speakers found matching "{{ speakerSearch }}"
-                  </p>
-                </div>
-              </div>
-              <p v-else class="text-sm text-verse-500 dark:text-verse-400 py-4 text-center">
-                No speakers available. Users with member role or above can be speakers.
-              </p>
-              <p
-                v-if="sessionForm.speakerIds.length > 0"
-                class="mt-2 text-xs text-verse-500 dark:text-verse-400"
-              >
-                {{ sessionForm.speakerIds.length }} speaker(s) selected
-              </p>
-            </div>
-
-            <!-- Actions -->
-            <div
-              class="flex items-center justify-end gap-3 pt-4 border-t border-verse-200 dark:border-verse-700"
-            >
-              <button
-                type="button"
-                @click="closeSessionForm"
-                class="px-4 py-2 border border-verse-300 dark:border-verse-600 text-verse-700 dark:text-verse-300 hover:bg-verse-50 dark:hover:bg-verse-700 font-medium squircle rounded-lg transition-colors"
-              >
-                Cancel
-              </button>
-              <button
-                type="submit"
-                :disabled="sessionFormProcessing"
-                class="px-4 py-2 bg-verse-600 hover:bg-verse-700 disabled:bg-verse-400 text-white font-medium squircle rounded-lg transition-colors"
-              >
-                <span v-if="sessionFormProcessing">Saving...</span>
-                <span v-else>{{ editingSession ? 'Update Session' : 'Create Session' }}</span>
-              </button>
-            </div>
-          </form>
-        </dialog>
-
-        <!-- Edit Form -->
-        <form @submit.prevent="handleSubmit" class="space-y-6">
-          <!-- Title -->
-          <div>
-            <label
-              for="title"
-              class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-2"
-            >
-              Title *
-            </label>
-            <input
-              id="title"
-              v-model="form.title"
-              type="text"
-              required
-              class="w-full px-4 py-2 border border-verse-300 dark:border-verse-600 squircle rounded-lg bg-white dark:bg-verse-800 text-verse-900 dark:text-verse-100 focus:ring-2 focus:ring-verse-500 focus:border-transparent"
-            />
-            <p v-if="form.errors.title" class="mt-1 text-sm text-red-600 dark:text-red-400">
-              {{ form.errors.title }}
-            </p>
-          </div>
-
-          <!-- Event Date -->
-          <div>
-            <label
-              for="eventDate"
-              class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-2"
-            >
-              Event Date *
-            </label>
-            <input
-              id="eventDate"
+    <div class="grid grid-cols-1 xl:grid-cols-[minmax(0,1fr)_320px] gap-6">
+      <form class="space-y-6 min-w-0" @submit.prevent="handleSubmit">
+        <AdminCard title="Basics">
+          <div class="space-y-5">
+            <AdminInput v-model="form.title" label="Title" required :error="form.errors.title" />
+            <AdminInput
               v-model="form.eventDate"
+              label="Event date"
               type="date"
               required
-              class="w-full px-4 py-2 border border-verse-300 dark:border-verse-600 squircle rounded-lg bg-white dark:bg-verse-800 text-verse-900 dark:text-verse-100 focus:ring-2 focus:ring-verse-500 focus:border-transparent"
+              :error="form.errors.eventDate"
             />
-            <p v-if="form.errors.eventDate" class="mt-1 text-sm text-red-600 dark:text-red-400">
-              {{ form.errors.eventDate }}
-            </p>
-          </div>
-
-          <!-- Description -->
-          <div>
-            <label
-              for="description"
-              class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-2"
-            >
-              Description
-            </label>
-            <textarea
-              id="description"
+            <AdminTextarea
               v-model="form.description"
-              rows="4"
-              class="w-full px-4 py-2 border border-verse-300 dark:border-verse-600 squircle rounded-lg bg-white dark:bg-verse-800 text-verse-900 dark:text-verse-100 focus:ring-2 focus:ring-verse-500 focus:border-transparent"
+              label="Description"
+              :error="form.errors.description"
             />
-            <p v-if="form.errors.description" class="mt-1 text-sm text-red-600 dark:text-red-400">
-              {{ form.errors.description }}
-            </p>
           </div>
+        </AdminCard>
 
-          <!-- Location & Venue -->
-          <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-            <div>
-              <label
-                for="location"
-                class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-2"
-              >
-                Location
-              </label>
-              <input
-                id="location"
-                v-model="form.location"
-                type="text"
-                class="w-full px-4 py-2 border border-verse-300 dark:border-verse-600 squircle rounded-lg bg-white dark:bg-verse-800 text-verse-900 dark:text-verse-100 focus:ring-2 focus:ring-verse-500 focus:border-transparent"
-              />
+        <AdminCard title="Where & when">
+          <div class="space-y-5">
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <AdminInput v-model="form.location" label="Location" />
+              <AdminInput v-model="form.venue" label="Venue" />
             </div>
-            <div>
-              <label
-                for="venue"
-                class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-2"
-              >
-                Venue
-              </label>
-              <input
-                id="venue"
-                v-model="form.venue"
-                type="text"
-                class="w-full px-4 py-2 border border-verse-300 dark:border-verse-600 squircle rounded-lg bg-white dark:bg-verse-800 text-verse-900 dark:text-verse-100 focus:ring-2 focus:ring-verse-500 focus:border-transparent"
-              />
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <AdminInput v-model="form.startTime" label="Start time" type="time" />
+              <AdminInput v-model="form.endTime" label="End time" type="time" />
+            </div>
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <AdminInput v-model="form.mapUrl" label="Map URL" type="url" />
+              <AdminInput v-model="form.parkingLocation" label="Parking URL" type="url" />
             </div>
           </div>
+        </AdminCard>
 
-          <!-- Start Time & End Time -->
-          <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-            <div>
-              <label
-                for="startTime"
-                class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-2"
-              >
-                Start Time
-              </label>
-              <input
-                id="startTime"
-                v-model="form.startTime"
-                type="time"
-                class="w-full px-4 py-2 border border-verse-300 dark:border-verse-600 squircle rounded-lg bg-white dark:bg-verse-800 text-verse-900 dark:text-verse-100 focus:ring-2 focus:ring-verse-500 focus:border-transparent"
+        <AdminCard title="RSVPs">
+          <div class="space-y-5">
+            <AdminCheckbox
+              v-model="form.acceptingRsvp"
+              label="Accept RSVPs"
+              description="Members can sign up for this event."
+            />
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <AdminInput
+                v-model="form.seatsAvailable"
+                label="Seats available"
+                type="number"
+                min="0"
+                hint="Leave empty for unlimited"
               />
-            </div>
-            <div>
-              <label
-                for="endTime"
-                class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-2"
-              >
-                End Time
-              </label>
-              <input
-                id="endTime"
-                v-model="form.endTime"
-                type="time"
-                class="w-full px-4 py-2 border border-verse-300 dark:border-verse-600 squircle rounded-lg bg-white dark:bg-verse-800 text-verse-900 dark:text-verse-100 focus:ring-2 focus:ring-verse-500 focus:border-transparent"
+              <AdminInput
+                v-model="form.rsvpClosingDate"
+                label="RSVP closing date"
+                type="date"
               />
             </div>
           </div>
+        </AdminCard>
 
-          <!-- RSVP Settings -->
-          <div
-            class="p-4 bg-verse-50 dark:bg-verse-800/50 squircle rounded-lg border border-verse-200 dark:border-verse-700"
-          >
-            <h3 class="text-lg font-medium text-verse-900 dark:text-verse-100 mb-4">
-              RSVP Settings
-            </h3>
-            <div class="space-y-4">
-              <div class="flex items-center gap-3">
-                <input
-                  id="acceptingRsvp"
-                  v-model="form.acceptingRsvp"
-                  type="checkbox"
-                  class="w-4 h-4 text-verse-600 border-verse-300 rounded focus:ring-verse-500"
-                />
-                <label for="acceptingRsvp" class="text-sm text-verse-700 dark:text-verse-300">
-                  Accepting RSVPs
-                </label>
-              </div>
+        <AdminCard title="Visibility">
+          <AdminSelect v-model="form.status" label="Status">
+            <option value="draft">Draft</option>
+            <option value="published">Published</option>
+            <option value="cancelled">Cancelled</option>
+          </AdminSelect>
+        </AdminCard>
 
-              <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-                <div>
-                  <label
-                    for="seatsAvailable"
-                    class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-2"
-                  >
-                    Seats Available
-                  </label>
-                  <input
-                    id="seatsAvailable"
-                    v-model.number="form.seatsAvailable"
-                    type="number"
-                    min="0"
-                    class="w-full px-4 py-2 border border-verse-300 dark:border-verse-600 squircle rounded-lg bg-white dark:bg-verse-800 text-verse-900 dark:text-verse-100 focus:ring-2 focus:ring-verse-500 focus:border-transparent"
-                  />
-                </div>
-                <div>
-                  <label
-                    for="rsvpClosingDate"
-                    class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-2"
-                  >
-                    RSVP Closing Date
-                  </label>
-                  <input
-                    id="rsvpClosingDate"
-                    v-model="form.rsvpClosingDate"
-                    type="date"
-                    class="w-full px-4 py-2 border border-verse-300 dark:border-verse-600 squircle rounded-lg bg-white dark:bg-verse-800 text-verse-900 dark:text-verse-100 focus:ring-2 focus:ring-verse-500 focus:border-transparent"
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <!-- Map & Parking -->
-          <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-            <div>
-              <label
-                for="mapUrl"
-                class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-2"
-              >
-                Map URL
-              </label>
-              <input
-                id="mapUrl"
-                v-model="form.mapUrl"
-                type="url"
-                class="w-full px-4 py-2 border border-verse-300 dark:border-verse-600 squircle rounded-lg bg-white dark:bg-verse-800 text-verse-900 dark:text-verse-100 focus:ring-2 focus:ring-verse-500 focus:border-transparent"
-              />
-            </div>
-            <div>
-              <label
-                for="parkingLocation"
-                class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-2"
-              >
-                Parking Location URL
-              </label>
-              <input
-                id="parkingLocation"
-                v-model="form.parkingLocation"
-                type="url"
-                class="w-full px-4 py-2 border border-verse-300 dark:border-verse-600 squircle rounded-lg bg-white dark:bg-verse-800 text-verse-900 dark:text-verse-100 focus:ring-2 focus:ring-verse-500 focus:border-transparent"
-              />
-            </div>
-          </div>
-
-          <!-- Status -->
-          <div>
-            <label
-              for="status"
-              class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-2"
-            >
-              Status
-            </label>
-            <select
-              id="status"
-              v-model="form.status"
-              class="w-full px-4 py-2 border border-verse-300 dark:border-verse-600 squircle rounded-lg bg-white dark:bg-verse-800 text-verse-900 dark:text-verse-100 focus:ring-2 focus:ring-verse-500 focus:border-transparent"
-            >
-              <option value="draft">Draft</option>
-              <option value="published">Published</option>
-              <option value="cancelled">Cancelled</option>
-            </select>
-          </div>
-
-          <!-- Actions -->
-          <div class="flex items-center gap-4 pt-4">
-            <button
-              type="submit"
-              :disabled="form.processing"
-              class="px-6 py-2.5 bg-verse-600 hover:bg-verse-700 disabled:bg-verse-400 text-white font-medium squircle rounded-lg transition-colors"
-            >
-              <span v-if="form.processing">Saving...</span>
-              <span v-else>Save Changes</span>
-            </button>
-            <Link
-              :href="`/meetup/${event.slug || event.id}`"
-              class="px-6 py-2.5 border border-verse-300 dark:border-verse-600 text-verse-700 dark:text-verse-300 hover:bg-verse-50 dark:hover:bg-verse-800 font-medium squircle rounded-lg transition-colors"
-            >
-              Cancel
-            </Link>
-          </div>
-        </form>
-
-        <!-- Sessions Section -->
         <div
-          class="mt-12 p-4 bg-verse-50 dark:bg-verse-800/50 squircle rounded-lg border border-verse-200 dark:border-verse-700"
+          class="sticky bottom-3 z-10 flex justify-end gap-2 bg-white/85 dark:bg-verse-950/85 backdrop-blur-md p-3 rounded-xl border border-verse-200 dark:border-verse-800"
         >
-          <div class="flex items-center justify-between mb-4">
-            <h3 class="text-lg font-medium text-verse-900 dark:text-verse-100">Sessions</h3>
-            <button
-              type="button"
-              @click="() => openNewSessionForm()"
-              class="px-4 py-2 bg-verse-600 hover:bg-verse-700 text-white text-sm font-medium squircle rounded-lg transition-colors"
-            >
-              Add Session
-            </button>
-          </div>
+          <AdminButton :href="`/meetup/${event.slug || event.id}`" variant="secondary">
+            Cancel
+          </AdminButton>
+          <AdminButton type="submit" variant="primary" :loading="form.processing">
+            {{ form.processing ? 'Saving…' : 'Save changes' }}
+          </AdminButton>
+        </div>
+      </form>
 
-          <!-- Quick-add presets -->
+      <!-- Side rail: sessions & sponsors -->
+      <aside class="space-y-6 min-w-0">
+        <AdminCard title="Schedule" :description="`${sessions.length} session${sessions.length === 1 ? '' : 's'}`">
+          <template #headerActions>
+            <AdminButton size="sm" variant="primary" @click="openNewSessionForm()">
+              + Session
+            </AdminButton>
+          </template>
+
           <div
-            class="flex flex-wrap items-center gap-2 mb-4 pb-4 border-b border-verse-200 dark:border-verse-700"
+            v-if="sessions.length"
+            class="space-y-2"
+            aria-label="Sessions list"
           >
-            <span
-              class="text-xs font-medium text-verse-500 dark:text-verse-400 uppercase tracking-wide"
-            >
-              Quick add
-            </span>
-            <button
-              v-for="preset in [
-                { key: 'intro', label: '+ Intro' },
-                { key: 'break', label: '+ Lunch break' },
-                { key: 'photo', label: '+ Group photo' },
-                { key: 'quiz', label: '+ Quiz' },
-                { key: 'sponsored', label: '+ Sponsored' },
-              ]"
-              :key="preset.key"
-              type="button"
-              @click="
-                openNewSessionForm(preset.key as 'intro' | 'break' | 'photo' | 'quiz' | 'sponsored')
-              "
-              class="px-2.5 py-1 text-xs font-medium text-verse-700 dark:text-verse-300 bg-white dark:bg-verse-700 border border-verse-300 dark:border-verse-600 hover:border-verse-500 hover:text-verse-900 dark:hover:text-verse-100 squircle rounded-md transition-colors"
-            >
-              {{ preset.label }}
-            </button>
-          </div>
-
-          <!-- Sessions List -->
-          <div v-if="sessions.length > 0" class="space-y-2">
-            <p class="text-xs text-verse-500 dark:text-verse-400 mb-2">Drag sessions to reorder</p>
+            <p class="text-[11px] font-mono text-verse-500 dark:text-verse-400 mb-2 uppercase tracking-wide">
+              Drag to reorder
+            </p>
             <div
               v-for="(session, index) in sessions"
               :key="session.id"
               draggable="true"
-              class="p-4 bg-white dark:bg-verse-700/50 squircle rounded-lg border-2 transition-all cursor-grab active:cursor-grabbing"
               :class="[
+                'group p-3 rounded-xl border transition-all cursor-grab active:cursor-grabbing',
                 dragOverIndex === index
-                  ? 'border-verse-500 bg-verse-50 dark:bg-verse-600/50'
-                  : 'border-verse-200 dark:border-verse-600',
+                  ? 'border-coral-strong bg-coral-soft/40 dark:bg-coral-strong/10'
+                  : 'border-verse-200 dark:border-verse-800 bg-white dark:bg-verse-900/40',
                 draggedSession?.id === session.id ? 'opacity-50' : '',
               ]"
               @dragstart="onDragStart(session)"
@@ -1019,252 +526,350 @@ async function removeSponsor(sponsorId: string) {
               @drop="onDrop(index)"
               @dragend="onDragEnd"
             >
-              <div class="flex items-start justify-between gap-4">
-                <div class="flex items-start gap-3 flex-1 min-w-0">
-                  <!-- Drag handle -->
-                  <div class="flex-shrink-0 mt-1 text-verse-400 dark:text-verse-500">
-                    <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
-                      <path
-                        d="M7 2a2 2 0 1 0 0 4 2 2 0 0 0 0-4zM7 8a2 2 0 1 0 0 4 2 2 0 0 0 0-4zM7 14a2 2 0 1 0 0 4 2 2 0 0 0 0-4zM13 2a2 2 0 1 0 0 4 2 2 0 0 0 0-4zM13 8a2 2 0 1 0 0 4 2 2 0 0 0 0-4zM13 14a2 2 0 1 0 0 4 2 2 0 0 0 0-4z"
-                      />
-                    </svg>
-                  </div>
-                  <div class="flex-1 min-w-0">
-                    <div class="flex items-center gap-2 mb-1 flex-wrap">
-                      <span
-                        class="px-2 py-0.5 bg-verse-200 dark:bg-verse-600 text-verse-700 dark:text-verse-200 text-xs font-medium rounded"
-                      >
-                        #{{ index + 1 }}
-                      </span>
-                      <span
-                        v-if="session.kind && session.kind !== 'talk'"
-                        class="px-2 py-0.5 bg-coral-soft text-coral-strong text-[10.5px] font-mono font-semibold uppercase tracking-wider rounded"
-                      >
-                        {{ session.kind }}
-                      </span>
-                      <h4 class="font-medium text-verse-900 dark:text-verse-100 truncate">
-                        {{ session.title }}
-                      </h4>
-                      <span
-                        v-if="session.durationMinutes"
-                        class="text-xs font-mono text-verse-500 dark:text-verse-400"
-                      >
-                        · {{ session.durationMinutes }}m
-                      </span>
-                    </div>
-                    <p
-                      v-if="session.description"
-                      class="text-sm text-verse-600 dark:text-verse-400 line-clamp-2 mb-2"
-                    >
-                      {{ session.description }}
-                    </p>
-                    <div
-                      v-if="session.speakers?.length"
-                      class="flex items-center gap-2 text-sm text-verse-500 dark:text-verse-400"
-                    >
-                      <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          stroke-width="2"
-                          d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
-                        />
-                      </svg>
-                      <span>{{ getSpeakerNames(session.speakers) }}</span>
-                    </div>
-                  </div>
+              <div class="flex items-start gap-2">
+                <div class="mt-0.5 text-verse-400 dark:text-verse-500 cursor-grab" aria-hidden="true">
+                  <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
+                    <circle cx="9" cy="5" r="1.5" />
+                    <circle cx="9" cy="12" r="1.5" />
+                    <circle cx="9" cy="19" r="1.5" />
+                    <circle cx="15" cy="5" r="1.5" />
+                    <circle cx="15" cy="12" r="1.5" />
+                    <circle cx="15" cy="19" r="1.5" />
+                  </svg>
                 </div>
-                <div class="flex items-center gap-2 flex-shrink-0">
+                <div class="flex-1 min-w-0">
+                  <div class="flex items-center gap-1.5 flex-wrap mb-1">
+                    <span class="text-[10px] font-mono text-verse-500 dark:text-verse-400 tabular-nums">
+                      #{{ index + 1 }}
+                    </span>
+                    <AdminBadge v-if="session.kind && session.kind !== 'talk'" tone="accent">
+                      {{ session.kind }}
+                    </AdminBadge>
+                    <span
+                      v-if="session.durationMinutes"
+                      class="text-[10px] font-mono text-verse-500 dark:text-verse-400"
+                    >
+                      {{ session.durationMinutes }}m
+                    </span>
+                  </div>
+                  <p class="text-sm font-medium text-verse-900 dark:text-verse-100 truncate">
+                    {{ session.title }}
+                  </p>
+                  <p
+                    v-if="session.speakers?.length"
+                    class="text-xs text-verse-500 dark:text-verse-400 truncate mt-0.5"
+                  >
+                    {{ getSpeakerNames(session.speakers) }}
+                  </p>
+                </div>
+                <div class="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
                   <button
                     type="button"
+                    class="p-1.5 rounded-md text-verse-500 hover:text-verse-900 dark:hover:text-verse-100 hover:bg-verse-100 dark:hover:bg-verse-800"
+                    title="Edit"
+                    aria-label="Edit session"
                     @click="openEditSessionForm(session)"
-                    class="p-2 text-verse-600 hover:text-verse-800 dark:text-verse-400 dark:hover:text-verse-200 hover:bg-verse-100 dark:hover:bg-verse-600 squircle rounded-lg transition-colors"
-                    title="Edit session"
                   >
-                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        stroke-width="2"
-                        d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
-                      />
+                    <svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+                      <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
+                      <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
                     </svg>
                   </button>
                   <button
                     type="button"
-                    @click.stop="deleteSession(session)"
-                    class="p-2 text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-200 hover:bg-red-100 dark:hover:bg-red-900/30 squircle rounded-lg transition-colors"
-                    title="Delete session"
+                    class="p-1.5 rounded-md text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20"
+                    title="Delete"
+                    aria-label="Delete session"
+                    @click="confirmDeleteSession(session)"
                   >
-                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        stroke-width="2"
-                        d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
-                      />
+                    <svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+                      <polyline points="3 6 5 6 21 6" />
+                      <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
                     </svg>
                   </button>
                 </div>
               </div>
             </div>
           </div>
-          <p v-else class="text-center py-8 text-verse-500 dark:text-verse-400">
-            No sessions yet. Click "Add Session" to create one.
+          <p v-else class="text-sm text-verse-500 dark:text-verse-400 py-3 text-center">
+            No sessions yet.
           </p>
-        </div>
 
-        <!-- Sponsors Section -->
-        <div
-          class="mt-12 p-4 bg-verse-50 dark:bg-verse-800/50 squircle rounded-lg border border-verse-200 dark:border-verse-700"
-        >
-          <div class="flex items-center justify-between mb-4">
-            <h3 class="text-lg font-medium text-verse-900 dark:text-verse-100">Sponsors</h3>
-            <button
-              type="button"
-              @click="openSponsorPicker"
-              class="px-4 py-2 bg-verse-600 hover:bg-verse-700 text-white text-sm font-medium squircle rounded-lg transition-colors"
-            >
-              Add Sponsor
-            </button>
-          </div>
+          <template #footer>
+            <div class="flex flex-wrap gap-1.5 text-[11px] font-mono text-verse-500 dark:text-verse-400 uppercase tracking-wide">
+              <span class="self-center mr-1">Quick add</span>
+              <button
+                v-for="preset in [
+                  { key: 'intro' as const, label: 'Intro' },
+                  { key: 'break' as const, label: 'Lunch' },
+                  { key: 'photo' as const, label: 'Photo' },
+                  { key: 'quiz' as const, label: 'Quiz' },
+                  { key: 'sponsored' as const, label: 'Sponsored' },
+                ]"
+                :key="preset.key"
+                type="button"
+                class="px-2 py-1 rounded-md border border-verse-200 dark:border-verse-700 hover:border-verse-400 dark:hover:border-verse-500 transition-colors text-verse-600 dark:text-verse-300 normal-case font-sans tracking-normal"
+                @click="openNewSessionForm(preset.key)"
+              >
+                + {{ preset.label }}
+              </button>
+            </div>
+          </template>
+        </AdminCard>
 
-          <!-- Sponsor Picker -->
+        <AdminCard title="Sponsors" :description="`${sponsors.length} attached`">
+          <template #headerActions>
+            <AdminButton size="sm" variant="primary" @click="openSponsorPicker">+ Sponsor</AdminButton>
+          </template>
+
           <div
             v-if="sponsorPickerOpen"
-            class="mb-4 p-4 bg-white dark:bg-verse-700/50 squircle rounded-lg border border-verse-200 dark:border-verse-600"
+            class="mb-3 p-3 rounded-xl bg-verse-50 dark:bg-verse-900/40 border border-verse-200 dark:border-verse-800"
           >
-            <div class="flex items-center justify-between mb-3">
-              <span class="text-sm font-medium text-verse-700 dark:text-verse-300"
-                >Select a sponsor</span
-              >
+            <div class="flex items-center justify-between mb-2">
+              <span class="text-xs font-medium text-verse-700 dark:text-verse-300">Attach sponsor</span>
               <button
                 type="button"
+                class="p-1 rounded text-verse-500 hover:text-verse-700 dark:hover:text-verse-300"
+                aria-label="Close"
                 @click="sponsorPickerOpen = false"
-                class="p-1 text-verse-500 hover:text-verse-700 dark:text-verse-400 dark:hover:text-verse-200"
               >
-                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                    d="M6 18L18 6M6 6l12 12"
-                  />
+                <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+                  <line x1="18" y1="6" x2="6" y2="18" />
+                  <line x1="6" y1="6" x2="18" y2="18" />
                 </svg>
               </button>
             </div>
-            <div class="relative mb-2">
-              <input
-                v-model="sponsorSearch"
-                type="text"
-                placeholder="Search sponsors..."
-                class="w-full px-4 py-2 pl-10 border border-verse-300 dark:border-verse-600 squircle rounded-lg bg-white dark:bg-verse-700 text-verse-900 dark:text-verse-100 focus:ring-2 focus:ring-verse-500 focus:border-transparent text-sm"
-              />
-              <svg
-                class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-verse-400"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
-                />
-              </svg>
+            <AdminSearchInput v-model="sponsorSearch" placeholder="Search sponsors…" />
+            <div v-if="loadingSponsors" class="text-center py-3 text-sm text-verse-500">
+              Loading…
             </div>
-            <div v-if="loadingSponsors" class="text-center py-4">
-              <span class="text-verse-500 dark:text-verse-400 text-sm">Loading sponsors...</span>
-            </div>
-            <div v-else class="max-h-48 overflow-y-auto">
-              <div
+            <div v-else class="mt-2 max-h-48 overflow-y-auto space-y-1">
+              <button
                 v-for="sponsor in filteredAvailableSponsors"
                 :key="sponsor.id"
+                type="button"
+                class="w-full flex items-center gap-3 p-2 rounded-lg hover:bg-verse-100 dark:hover:bg-verse-800 transition-colors text-left"
                 @click="attachSponsor(sponsor)"
-                class="flex items-center gap-3 p-2 cursor-pointer hover:bg-verse-50 dark:hover:bg-verse-600 squircle rounded-lg transition-colors"
               >
-                <img
-                  v-if="sponsor.logoUrl"
+                <AdminAvatar
                   :src="sponsor.logoUrl"
-                  :alt="sponsor.name"
-                  class="w-8 h-8 rounded object-contain bg-white"
+                  :name="sponsor.name"
+                  size="sm"
+                  rounded="lg"
                 />
-                <div
-                  v-else
-                  class="w-8 h-8 rounded bg-verse-300 dark:bg-verse-600 flex items-center justify-center text-verse-600 dark:text-verse-300 text-sm font-medium"
-                >
-                  {{ sponsor.name.charAt(0).toUpperCase() }}
-                </div>
-                <span class="text-sm text-verse-900 dark:text-verse-100">{{ sponsor.name }}</span>
-              </div>
+                <span class="text-sm text-verse-900 dark:text-verse-100 truncate">{{ sponsor.name }}</span>
+              </button>
               <p
                 v-if="filteredAvailableSponsors.length === 0"
-                class="text-sm text-verse-500 dark:text-verse-400 py-4 text-center"
+                class="text-xs text-verse-500 dark:text-verse-400 py-2 text-center"
               >
-                {{
-                  sponsorSearch
-                    ? `No sponsors found matching "${sponsorSearch}"`
-                    : 'All sponsors are already attached'
-                }}
+                {{ sponsorSearch ? `No matches for "${sponsorSearch}"` : 'All sponsors attached' }}
               </p>
             </div>
           </div>
 
-          <!-- Attached Sponsors List -->
-          <div v-if="sponsors.length > 0" class="space-y-2">
+          <div v-if="sponsors.length" class="space-y-2">
             <div
               v-for="sponsor in sponsors"
               :key="sponsor.id"
-              class="flex items-center justify-between p-3 bg-white dark:bg-verse-700/50 squircle rounded-lg border border-verse-200 dark:border-verse-600"
+              class="flex items-center gap-3 p-2.5 rounded-lg border border-verse-200 dark:border-verse-800"
             >
-              <div class="flex items-center gap-3 min-w-0">
-                <img
-                  v-if="sponsor.logoUrl"
-                  :src="sponsor.logoUrl"
-                  :alt="sponsor.name"
-                  class="w-8 h-8 rounded object-contain bg-white"
-                />
-                <div
-                  v-else
-                  class="w-8 h-8 rounded bg-verse-300 dark:bg-verse-600 flex items-center justify-center text-verse-600 dark:text-verse-300 text-sm font-medium"
+              <AdminAvatar
+                :src="sponsor.logoUrl"
+                :name="sponsor.name"
+                size="sm"
+                rounded="lg"
+              />
+              <div class="flex-1 min-w-0">
+                <p class="text-sm font-medium text-verse-900 dark:text-verse-100 truncate">
+                  {{ sponsor.name }}
+                </p>
+                <p
+                  v-if="sponsor.sponsorTypes?.length"
+                  class="text-xs text-verse-500 dark:text-verse-400 truncate"
                 >
-                  {{ sponsor.name.charAt(0).toUpperCase() }}
-                </div>
-                <div class="min-w-0">
-                  <p class="text-sm font-medium text-verse-900 dark:text-verse-100 truncate">
-                    {{ sponsor.name }}
-                  </p>
-                  <p
-                    v-if="sponsor.sponsorTypes?.length"
-                    class="text-xs text-verse-500 dark:text-verse-400"
-                  >
-                    {{ sponsor.sponsorTypes.join(', ') }}
-                  </p>
-                </div>
+                  {{ sponsor.sponsorTypes.join(', ') }}
+                </p>
               </div>
               <button
                 type="button"
-                @click="removeSponsor(sponsor.id)"
-                class="p-2 text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-200 hover:bg-red-100 dark:hover:bg-red-900/30 squircle rounded-lg transition-colors"
+                class="p-1.5 rounded-md text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20"
                 title="Remove sponsor"
+                aria-label="Remove sponsor"
+                @click="removeSponsor(sponsor.id)"
               >
-                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                    d="M6 18L18 6M6 6l12 12"
-                  />
+                <svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+                  <line x1="18" y1="6" x2="6" y2="18" />
+                  <line x1="6" y1="6" x2="18" y2="18" />
                 </svg>
               </button>
             </div>
           </div>
-          <p v-else class="text-center py-8 text-verse-500 dark:text-verse-400">
-            No sponsors attached. Click "Add Sponsor" to add one.
+          <p v-else class="text-sm text-verse-500 dark:text-verse-400 py-3 text-center">
+            No sponsors attached.
+          </p>
+        </AdminCard>
+      </aside>
+    </div>
+
+    <!-- Session form dialog (native) -->
+    <dialog
+      ref="sessionDialog"
+      class="w-full max-w-2xl rounded-2xl shadow-xl bg-white dark:bg-verse-900 max-h-[85vh] overflow-hidden border border-verse-200 dark:border-verse-800"
+      @close="isDialogOpen = false"
+    >
+      <div
+        class="flex items-center justify-between px-5 py-4 border-b border-verse-200 dark:border-verse-800"
+      >
+        <h3 class="text-base font-semibold text-verse-900 dark:text-verse-50">
+          {{ editingSession ? 'Edit session' : 'New session' }}
+        </h3>
+        <button
+          type="button"
+          class="p-1.5 text-verse-500 hover:text-verse-900 dark:hover:text-verse-100 rounded-lg transition-colors"
+          aria-label="Close"
+          @click="closeSessionForm"
+        >
+          <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+            <line x1="18" y1="6" x2="6" y2="18" />
+            <line x1="6" y1="6" x2="18" y2="18" />
+          </svg>
+        </button>
+      </div>
+      <form
+        class="p-5 space-y-4 overflow-y-auto max-h-[calc(85vh-130px)]"
+        @submit.prevent="saveSession"
+      >
+        <AdminInput
+          v-model="sessionForm.title"
+          label="Title"
+          required
+          placeholder="e.g. Introduction to Vue 3"
+          :error="sessionFormErrors.title"
+        />
+        <AdminTextarea
+          v-model="sessionForm.description"
+          label="Description"
+          :rows="3"
+          placeholder="What is this session about?"
+        />
+        <div class="grid grid-cols-[1fr_140px] gap-3">
+          <AdminSelect v-model="sessionForm.kind" label="Type">
+            <option v-for="opt in SESSION_KIND_OPTIONS" :key="opt.value" :value="opt.value">
+              {{ opt.label }} — {{ opt.hint }}
+            </option>
+          </AdminSelect>
+          <AdminInput
+            v-model="sessionForm.durationMinutes"
+            label="Duration (min)"
+            type="number"
+            min="1"
+            max="1440"
+            placeholder="—"
+          />
+        </div>
+
+        <AdminSelect v-if="showSponsor" v-model="sessionForm.sponsorId" label="Sponsor" required>
+          <option :value="null">— Pick a sponsor —</option>
+          <option v-for="sp in sponsors" :key="sp.id" :value="sp.id">{{ sp.name }}</option>
+        </AdminSelect>
+        <p
+          v-if="showSponsor && sponsors.length === 0"
+          class="text-xs text-amber-600 dark:text-amber-400"
+        >
+          Attach sponsors to this event first (Sponsors panel).
+        </p>
+
+        <div v-if="showSpeakers">
+          <label class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-1.5">
+            Speakers
+          </label>
+          <div v-if="loadingSpeakers" class="text-center py-3 text-sm text-verse-500">
+            Loading speakers…
+          </div>
+          <div v-else-if="availableSpeakers.length > 0">
+            <AdminSearchInput v-model="speakerSearch" placeholder="Search speakers…" class="mb-2" />
+            <div
+              class="max-h-48 overflow-y-auto rounded-lg border border-verse-200 dark:border-verse-800"
+            >
+              <button
+                v-for="speaker in filteredSpeakers"
+                :key="speaker.id"
+                type="button"
+                :class="[
+                  'w-full flex items-center gap-3 p-2.5 text-left transition-colors',
+                  isSpeakerSelected(speaker.id)
+                    ? 'bg-verse-100 dark:bg-verse-800'
+                    : 'hover:bg-verse-50 dark:hover:bg-verse-800/50',
+                ]"
+                @click="toggleSpeaker(speaker.id)"
+              >
+                <input
+                  type="checkbox"
+                  :checked="isSpeakerSelected(speaker.id)"
+                  class="w-4 h-4 text-verse-600 border-verse-300 rounded focus:ring-verse-500 pointer-events-none"
+                  tabindex="-1"
+                />
+                <AdminAvatar :src="speaker.avatarUrl" :name="speaker.name" size="sm" />
+                <div class="flex-1 min-w-0">
+                  <p class="text-sm font-medium text-verse-900 dark:text-verse-100 truncate">
+                    {{ speaker.name }}
+                  </p>
+                  <p
+                    v-if="speaker.email"
+                    class="text-xs text-verse-500 dark:text-verse-400 truncate"
+                  >
+                    {{ speaker.email }}
+                  </p>
+                </div>
+              </button>
+              <p
+                v-if="filteredSpeakers.length === 0"
+                class="text-sm text-verse-500 dark:text-verse-400 py-3 text-center"
+              >
+                No speakers found.
+              </p>
+            </div>
+            <p
+              v-if="sessionForm.speakerIds.length > 0"
+              class="mt-2 text-xs text-verse-500 dark:text-verse-400"
+            >
+              {{ sessionForm.speakerIds.length }} speaker(s) selected
+            </p>
+          </div>
+          <p v-else class="text-sm text-verse-500 dark:text-verse-400 py-3 text-center">
+            No speakers available. Members can be assigned as speakers.
           </p>
         </div>
+      </form>
+
+      <div
+        class="flex items-center justify-end gap-2 px-5 py-3 border-t border-verse-200 dark:border-verse-800"
+      >
+        <AdminButton variant="secondary" @click="closeSessionForm">Cancel</AdminButton>
+        <AdminButton
+          type="submit"
+          variant="primary"
+          :loading="sessionFormProcessing"
+          @click="saveSession"
+        >
+          {{ editingSession ? 'Update session' : 'Create session' }}
+        </AdminButton>
       </div>
-    </ContentBlock>
-  </main>
+    </dialog>
+  </AdminShell>
+
+  <AdminConfirmModal
+    :open="!!sessionToDelete"
+    title="Delete session"
+    :loading="isDeletingSession"
+    confirm-label="Delete session"
+    @cancel="sessionToDelete = null"
+    @confirm="deleteSession"
+  >
+    Are you sure you want to delete
+    <strong class="text-verse-900 dark:text-verse-100">{{ sessionToDelete?.title }}</strong
+    >?
+  </AdminConfirmModal>
 </template>

--- a/packages/frontendmu-adonis/inertia/pages/admin/events/edit.vue
+++ b/packages/frontendmu-adonis/inertia/pages/admin/events/edit.vue
@@ -716,7 +716,13 @@ async function removeSponsor(sponsorId: string) {
     <dialog
       ref="sessionDialog"
       class="w-full max-w-2xl rounded-2xl shadow-xl bg-white dark:bg-verse-900 max-h-[85vh] overflow-hidden border border-verse-200 dark:border-verse-800"
-      @close="isDialogOpen = false"
+      @close="
+        () => {
+          isDialogOpen = false
+          editingSession = null
+          sessionFormErrors = {}
+        }
+      "
     >
       <div
         class="flex items-center justify-between px-5 py-4 border-b border-verse-200 dark:border-verse-800"

--- a/packages/frontendmu-adonis/inertia/pages/admin/events/index.vue
+++ b/packages/frontendmu-adonis/inertia/pages/admin/events/index.vue
@@ -74,7 +74,7 @@ function doDelete() {
         :chips="filterChips"
         aria--label="Filter by status"
       />
-      <p class="text-xs font-mono text-verse-500 dark:text-verse-400 tabular-nums">
+      <p class="text-xs font-mono text-verse-500 dark:text-verse-300 tabular-nums">
         Showing {{ events.length }} event{{ events.length === 1 ? '' : 's' }}
       </p>
     </div>
@@ -103,7 +103,7 @@ function doDelete() {
               >
                 {{ event.title }}
               </Link>
-              <span v-if="event.venue" class="text-xs text-verse-500 dark:text-verse-400 mt-0.5">
+              <span v-if="event.venue" class="text-xs text-verse-500 dark:text-verse-300 mt-0.5">
                 {{ event.venue }}
               </span>
             </div>

--- a/packages/frontendmu-adonis/inertia/pages/admin/events/index.vue
+++ b/packages/frontendmu-adonis/inertia/pages/admin/events/index.vue
@@ -72,7 +72,7 @@ function doDelete() {
       <AdminFilterChips
         v-model="currentStatus"
         :chips="filterChips"
-        aria--label="Filter by status"
+        aria-label="Filter by status"
       />
       <p class="text-xs font-mono text-verse-500 dark:text-verse-300 tabular-nums">
         Showing {{ events.length }} event{{ events.length === 1 ? '' : 's' }}

--- a/packages/frontendmu-adonis/inertia/pages/admin/events/index.vue
+++ b/packages/frontendmu-adonis/inertia/pages/admin/events/index.vue
@@ -1,9 +1,15 @@
 <script setup lang="ts">
-import { Head, router } from '@inertiajs/vue3'
-import { Link } from '@inertiajs/vue3'
+import { computed } from 'vue'
+import { Head, Link, router } from '@inertiajs/vue3'
 import type { Data } from '@generated/data'
-import ContentBlock from '~/components/shared/ContentBlock.vue'
-import BaseHeading from '~/components/base/BaseHeading.vue'
+import AdminShell from '~/components/admin/ui/AdminShell.vue'
+import AdminCard from '~/components/admin/ui/AdminCard.vue'
+import AdminBadge from '~/components/admin/ui/AdminBadge.vue'
+import AdminButton from '~/components/admin/ui/AdminButton.vue'
+import AdminTable from '~/components/admin/ui/AdminTable.vue'
+import AdminFilterChips from '~/components/admin/ui/AdminFilterChips.vue'
+import AdminEmptyState from '~/components/admin/ui/AdminEmptyState.vue'
+import AdminConfirmModal from '~/components/admin/ui/AdminConfirmModal.vue'
 import { useAuth } from '~/composables/use_auth'
 import { useDeleteConfirmation } from '~/composables/use_delete_confirmation'
 import { formatEventDate } from '~/utils/date'
@@ -19,32 +25,28 @@ const {
   showModal: showDeleteModal,
   itemToDelete: eventToDelete,
   isDeleting,
-  confirmDelete: confirmDeleteItem,
+  confirmDelete,
   cancelDelete,
   executeDelete,
 } = useDeleteConfirmation<Data.Event.Variants['forAdminIndex']>()
 
-// Status badge styles
-const getStatusBadge = (status: string) => {
-  switch (status) {
-    case 'published':
-      return 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300'
-    case 'draft':
-      return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300'
-    case 'cancelled':
-      return 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300'
-    default:
-      return 'bg-gray-100 text-gray-800 dark:bg-gray-900/30 dark:text-gray-300'
-  }
-}
+const filterChips = [
+  { key: 'all', label: 'All' },
+  { key: 'published', label: 'Published' },
+  { key: 'draft', label: 'Draft' },
+  { key: 'cancelled', label: 'Cancelled' },
+]
 
-// Filter events
-function filterByStatus(status: string) {
-  router.get('/admin/events', { status }, { preserveState: true })
-}
+const currentStatus = computed({
+  get: () => props.statusFilter,
+  set: (value) => router.get('/admin/events', { status: value }, { preserveState: true }),
+})
 
-function confirmDelete(event: Data.Event.Variants['forAdminIndex']) {
-  confirmDeleteItem(event)
+function statusTone(status: string) {
+  if (status === 'published') return 'success'
+  if (status === 'draft') return 'warning'
+  if (status === 'cancelled') return 'danger'
+  return 'neutral'
 }
 
 function doDelete() {
@@ -54,301 +56,166 @@ function doDelete() {
 </script>
 
 <template>
-  <Head title="Manage Events" />
-  <main class="relative min-h-screen pt-40 pb-20">
-    <ContentBlock>
-      <!-- Header -->
-      <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-8">
-        <div>
-          <BaseHeading :level="1">Manage Events</BaseHeading>
-          <p class="text-verse-600 dark:text-verse-400 mt-2">
-            View and manage all events including drafts and cancelled events.
-          </p>
-        </div>
-        <Link
-          href="/admin/events/create"
-          class="inline-flex items-center gap-2 px-4 py-2 bg-verse-600 hover:bg-verse-700 text-white text-sm font-medium squircle rounded-lg transition-colors"
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            class="h-4 w-4"
-            viewBox="0 0 20 20"
-            fill="currentColor"
-          >
-            <path
-              fill-rule="evenodd"
-              d="M10 3a1 1 0 011 1v5h5a1 1 0 110 2h-5v5a1 1 0 11-2 0v-5H4a1 1 0 110-2h5V4a1 1 0 011-1z"
-              clip-rule="evenodd"
-            />
-          </svg>
-          Create Event
-        </Link>
-      </div>
+  <Head title="Events · Admin" />
+  <AdminShell title="Events" description="Manage upcoming meetups, drafts and archived events.">
+    <template #actions>
+      <AdminButton href="/admin/events/create" variant="primary">
+        <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <line x1="12" y1="5" x2="12" y2="19" />
+          <line x1="5" y1="12" x2="19" y2="12" />
+        </svg>
+        New event
+      </AdminButton>
+    </template>
 
-      <!-- Filters -->
-      <div class="flex flex-wrap gap-2 mb-6">
-        <button
-          @click="filterByStatus('all')"
-          :class="[
-            'px-4 py-2 squircle rounded-lg text-sm font-medium transition-colors',
-            statusFilter === 'all'
-              ? 'bg-verse-600 text-white'
-              : 'bg-verse-100 dark:bg-verse-800 text-verse-700 dark:text-verse-300 hover:bg-verse-200 dark:hover:bg-verse-700',
-          ]"
-        >
-          All
-        </button>
-        <button
-          @click="filterByStatus('published')"
-          :class="[
-            'px-4 py-2 squircle rounded-lg text-sm font-medium transition-colors',
-            statusFilter === 'published'
-              ? 'bg-green-600 text-white'
-              : 'bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-300 hover:bg-green-200 dark:hover:bg-green-900/50',
-          ]"
-        >
-          Published
-        </button>
-        <button
-          @click="filterByStatus('draft')"
-          :class="[
-            'px-4 py-2 squircle rounded-lg text-sm font-medium transition-colors',
-            statusFilter === 'draft'
-              ? 'bg-yellow-600 text-white'
-              : 'bg-yellow-100 dark:bg-yellow-900/30 text-yellow-700 dark:text-yellow-300 hover:bg-yellow-200 dark:hover:bg-yellow-900/50',
-          ]"
-        >
-          Draft
-        </button>
-        <button
-          @click="filterByStatus('cancelled')"
-          :class="[
-            'px-4 py-2 squircle rounded-lg text-sm font-medium transition-colors',
-            statusFilter === 'cancelled'
-              ? 'bg-red-600 text-white'
-              : 'bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-300 hover:bg-red-200 dark:hover:bg-red-900/50',
-          ]"
-        >
-          Cancelled
-        </button>
-      </div>
+    <div class="flex flex-col gap-4 mb-5 sm:flex-row sm:items-center sm:justify-between">
+      <AdminFilterChips
+        v-model="currentStatus"
+        :chips="filterChips"
+        aria--label="Filter by status"
+      />
+      <p class="text-xs font-mono text-verse-500 dark:text-verse-400 tabular-nums">
+        Showing {{ events.length }} event{{ events.length === 1 ? '' : 's' }}
+      </p>
+    </div>
 
-      <!-- Events Table -->
-      <div
-        class="bg-white dark:bg-verse-800/50 squircle rounded-xl border border-verse-200 dark:border-verse-700 overflow-hidden"
+    <AdminCard :padded="false">
+      <AdminTable
+        v-if="events.length"
+        :columns="[
+          { label: 'Event' },
+          { label: 'Date' },
+          { label: 'Status' },
+          { label: 'RSVP' },
+          { label: 'Actions', align: 'right' },
+        ]"
       >
-        <div class="overflow-x-auto">
-          <table class="w-full">
-            <thead
-              class="bg-verse-50 dark:bg-verse-800 border-b border-verse-200 dark:border-verse-700"
-            >
-              <tr>
-                <th
-                  class="px-6 py-3 text-left text-xs font-semibold text-verse-600 dark:text-verse-400 uppercase tracking-wider"
-                >
-                  Event
-                </th>
-                <th
-                  class="px-6 py-3 text-left text-xs font-semibold text-verse-600 dark:text-verse-400 uppercase tracking-wider"
-                >
-                  Date
-                </th>
-                <th
-                  class="px-6 py-3 text-left text-xs font-semibold text-verse-600 dark:text-verse-400 uppercase tracking-wider"
-                >
-                  Status
-                </th>
-                <th
-                  class="px-6 py-3 text-left text-xs font-semibold text-verse-600 dark:text-verse-400 uppercase tracking-wider"
-                >
-                  RSVP
-                </th>
-                <th
-                  class="px-6 py-3 text-right text-xs font-semibold text-verse-600 dark:text-verse-400 uppercase tracking-wider"
-                >
-                  Actions
-                </th>
-              </tr>
-            </thead>
-            <tbody class="divide-y divide-verse-200 dark:divide-verse-700">
-              <tr
-                v-for="event in events"
-                :key="event.id"
-                class="hover:bg-verse-50 dark:hover:bg-verse-800/80 transition-colors"
+        <tr
+          v-for="event in events"
+          :key="event.id"
+          class="hover:bg-verse-50/50 dark:hover:bg-verse-800/40 transition-colors"
+        >
+          <td class="px-5 py-3.5">
+            <div class="flex flex-col">
+              <Link
+                :href="`/admin/events/${event.id}/edit`"
+                class="font-medium text-verse-900 dark:text-verse-50 hover:underline decoration-coral-strong decoration-2 underline-offset-4"
               >
-                <td class="px-6 py-4">
-                  <div class="flex flex-col">
-                    <span class="font-medium text-verse-900 dark:text-verse-100">
-                      {{ event.title }}
-                    </span>
-                    <span v-if="event.venue" class="text-sm text-verse-500 dark:text-verse-400">
-                      {{ event.venue }}
-                    </span>
-                  </div>
-                </td>
-                <td class="px-6 py-4 text-sm text-verse-600 dark:text-verse-400">
-                  {{ formatEventDate(event.date) }}
-                </td>
-                <td class="px-6 py-4">
-                  <span
-                    :class="[
-                      'px-2.5 py-1 rounded-full text-xs font-medium capitalize',
-                      getStatusBadge(event.status),
-                    ]"
-                  >
-                    {{ event.status }}
-                  </span>
-                </td>
-                <td class="px-6 py-4">
-                  <span
-                    v-if="event.acceptingRsvp"
-                    class="px-2.5 py-1 rounded-full text-xs font-medium bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300"
-                  >
-                    Open
-                  </span>
-                  <span
-                    v-else
-                    class="px-2.5 py-1 rounded-full text-xs font-medium bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400"
-                  >
-                    Closed
-                  </span>
-                </td>
-                <td class="px-6 py-4 text-right">
-                  <div class="flex items-center justify-end gap-2">
-                    <Link
-                      :href="`/meetup/${event.slug || event.id}`"
-                      class="p-2 text-verse-500 hover:text-verse-700 dark:text-verse-400 dark:hover:text-verse-200 transition-colors"
-                      title="View"
-                      aria-label="View event"
-                    >
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        class="h-5 w-5"
-                        viewBox="0 0 20 20"
-                        fill="currentColor"
-                      >
-                        <path d="M10 12a2 2 0 100-4 2 2 0 000 4z" />
-                        <path
-                          fill-rule="evenodd"
-                          d="M.458 10C1.732 5.943 5.522 3 10 3s8.268 2.943 9.542 7c-1.274 4.057-5.064 7-9.542 7S1.732 14.057.458 10zM14 10a4 4 0 11-8 0 4 4 0 018 0z"
-                          clip-rule="evenodd"
-                        />
-                      </svg>
-                    </Link>
-                    <Link
-                      :href="`/admin/events/${event.slug || event.id}/attendees`"
-                      class="p-2 text-verse-500 hover:text-verse-700 dark:text-verse-400 dark:hover:text-verse-200 transition-colors"
-                      title="Attendees"
-                      aria-label="View attendees"
-                    >
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        class="h-5 w-5"
-                        viewBox="0 0 20 20"
-                        fill="currentColor"
-                      >
-                        <path
-                          d="M9 6a3 3 0 11-6 0 3 3 0 016 0zM17 6a3 3 0 11-6 0 3 3 0 016 0zM12.93 17c.046-.327.07-.66.07-1a6.97 6.97 0 00-1.5-4.33A5 5 0 0119 16v1h-6.07zM6 11a5 5 0 015 5v1H1v-1a5 5 0 015-5z"
-                        />
-                      </svg>
-                    </Link>
-                    <Link
-                      :href="`/admin/events/${event.id}/edit`"
-                      class="p-2 text-verse-500 hover:text-verse-700 dark:text-verse-400 dark:hover:text-verse-200 transition-colors"
-                      title="Edit"
-                      aria-label="Edit event"
-                    >
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        class="h-5 w-5"
-                        viewBox="0 0 20 20"
-                        fill="currentColor"
-                      >
-                        <path
-                          d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z"
-                        />
-                      </svg>
-                    </Link>
-                    <button
-                      v-if="canDelete"
-                      @click="confirmDelete(event)"
-                      class="p-2 text-red-500 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300 transition-colors"
-                      title="Delete"
-                      aria-label="Delete event"
-                    >
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        class="h-5 w-5"
-                        viewBox="0 0 20 20"
-                        fill="currentColor"
-                      >
-                        <path
-                          fill-rule="evenodd"
-                          d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z"
-                          clip-rule="evenodd"
-                        />
-                      </svg>
-                    </button>
-                  </div>
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
+                {{ event.title }}
+              </Link>
+              <span v-if="event.venue" class="text-xs text-verse-500 dark:text-verse-400 mt-0.5">
+                {{ event.venue }}
+              </span>
+            </div>
+          </td>
+          <td class="px-5 py-3.5 text-sm text-verse-600 dark:text-verse-300 whitespace-nowrap">
+            {{ formatEventDate(event.date) }}
+          </td>
+          <td class="px-5 py-3.5">
+            <AdminBadge :tone="statusTone(event.status)" dot>{{ event.status }}</AdminBadge>
+          </td>
+          <td class="px-5 py-3.5">
+            <AdminBadge :tone="event.acceptingRsvp ? 'info' : 'muted'">
+              {{ event.acceptingRsvp ? 'Open' : 'Closed' }}
+            </AdminBadge>
+          </td>
+          <td class="px-5 py-3.5">
+            <div class="flex items-center justify-end gap-1">
+              <AdminButton
+                :href="`/meetup/${event.slug || event.id}`"
+                variant="ghost"
+                size="sm"
+                icon-only
+                title="View public page"
+              >
+                <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+                  <circle cx="12" cy="12" r="3" />
+                </svg>
+              </AdminButton>
+              <AdminButton
+                :href="`/admin/events/${event.slug || event.id}/attendees`"
+                variant="ghost"
+                size="sm"
+                icon-only
+                title="View attendees"
+              >
+                <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
+                  <circle cx="9" cy="7" r="4" />
+                  <path d="M23 21v-2a4 4 0 0 0-3-3.87M16 3.13a4 4 0 0 1 0 7.75" />
+                </svg>
+              </AdminButton>
+              <AdminButton
+                :href="`/admin/events/${event.id}/edit`"
+                variant="ghost"
+                size="sm"
+                icon-only
+                title="Edit event"
+              >
+                <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
+                  <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
+                </svg>
+              </AdminButton>
+              <button
+                v-if="canDelete"
+                type="button"
+                class="p-2 rounded-lg text-red-500 hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-900/20 dark:text-red-400 dark:hover:text-red-300 transition-colors"
+                title="Delete event"
+                aria-label="Delete event"
+                @click="confirmDelete(event)"
+              >
+                <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <polyline points="3 6 5 6 21 6" />
+                  <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+                </svg>
+              </button>
+            </div>
+          </td>
+        </tr>
+      </AdminTable>
 
-        <!-- Empty state -->
-        <div v-if="!events.length" class="px-6 py-12 text-center">
-          <p class="text-verse-500 dark:text-verse-400">
-            No events found<span v-if="statusFilter !== 'all'">
-              with status "{{ statusFilter }}"</span
-            >.
-          </p>
-          <Link
+      <AdminEmptyState
+        v-else
+        :title="
+          statusFilter !== 'all'
+            ? `No ${statusFilter} events`
+            : 'No events yet'
+        "
+        :description="
+          statusFilter !== 'all'
+            ? `Try a different filter, or clear filters to see all events.`
+            : 'Create your first event to get started.'
+        "
+        icon="M8 2v4M16 2v4M3 10h18M5 4h14a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2z"
+      >
+        <template #actions>
+          <AdminButton
             v-if="statusFilter !== 'all'"
             href="/admin/events"
-            class="inline-block mt-2 text-verse-600 hover:text-verse-800 dark:text-verse-400 dark:hover:text-verse-200 underline"
+            variant="secondary"
           >
-            View all events
-          </Link>
-        </div>
-      </div>
-    </ContentBlock>
-  </main>
+            Clear filters
+          </AdminButton>
+          <AdminButton href="/admin/events/create" variant="primary">
+            New event
+          </AdminButton>
+        </template>
+      </AdminEmptyState>
+    </AdminCard>
+  </AdminShell>
 
-  <!-- Delete Confirmation Modal -->
-  <Teleport to="body">
-    <div v-if="showDeleteModal" class="fixed inset-0 z-50 flex items-center justify-center p-4">
-      <!-- Backdrop -->
-      <div class="absolute inset-0 bg-black/50" @click="cancelDelete" />
-
-      <!-- Modal -->
-      <div
-        class="relative bg-white dark:bg-verse-800 squircle rounded-xl shadow-xl max-w-md w-full p-6"
-      >
-        <h3 class="text-lg font-semibold text-verse-900 dark:text-verse-100 mb-2">Delete Event</h3>
-        <p class="text-verse-600 dark:text-verse-400 mb-4">
-          Are you sure you want to delete "<strong>{{ eventToDelete?.title }}</strong
-          >"? This action cannot be undone.
-        </p>
-
-        <div class="flex justify-end gap-3">
-          <button
-            @click="cancelDelete"
-            :disabled="isDeleting"
-            class="px-4 py-2 text-sm font-medium text-verse-700 dark:text-verse-300 bg-verse-100 dark:bg-verse-700 hover:bg-verse-200 dark:hover:bg-verse-600 squircle rounded-lg transition-colors disabled:opacity-50"
-          >
-            Cancel
-          </button>
-          <button
-            @click="doDelete"
-            :disabled="isDeleting"
-            class="px-4 py-2 text-sm font-medium text-white bg-red-600 hover:bg-red-700 squircle rounded-lg transition-colors disabled:opacity-50"
-          >
-            <span v-if="isDeleting">Deleting...</span>
-            <span v-else>Delete</span>
-          </button>
-        </div>
-      </div>
-    </div>
-  </Teleport>
+  <AdminConfirmModal
+    :open="showDeleteModal"
+    title="Delete event"
+    :loading="isDeleting"
+    confirm-label="Delete event"
+    @cancel="cancelDelete"
+    @confirm="doDelete"
+  >
+    Are you sure you want to delete
+    <strong class="text-verse-900 dark:text-verse-100">{{ eventToDelete?.title }}</strong
+    >? This action cannot be undone.
+  </AdminConfirmModal>
 </template>

--- a/packages/frontendmu-adonis/inertia/pages/admin/index.vue
+++ b/packages/frontendmu-adonis/inertia/pages/admin/index.vue
@@ -148,7 +148,7 @@ const toneClasses: Record<NonNullable<Section['stats'][number]['tone']>, string>
                 </Link>
                 <AdminBadge v-if="section.superadminOnly" tone="danger">Superadmin</AdminBadge>
               </div>
-              <p class="text-sm text-verse-500 dark:text-verse-400 mt-1">
+              <p class="text-sm text-verse-500 dark:text-verse-300 mt-1">
                 {{ section.description }}
               </p>
               <div
@@ -161,7 +161,7 @@ const toneClasses: Record<NonNullable<Section['stats'][number]['tone']>, string>
                   >
                     {{ stat.value }}
                   </span>
-                  <span class="text-xs text-verse-500 dark:text-verse-400 font-mono uppercase tracking-wide">
+                  <span class="text-xs text-verse-500 dark:text-verse-300 font-mono uppercase tracking-wide">
                     {{ stat.label }}
                   </span>
                 </div>

--- a/packages/frontendmu-adonis/inertia/pages/admin/index.vue
+++ b/packages/frontendmu-adonis/inertia/pages/admin/index.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
 import { computed } from 'vue'
-import { Head, usePage } from '@inertiajs/vue3'
-import { Link } from '@inertiajs/vue3'
+import { Head, Link, usePage } from '@inertiajs/vue3'
 import type { Data } from '@generated/data'
-import ContentBlock from '~/components/shared/ContentBlock.vue'
-import BaseHeading from '~/components/base/BaseHeading.vue'
+import AdminShell from '~/components/admin/ui/AdminShell.vue'
+import AdminCard from '~/components/admin/ui/AdminCard.vue'
+import AdminStatGrid from '~/components/admin/ui/AdminStatGrid.vue'
+import AdminBadge from '~/components/admin/ui/AdminBadge.vue'
 
 interface Stats {
   events: {
@@ -25,201 +26,170 @@ interface Props {
 const props = defineProps<Props>()
 const page = usePage<Data.SharedProps>()
 const user = computed(() => page.props.auth.user)
-const isSuperadmin = computed(() => user.value?.roles.some((role) => role.name === 'superadmin') ?? false)
+const isSuperadmin = computed(
+  () => user.value?.roles.some((role) => role.name === 'superadmin') ?? false
+)
 
-// Admin menu items
-const menuItems = [
+const overviewStats = computed(() => [
+  { label: 'Events', value: props.stats.events.total },
+  { label: 'Speakers', value: props.stats.speakers },
+  { label: 'Sponsors', value: props.stats.sponsors },
+  { label: 'Users', value: props.stats.users },
+])
+
+interface Section {
+  title: string
+  href: string
+  description: string
+  stats: { label: string; value: number; tone?: 'success' | 'warning' | 'danger' | 'default' }[]
+  icon: string
+  superadminOnly?: boolean
+  primaryAction?: { label: string; href: string }
+}
+
+const sections = computed<Section[]>(() => [
   {
     title: 'Events',
-    description: 'Create, edit, and manage meetup events',
     href: '/admin/events',
-    icon: 'calendar',
+    description: 'Plan meetups, manage RSVPs and run the event timeline.',
     stats: [
-      { label: 'Total', value: props.stats.events.total },
-      {
-        label: 'Published',
-        value: props.stats.events.published,
-        color: 'text-green-600 dark:text-green-400',
-      },
-      {
-        label: 'Draft',
-        value: props.stats.events.draft,
-        color: 'text-yellow-600 dark:text-yellow-400',
-      },
-      {
-        label: 'Cancelled',
-        value: props.stats.events.cancelled,
-        color: 'text-red-600 dark:text-red-400',
-      },
+      { label: 'Published', value: props.stats.events.published, tone: 'success' },
+      { label: 'Draft', value: props.stats.events.draft, tone: 'warning' },
+      { label: 'Cancelled', value: props.stats.events.cancelled, tone: 'danger' },
     ],
+    icon: 'M8 2v4M16 2v4M3 10h18M5 4h14a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2z',
+    primaryAction: { label: 'New event', href: '/admin/events/create' },
   },
   {
     title: 'Speakers',
-    description: 'Manage speaker profiles and information',
     href: '/admin/speakers',
-    icon: 'users',
-    stats: [{ label: 'Total', value: props.stats.speakers }],
+    description: 'Curate speakers, bios and link them to upcoming sessions.',
+    stats: [{ label: 'In roster', value: props.stats.speakers }],
+    icon: 'M3 21v-2a4 4 0 0 1 4-4h4a4 4 0 0 1 4 4v2M9 11a4 4 0 1 0 0-8 4 4 0 0 0 0 8z',
+    primaryAction: { label: 'Add speaker', href: '/admin/speakers/create' },
   },
   {
     title: 'Sponsors',
-    description: 'Manage sponsors and partnerships',
     href: '/admin/sponsors',
-    icon: 'heart',
-    stats: [{ label: 'Total', value: props.stats.sponsors }],
+    description: 'Track sponsors, partnerships and event-level perks.',
+    stats: [{ label: 'On record', value: props.stats.sponsors }],
+    icon: 'M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z',
+    primaryAction: { label: 'Add sponsor', href: '/admin/sponsors/create' },
   },
   {
     title: 'Users',
-    description: 'Manage user accounts and roles',
     href: '/admin/users',
-    icon: 'user',
+    description: 'Roles, permissions and account management for the community.',
     stats: [{ label: 'Total', value: props.stats.users }],
+    icon: 'M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2M9 11a4 4 0 1 0 0-8 4 4 0 0 0 0 8z',
     superadminOnly: true,
   },
-]
+])
 
-const getIcon = (name: string) => {
-  const icons: Record<string, string> = {
-    calendar:
-      'M26 4h-4V2h-2v2h-8V2h-2v2H6c-1.1 0-2 .9-2 2v20c0 1.1.9 2 2 2h20c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2m0 22H6V12h20zm0-16H6V6h4v2h2V6h8v2h2V6h4z',
-    users:
-      'M31 30h-2v-5a3 3 0 0 0-3-3h-4a3 3 0 0 0-3 3v5h-2v-5a5 5 0 0 1 5-5h4a5 5 0 0 1 5 5zM24 12a3 3 0 1 1-3 3a3 3 0 0 1 3-3m0-2a5 5 0 1 0 5 5a5 5 0 0 0-5-5M15 22h-2v-5a3 3 0 0 0-3-3H6a3 3 0 0 0-3 3v5H1v-5a5 5 0 0 1 5-5h4a5 5 0 0 1 5 5zM8 4a3 3 0 1 1-3 3a3 3 0 0 1 3-3m0-2a5 5 0 1 0 5 5a5 5 0 0 0-5-5',
-    heart:
-      'M22.45 6a5.47 5.47 0 0 1 3.91 1.64a5.7 5.7 0 0 1 0 8L16 26.13L5.64 15.64a5.7 5.7 0 0 1 0-8a5.48 5.48 0 0 1 7.82 0l2.54 2.6l2.53-2.58A5.44 5.44 0 0 1 22.45 6m0-2a7.47 7.47 0 0 0-5.34 2.24L16 7.36l-1.11-1.12a7.49 7.49 0 0 0-10.68 0a7.72 7.72 0 0 0 0 10.82L16 29l11.79-11.94a7.72 7.72 0 0 0 0-10.82A7.49 7.49 0 0 0 22.45 4',
-    user: 'M16 4a5 5 0 1 1-5 5a5 5 0 0 1 5-5m0-2a7 7 0 1 0 7 7a7 7 0 0 0-7-7m10 28h-2v-5a5 5 0 0 0-5-5h-6a5 5 0 0 0-5 5v5H6v-5a7 7 0 0 1 7-7h6a7 7 0 0 1 7 7z',
-  }
-  return icons[name] || icons.calendar
+const visibleSections = computed(() =>
+  sections.value.filter((s) => !s.superadminOnly || isSuperadmin.value)
+)
+
+const toneClasses: Record<NonNullable<Section['stats'][number]['tone']>, string> = {
+  default: 'text-verse-900 dark:text-verse-100',
+  success: 'text-emerald-600 dark:text-emerald-400',
+  warning: 'text-amber-600 dark:text-amber-400',
+  danger: 'text-red-600 dark:text-red-400',
 }
 </script>
 
 <template>
-  <Head title="Admin Dashboard" />
-  <main class="relative min-h-screen pt-40 pb-20">
-    <ContentBlock>
-      <!-- Header -->
-      <div class="mb-8">
-        <BaseHeading :level="1">Admin Dashboard</BaseHeading>
-        <p class="text-verse-600 dark:text-verse-400 mt-2">
-          Manage your frontend.mu content and settings.
-        </p>
+  <Head title="Admin" />
+  <AdminShell
+    title="Admin"
+    :description="`Welcome back${user?.name ? `, ${user.name.split(' ')[0]}` : ''}. Here’s what’s happening across frontend.mu.`"
+  >
+    <section class="mb-8">
+      <AdminStatGrid :stats="overviewStats" />
+    </section>
+
+    <section>
+      <div class="mb-3 flex items-baseline justify-between">
+        <h2 class="font-display text-xl text-verse-900 dark:text-verse-50 tracking-tight">
+          Manage
+        </h2>
       </div>
-
-      <!-- Quick Stats -->
-      <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
-        <div
-          class="bg-white dark:bg-verse-800/50 squircle rounded-xl border border-verse-200 dark:border-verse-700 p-4"
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <AdminCard
+          v-for="section in visibleSections"
+          :key="section.title"
+          interactive
+          padded
         >
-          <div class="text-2xl font-bold text-verse-900 dark:text-verse-100">
-            {{ stats.events.total }}
-          </div>
-          <div class="text-sm text-verse-600 dark:text-verse-400">Total Events</div>
-        </div>
-        <div
-          class="bg-white dark:bg-verse-800/50 squircle rounded-xl border border-verse-200 dark:border-verse-700 p-4"
-        >
-          <div class="text-2xl font-bold text-verse-900 dark:text-verse-100">
-            {{ stats.speakers }}
-          </div>
-          <div class="text-sm text-verse-600 dark:text-verse-400">Speakers</div>
-        </div>
-        <div
-          class="bg-white dark:bg-verse-800/50 squircle rounded-xl border border-verse-200 dark:border-verse-700 p-4"
-        >
-          <div class="text-2xl font-bold text-verse-900 dark:text-verse-100">
-            {{ stats.sponsors }}
-          </div>
-          <div class="text-sm text-verse-600 dark:text-verse-400">Sponsors</div>
-        </div>
-        <div
-          class="bg-white dark:bg-verse-800/50 squircle rounded-xl border border-verse-200 dark:border-verse-700 p-4"
-        >
-          <div class="text-2xl font-bold text-verse-900 dark:text-verse-100">{{ stats.users }}</div>
-          <div class="text-sm text-verse-600 dark:text-verse-400">Users</div>
-        </div>
-      </div>
-
-      <!-- Admin Menu -->
-      <div class="grid md:grid-cols-2 gap-6">
-        <template v-for="item in menuItems" :key="item.title">
-          <component
-            v-if="!item.superadminOnly || isSuperadmin"
-            :is="item.disabled ? 'div' : Link"
-            :href="item.disabled ? undefined : item.href"
-            :class="[
-              'block p-6 bg-white dark:bg-verse-800/50 squircle rounded-xl border border-verse-200 dark:border-verse-700 transition-all',
-              item.disabled
-                ? 'opacity-50 cursor-not-allowed'
-                : 'hover:shadow-lg hover:border-verse-300 dark:hover:border-verse-600',
-            ]"
-          >
-            <div class="flex items-start gap-4">
-              <!-- Icon -->
-              <div
-                class="flex-shrink-0 w-12 h-12 bg-verse-100 dark:bg-verse-700 squircle rounded-lg flex items-center justify-center"
-              >
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  class="w-6 h-6 text-verse-600 dark:text-verse-300"
-                  viewBox="0 0 32 32"
-                  fill="currentColor"
-                >
-                  <path :d="getIcon(item.icon)" />
-                </svg>
-              </div>
-
-              <!-- Content -->
-              <div class="flex-1 min-w-0">
-                <div class="flex items-center gap-2">
-                  <h3 class="text-lg font-semibold text-verse-900 dark:text-verse-100">
-                    {{ item.title }}
-                  </h3>
-                  <span
-                    v-if="item.disabled"
-                    class="px-2 py-0.5 text-xs font-medium bg-verse-100 dark:bg-verse-700 text-verse-500 dark:text-verse-400 rounded"
-                  >
-                    Coming Soon
-                  </span>
-                  <span
-                    v-if="item.superadminOnly"
-                    class="px-2 py-0.5 text-xs font-medium bg-red-100 dark:bg-red-900/30 text-red-600 dark:text-red-400 rounded"
-                  >
-                    Superadmin
-                  </span>
-                </div>
-                <p class="text-sm text-verse-600 dark:text-verse-400 mt-1">
-                  {{ item.description }}
-                </p>
-                <!-- Stats -->
-                <div class="flex flex-wrap gap-4 mt-3">
-                  <div v-for="stat in item.stats" :key="stat.label" class="text-sm">
-                    <span class="text-verse-500 dark:text-verse-400">{{ stat.label }}:</span>
-                    <span
-                      :class="stat.color || 'text-verse-900 dark:text-verse-100'"
-                      class="font-semibold ml-1"
-                    >
-                      {{ stat.value }}
-                    </span>
-                  </div>
-                </div>
-              </div>
-
-              <!-- Arrow -->
+          <div class="flex items-start gap-4">
+            <div
+              class="shrink-0 w-11 h-11 rounded-2xl bg-verse-100 dark:bg-verse-800 flex items-center justify-center text-verse-600 dark:text-verse-300"
+            >
               <svg
-                v-if="!item.disabled"
-                xmlns="http://www.w3.org/2000/svg"
-                class="w-5 h-5 text-verse-400 dark:text-verse-500 flex-shrink-0"
-                viewBox="0 0 20 20"
-                fill="currentColor"
+                class="w-5 h-5"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.75"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
               >
-                <path
-                  fill-rule="evenodd"
-                  d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
-                  clip-rule="evenodd"
-                />
+                <path :d="section.icon" />
               </svg>
             </div>
-          </component>
-        </template>
+            <div class="flex-1 min-w-0">
+              <div class="flex items-center gap-2 flex-wrap">
+                <Link
+                  :href="section.href"
+                  class="text-base font-semibold text-verse-900 dark:text-verse-50 hover:underline decoration-coral-strong decoration-2 underline-offset-4"
+                >
+                  {{ section.title }}
+                </Link>
+                <AdminBadge v-if="section.superadminOnly" tone="danger">Superadmin</AdminBadge>
+              </div>
+              <p class="text-sm text-verse-500 dark:text-verse-400 mt-1">
+                {{ section.description }}
+              </p>
+              <div
+                v-if="section.stats.length"
+                class="mt-3 flex flex-wrap items-baseline gap-x-5 gap-y-1"
+              >
+                <div v-for="stat in section.stats" :key="stat.label" class="flex items-baseline gap-1.5">
+                  <span
+                    :class="['text-sm font-semibold tabular-nums', toneClasses[stat.tone ?? 'default']]"
+                  >
+                    {{ stat.value }}
+                  </span>
+                  <span class="text-xs text-verse-500 dark:text-verse-400 font-mono uppercase tracking-wide">
+                    {{ stat.label }}
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <template #footer>
+            <Link
+              :href="section.href"
+              class="inline-flex items-center gap-1.5 text-sm font-medium text-verse-700 dark:text-verse-200 hover:text-verse-900 dark:hover:text-white"
+            >
+              View {{ section.title.toLowerCase() }}
+              <svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <line x1="5" y1="12" x2="19" y2="12" />
+                <polyline points="12 5 19 12 12 19" />
+              </svg>
+            </Link>
+            <Link
+              v-if="section.primaryAction"
+              :href="section.primaryAction.href"
+              class="text-xs font-medium text-coral-deep dark:text-coral-strong hover:underline"
+            >
+              {{ section.primaryAction.label }}
+            </Link>
+          </template>
+        </AdminCard>
       </div>
-    </ContentBlock>
-  </main>
+    </section>
+  </AdminShell>
 </template>

--- a/packages/frontendmu-adonis/inertia/pages/admin/speakers/create.vue
+++ b/packages/frontendmu-adonis/inertia/pages/admin/speakers/create.vue
@@ -1,8 +1,11 @@
 <script setup lang="ts">
 import { Head, useForm } from '@inertiajs/vue3'
-import { Link } from '@inertiajs/vue3'
-import ContentBlock from '~/components/shared/ContentBlock.vue'
-import BaseHeading from '~/components/base/BaseHeading.vue'
+import AdminShell from '~/components/admin/ui/AdminShell.vue'
+import AdminCard from '~/components/admin/ui/AdminCard.vue'
+import AdminButton from '~/components/admin/ui/AdminButton.vue'
+import AdminInput from '~/components/admin/ui/AdminInput.vue'
+import AdminTextarea from '~/components/admin/ui/AdminTextarea.vue'
+import AdminCheckbox from '~/components/admin/ui/AdminCheckbox.vue'
 
 const form = useForm({
   name: '',
@@ -21,161 +24,84 @@ function handleSubmit() {
 </script>
 
 <template>
-  <Head title="Add Speaker" />
-  <main class="relative min-h-screen pt-40 pb-20">
-      <ContentBlock>
-        <div class="max-w-2xl mx-auto">
-        <!-- Breadcrumb -->
-        <nav class="mb-6 flex items-center gap-2 text-sm">
-          <Link href="/admin" class="text-verse-600 hover:text-verse-800 dark:text-verse-400 dark:hover:text-verse-200">
-            Admin
-          </Link>
-          <span class="text-verse-400">/</span>
-          <Link href="/admin/speakers" class="text-verse-600 hover:text-verse-800 dark:text-verse-400 dark:hover:text-verse-200">
-            Speakers
-          </Link>
-          <span class="text-verse-400">/</span>
-          <span class="text-verse-900 dark:text-verse-100">Add Speaker</span>
-        </nav>
+  <Head title="Add speaker · Admin" />
+  <AdminShell
+    title="Add speaker"
+    description="Speakers can be linked to sessions on any event."
+    :breadcrumbs="[
+      { label: 'Admin', href: '/admin' },
+      { label: 'Speakers', href: '/admin/speakers' },
+      { label: 'Add speaker' },
+    ]"
+  >
+    <form class="space-y-6 max-w-3xl" @submit.prevent="handleSubmit">
+      <AdminCard title="Basic info">
+        <div class="space-y-5">
+          <AdminInput
+            v-model="form.name"
+            label="Name"
+            required
+            :error="form.errors.name"
+          />
+          <AdminInput
+            v-model="form.email"
+            label="Email"
+            type="email"
+            :error="form.errors.email"
+          />
+          <AdminInput
+            v-model="form.githubUsername"
+            label="GitHub username"
+            leading-text="@"
+            hint="Used to fetch the avatar from GitHub"
+            :error="form.errors.githubUsername"
+          />
+          <AdminTextarea
+            v-model="form.bio"
+            label="Bio"
+            :rows="4"
+            :error="form.errors.bio"
+          />
+        </div>
+      </AdminCard>
 
-        <BaseHeading :level="1" class="mb-8">Add Speaker</BaseHeading>
+      <AdminCard title="Social links">
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <AdminInput
+            v-model="form.linkedinUrl"
+            label="LinkedIn"
+            type="url"
+            placeholder="https://linkedin.com/in/…"
+          />
+          <AdminInput
+            v-model="form.twitterUrl"
+            label="Twitter"
+            type="url"
+            placeholder="https://twitter.com/…"
+          />
+          <AdminInput
+            v-model="form.websiteUrl"
+            label="Website"
+            type="url"
+            placeholder="https://…"
+          />
+        </div>
+      </AdminCard>
 
-        <form @submit.prevent="handleSubmit" class="space-y-6">
-          <!-- Name -->
-          <div>
-            <label for="name" class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-2">
-              Name <span class="text-red-500">*</span>
-            </label>
-            <input
-              id="name"
-              v-model="form.name"
-              type="text"
-              required
-              class="w-full px-4 py-2 border border-verse-300 dark:border-verse-600 squircle rounded-lg bg-white dark:bg-verse-800 text-verse-900 dark:text-verse-100 focus:ring-2 focus:ring-verse-500 focus:border-transparent"
-            />
-            <p v-if="form.errors.name" class="mt-1 text-sm text-red-500">{{ form.errors.name }}</p>
-          </div>
+      <AdminCard title="Visibility">
+        <AdminCheckbox
+          v-model="form.featured"
+          label="Featured speaker"
+          description="Featured speakers are highlighted on the speakers page."
+        />
+      </AdminCard>
 
-          <!-- Email -->
-          <div>
-            <label for="email" class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-2">
-              Email
-            </label>
-            <input
-              id="email"
-              v-model="form.email"
-              type="email"
-              class="w-full px-4 py-2 border border-verse-300 dark:border-verse-600 squircle rounded-lg bg-white dark:bg-verse-800 text-verse-900 dark:text-verse-100 focus:ring-2 focus:ring-verse-500 focus:border-transparent"
-            />
-            <p v-if="form.errors.email" class="mt-1 text-sm text-red-500">{{ form.errors.email }}</p>
-          </div>
-
-          <!-- GitHub Username -->
-          <div>
-            <label for="githubUsername" class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-2">
-              GitHub Username
-            </label>
-            <div class="flex">
-              <span class="inline-flex items-center px-3 border border-r-0 border-verse-300 dark:border-verse-600 rounded-l-lg bg-verse-50 dark:bg-verse-700 text-verse-500 dark:text-verse-400">
-                @
-              </span>
-              <input
-                id="githubUsername"
-                v-model="form.githubUsername"
-                type="text"
-                class="flex-1 px-4 py-2 border border-verse-300 dark:border-verse-600 rounded-r-lg bg-white dark:bg-verse-800 text-verse-900 dark:text-verse-100 focus:ring-2 focus:ring-verse-500 focus:border-transparent"
-              />
-            </div>
-            <p class="mt-1 text-xs text-verse-500 dark:text-verse-400">Used to fetch avatar from GitHub</p>
-            <p v-if="form.errors.githubUsername" class="mt-1 text-sm text-red-500">{{ form.errors.githubUsername }}</p>
-          </div>
-
-          <!-- Bio -->
-          <div>
-            <label for="bio" class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-2">
-              Bio
-            </label>
-            <textarea
-              id="bio"
-              v-model="form.bio"
-              rows="4"
-              class="w-full px-4 py-2 border border-verse-300 dark:border-verse-600 squircle rounded-lg bg-white dark:bg-verse-800 text-verse-900 dark:text-verse-100 focus:ring-2 focus:ring-verse-500 focus:border-transparent"
-            />
-            <p v-if="form.errors.bio" class="mt-1 text-sm text-red-500">{{ form.errors.bio }}</p>
-          </div>
-
-          <!-- Social Links -->
-          <div class="grid md:grid-cols-3 gap-4">
-            <div>
-              <label for="linkedinUrl" class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-2">
-                LinkedIn URL
-              </label>
-              <input
-                id="linkedinUrl"
-                v-model="form.linkedinUrl"
-                type="url"
-                placeholder="https://linkedin.com/in/..."
-                class="w-full px-4 py-2 border border-verse-300 dark:border-verse-600 squircle rounded-lg bg-white dark:bg-verse-800 text-verse-900 dark:text-verse-100 focus:ring-2 focus:ring-verse-500 focus:border-transparent"
-              />
-            </div>
-            <div>
-              <label for="twitterUrl" class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-2">
-                Twitter URL
-              </label>
-              <input
-                id="twitterUrl"
-                v-model="form.twitterUrl"
-                type="url"
-                placeholder="https://twitter.com/..."
-                class="w-full px-4 py-2 border border-verse-300 dark:border-verse-600 squircle rounded-lg bg-white dark:bg-verse-800 text-verse-900 dark:text-verse-100 focus:ring-2 focus:ring-verse-500 focus:border-transparent"
-              />
-            </div>
-            <div>
-              <label for="websiteUrl" class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-2">
-                Website URL
-              </label>
-              <input
-                id="websiteUrl"
-                v-model="form.websiteUrl"
-                type="url"
-                placeholder="https://..."
-                class="w-full px-4 py-2 border border-verse-300 dark:border-verse-600 squircle rounded-lg bg-white dark:bg-verse-800 text-verse-900 dark:text-verse-100 focus:ring-2 focus:ring-verse-500 focus:border-transparent"
-              />
-            </div>
-          </div>
-
-          <!-- Featured -->
-          <div class="flex items-center gap-3">
-            <input
-              id="featured"
-              v-model="form.featured"
-              type="checkbox"
-              class="h-4 w-4 text-verse-600 focus:ring-verse-500 border-verse-300 rounded"
-            />
-            <label for="featured" class="text-sm font-medium text-verse-700 dark:text-verse-300">
-              Featured speaker
-            </label>
-          </div>
-
-          <!-- Submit -->
-          <div class="flex justify-end gap-4 pt-4">
-            <Link
-              href="/admin/speakers"
-              class="px-6 py-2 text-verse-700 dark:text-verse-300 hover:bg-verse-100 dark:hover:bg-verse-700 squircle rounded-lg transition-colors"
-            >
-              Cancel
-            </Link>
-            <button
-              type="submit"
-              :disabled="form.processing"
-              class="px-6 py-2 bg-verse-600 hover:bg-verse-700 text-white font-medium squircle rounded-lg transition-colors disabled:opacity-50"
-            >
-              <span v-if="form.processing">Creating...</span>
-              <span v-else>Create Speaker</span>
-            </button>
-          </div>
-        </form>
+      <div class="sticky bottom-3 z-10 flex justify-end gap-2 bg-white/85 dark:bg-verse-950/85 backdrop-blur-md p-3 rounded-xl border border-verse-200 dark:border-verse-800">
+        <AdminButton href="/admin/speakers" variant="secondary">Cancel</AdminButton>
+        <AdminButton type="submit" variant="primary" :loading="form.processing">
+          {{ form.processing ? 'Creating…' : 'Create speaker' }}
+        </AdminButton>
       </div>
-    </ContentBlock>
-  </main>
+    </form>
+  </AdminShell>
 </template>

--- a/packages/frontendmu-adonis/inertia/pages/admin/speakers/index.vue
+++ b/packages/frontendmu-adonis/inertia/pages/admin/speakers/index.vue
@@ -1,9 +1,15 @@
 <script setup lang="ts">
-import { Head } from '@inertiajs/vue3'
-import { Link } from '@inertiajs/vue3'
+import { computed, ref } from 'vue'
+import { Head, Link } from '@inertiajs/vue3'
 import type { Data } from '@generated/data'
-import ContentBlock from '~/components/shared/ContentBlock.vue'
-import BaseHeading from '~/components/base/BaseHeading.vue'
+import AdminShell from '~/components/admin/ui/AdminShell.vue'
+import AdminCard from '~/components/admin/ui/AdminCard.vue'
+import AdminButton from '~/components/admin/ui/AdminButton.vue'
+import AdminBadge from '~/components/admin/ui/AdminBadge.vue'
+import AdminAvatar from '~/components/admin/ui/AdminAvatar.vue'
+import AdminSearchInput from '~/components/admin/ui/AdminSearchInput.vue'
+import AdminEmptyState from '~/components/admin/ui/AdminEmptyState.vue'
+import AdminConfirmModal from '~/components/admin/ui/AdminConfirmModal.vue'
 import { useAuth } from '~/composables/use_auth'
 import { useDeleteConfirmation } from '~/composables/use_delete_confirmation'
 
@@ -19,207 +25,155 @@ const {
   isDeleting,
   confirmDelete,
   cancelDelete,
-  executeDelete: execDelete,
+  executeDelete,
 } = useDeleteConfirmation<Data.Speaker.Variants['forAdminIndex']>()
+
+const search = ref('')
+
+const filtered = computed(() => {
+  const q = search.value.trim().toLowerCase()
+  if (!q) return props.speakers
+  return props.speakers.filter(
+    (s) =>
+      s.name.toLowerCase().includes(q) ||
+      (s.githubUsername?.toLowerCase().includes(q) ?? false)
+  )
+})
 
 function doDelete() {
   if (!speakerToDelete.value) return
-  execDelete(`/admin/speakers/${speakerToDelete.value.id}`)
+  executeDelete(`/admin/speakers/${speakerToDelete.value.id}`)
 }
 </script>
 
 <template>
-  <Head title="Manage Speakers" />
-  <main class="relative min-h-screen pt-40 pb-20">
-    <ContentBlock>
-      <!-- Header -->
-      <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-8">
-        <div>
-          <BaseHeading :level="1">Manage Speakers</BaseHeading>
-          <p class="text-verse-600 dark:text-verse-400 mt-2">View and manage speaker profiles.</p>
-        </div>
-        <Link
-          href="/admin/speakers/create"
-          class="inline-flex items-center gap-2 px-4 py-2 bg-verse-600 hover:bg-verse-700 text-white text-sm font-medium squircle rounded-lg transition-colors"
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            class="h-4 w-4"
-            viewBox="0 0 20 20"
-            fill="currentColor"
-          >
-            <path
-              fill-rule="evenodd"
-              d="M10 3a1 1 0 011 1v5h5a1 1 0 110 2h-5v5a1 1 0 11-2 0v-5H4a1 1 0 110-2h5V4a1 1 0 011-1z"
-              clip-rule="evenodd"
-            />
-          </svg>
-          Add Speaker
-        </Link>
+  <Head title="Speakers · Admin" />
+  <AdminShell title="Speakers" description="Curate the people who lead sessions across our meetups.">
+    <template #actions>
+      <AdminButton href="/admin/speakers/create" variant="primary">
+        <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <line x1="12" y1="5" x2="12" y2="19" />
+          <line x1="5" y1="12" x2="19" y2="12" />
+        </svg>
+        Add speaker
+      </AdminButton>
+    </template>
+
+    <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between mb-5">
+      <p class="text-xs font-mono text-verse-500 dark:text-verse-400 tabular-nums">
+        {{ filtered.length }} speaker{{ filtered.length === 1 ? '' : 's' }}
+      </p>
+      <div class="sm:w-72">
+        <AdminSearchInput v-model="search" placeholder="Search by name or GitHub" />
       </div>
+    </div>
 
-      <!-- Speakers Grid -->
-      <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
-        <div
-          v-for="speaker in speakers"
-          :key="speaker.id"
-          class="bg-white dark:bg-verse-800/50 squircle rounded-xl border border-verse-200 dark:border-verse-700 p-6 hover:shadow-lg transition-shadow"
-        >
-          <div class="flex items-start gap-4">
-            <!-- Avatar -->
-            <img
-              v-if="speaker.avatarUrl"
-              :src="speaker.avatarUrl"
-              :alt="speaker.name"
-              class="w-16 h-16 rounded-full object-cover"
-            />
-            <div
-              v-else
-              class="w-16 h-16 rounded-full bg-verse-200 dark:bg-verse-700 flex items-center justify-center"
+    <div
+      v-if="filtered.length"
+      class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 sm:gap-4"
+    >
+      <AdminCard
+        v-for="speaker in filtered"
+        :key="speaker.id"
+        padded
+        interactive
+      >
+        <div class="flex items-start gap-3">
+          <AdminAvatar
+            :src="speaker.avatarUrl"
+            :name="speaker.name"
+            size="lg"
+            rounded="xl"
+          />
+          <div class="flex-1 min-w-0">
+            <div class="flex items-center gap-2 flex-wrap">
+              <h3 class="font-semibold text-verse-900 dark:text-verse-50 truncate">
+                {{ speaker.name }}
+              </h3>
+              <AdminBadge v-if="speaker.featured" tone="accent">Featured</AdminBadge>
+            </div>
+            <p
+              v-if="speaker.githubUsername"
+              class="text-sm text-verse-500 dark:text-verse-400 truncate mt-0.5"
             >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                class="h-8 w-8 text-verse-400"
-                viewBox="0 0 20 20"
-                fill="currentColor"
-              >
-                <path
-                  fill-rule="evenodd"
-                  d="M10 9a3 3 0 100-6 3 3 0 000 6zm-7 9a7 7 0 1114 0H3z"
-                  clip-rule="evenodd"
-                />
-              </svg>
-            </div>
-
-            <!-- Info -->
-            <div class="flex-1 min-w-0">
-              <div class="flex items-center gap-2">
-                <h3 class="font-semibold text-verse-900 dark:text-verse-100 truncate">
-                  {{ speaker.name }}
-                </h3>
-                <span
-                  v-if="speaker.featured"
-                  class="px-2 py-0.5 text-xs font-medium bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300 rounded"
-                >
-                  Featured
-                </span>
-              </div>
-              <p v-if="speaker.githubUsername" class="text-sm text-verse-500 dark:text-verse-400">
-                @{{ speaker.githubUsername }}
-              </p>
-              <p class="text-sm text-verse-600 dark:text-verse-400 mt-1">
-                {{ speaker.sessionCount }} session{{ speaker.sessionCount !== 1 ? 's' : '' }}
-              </p>
-            </div>
+              @{{ speaker.githubUsername }}
+            </p>
+            <p class="text-xs font-mono text-verse-500 dark:text-verse-400 mt-1.5 uppercase tracking-wide">
+              {{ speaker.sessionCount }} session{{ speaker.sessionCount === 1 ? '' : 's' }}
+            </p>
           </div>
+        </div>
 
-          <!-- Actions -->
-          <div
-            class="flex items-center justify-end gap-2 mt-4 pt-4 border-t border-verse-100 dark:border-verse-700"
+        <template #footer>
+          <Link
+            :href="`/speaker/${speaker.id}`"
+            class="text-sm font-medium text-verse-700 dark:text-verse-200 hover:text-verse-900 dark:hover:text-white"
           >
-            <Link
-              :href="`/speaker/${speaker.id}`"
-              class="p-2 text-verse-500 hover:text-verse-700 dark:text-verse-400 dark:hover:text-verse-200 transition-colors"
-              title="View"
-            >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                class="h-5 w-5"
-                viewBox="0 0 20 20"
-                fill="currentColor"
-              >
-                <path d="M10 12a2 2 0 100-4 2 2 0 000 4z" />
-                <path
-                  fill-rule="evenodd"
-                  d="M.458 10C1.732 5.943 5.522 3 10 3s8.268 2.943 9.542 7c-1.274 4.057-5.064 7-9.542 7S1.732 14.057.458 10zM14 10a4 4 0 11-8 0 4 4 0 018 0z"
-                  clip-rule="evenodd"
-                />
-              </svg>
-            </Link>
-            <Link
+            View profile
+          </Link>
+          <div class="flex items-center gap-1">
+            <AdminButton
               :href="`/admin/users/${speaker.id}/edit`"
-              class="p-2 text-verse-500 hover:text-verse-700 dark:text-verse-400 dark:hover:text-verse-200 transition-colors"
-              title="Edit"
+              variant="ghost"
+              size="sm"
+              icon-only
+              title="Edit speaker"
             >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                class="h-5 w-5"
-                viewBox="0 0 20 20"
-                fill="currentColor"
-              >
-                <path
-                  d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z"
-                />
+              <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
+                <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
               </svg>
-            </Link>
+            </AdminButton>
             <button
               v-if="canDelete"
+              type="button"
+              class="p-2 rounded-lg text-red-500 hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-900/20 dark:text-red-400 dark:hover:text-red-300 transition-colors"
+              title="Delete speaker"
+              aria-label="Delete speaker"
               @click="confirmDelete(speaker)"
-              class="p-2 text-red-500 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300 transition-colors"
-              title="Delete"
             >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                class="h-5 w-5"
-                viewBox="0 0 20 20"
-                fill="currentColor"
-              >
-                <path
-                  fill-rule="evenodd"
-                  d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z"
-                  clip-rule="evenodd"
-                />
+              <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+                <polyline points="3 6 5 6 21 6" />
+                <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
               </svg>
             </button>
           </div>
-        </div>
-      </div>
-
-      <!-- Empty state -->
-      <div v-if="!speakers.length" class="text-center py-16">
-        <p class="text-verse-500 dark:text-verse-400 mb-4">No speakers found.</p>
-        <Link
-          href="/admin/speakers/create"
-          class="inline-flex items-center gap-2 px-4 py-2 bg-verse-600 hover:bg-verse-700 text-white text-sm font-medium squircle rounded-lg transition-colors"
-        >
-          Add your first speaker
-        </Link>
-      </div>
-    </ContentBlock>
-  </main>
-
-  <!-- Delete Confirmation Modal -->
-  <Teleport to="body">
-    <div v-if="showDeleteModal" class="fixed inset-0 z-50 flex items-center justify-center p-4">
-      <div class="absolute inset-0 bg-black/50" @click="cancelDelete" />
-      <div
-        class="relative bg-white dark:bg-verse-800 squircle rounded-xl shadow-xl max-w-md w-full p-6"
-      >
-        <h3 class="text-lg font-semibold text-verse-900 dark:text-verse-100 mb-2">
-          Delete Speaker
-        </h3>
-        <p class="text-verse-600 dark:text-verse-400 mb-4">
-          Are you sure you want to delete "<strong>{{ speakerToDelete?.name }}</strong
-          >"? This will also remove them from all sessions. This action cannot be undone.
-        </p>
-        <div class="flex justify-end gap-3">
-          <button
-            @click="cancelDelete"
-            :disabled="isDeleting"
-            class="px-4 py-2 text-sm font-medium text-verse-700 dark:text-verse-300 bg-verse-100 dark:bg-verse-700 hover:bg-verse-200 dark:hover:bg-verse-600 squircle rounded-lg transition-colors disabled:opacity-50"
-          >
-            Cancel
-          </button>
-          <button
-            @click="doDelete"
-            :disabled="isDeleting"
-            class="px-4 py-2 text-sm font-medium text-white bg-red-600 hover:bg-red-700 squircle rounded-lg transition-colors disabled:opacity-50"
-          >
-            <span v-if="isDeleting">Deleting...</span>
-            <span v-else>Delete</span>
-          </button>
-        </div>
-      </div>
+        </template>
+      </AdminCard>
     </div>
-  </Teleport>
+
+    <AdminCard v-else :padded="false">
+      <AdminEmptyState
+        :title="search ? 'No speakers match your search' : 'No speakers yet'"
+        :description="
+          search
+            ? 'Try a different name or GitHub handle.'
+            : 'Add your first speaker to get started.'
+        "
+        icon="M3 21v-2a4 4 0 0 1 4-4h4a4 4 0 0 1 4 4v2M9 11a4 4 0 1 0 0-8 4 4 0 0 0 0 8z"
+      >
+        <template #actions>
+          <AdminButton v-if="search" variant="secondary" @click="search = ''">
+            Clear search
+          </AdminButton>
+          <AdminButton href="/admin/speakers/create" variant="primary">
+            Add speaker
+          </AdminButton>
+        </template>
+      </AdminEmptyState>
+    </AdminCard>
+  </AdminShell>
+
+  <AdminConfirmModal
+    :open="showDeleteModal"
+    title="Delete speaker"
+    :loading="isDeleting"
+    confirm-label="Delete speaker"
+    @cancel="cancelDelete"
+    @confirm="doDelete"
+  >
+    Are you sure you want to delete
+    <strong class="text-verse-900 dark:text-verse-100">{{ speakerToDelete?.name }}</strong
+    >? This will also remove them from all sessions.
+  </AdminConfirmModal>
 </template>

--- a/packages/frontendmu-adonis/inertia/pages/admin/speakers/index.vue
+++ b/packages/frontendmu-adonis/inertia/pages/admin/speakers/index.vue
@@ -60,7 +60,7 @@ function doDelete() {
     </template>
 
     <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between mb-5">
-      <p class="text-xs font-mono text-verse-500 dark:text-verse-400 tabular-nums">
+      <p class="text-xs font-mono text-verse-500 dark:text-verse-300 tabular-nums">
         {{ filtered.length }} speaker{{ filtered.length === 1 ? '' : 's' }}
       </p>
       <div class="sm:w-72">
@@ -94,11 +94,11 @@ function doDelete() {
             </div>
             <p
               v-if="speaker.githubUsername"
-              class="text-sm text-verse-500 dark:text-verse-400 truncate mt-0.5"
+              class="text-sm text-verse-500 dark:text-verse-300 truncate mt-0.5"
             >
               @{{ speaker.githubUsername }}
             </p>
-            <p class="text-xs font-mono text-verse-500 dark:text-verse-400 mt-1.5 uppercase tracking-wide">
+            <p class="text-xs font-mono text-verse-500 dark:text-verse-300 mt-1.5 uppercase tracking-wide">
               {{ speaker.sessionCount }} session{{ speaker.sessionCount === 1 ? '' : 's' }}
             </p>
           </div>

--- a/packages/frontendmu-adonis/inertia/pages/admin/sponsors/create.vue
+++ b/packages/frontendmu-adonis/inertia/pages/admin/sponsors/create.vue
@@ -1,11 +1,8 @@
 <script setup lang="ts">
 import { Head, useForm } from '@inertiajs/vue3'
-import { Link } from '@inertiajs/vue3'
-import ContentBlock from '~/components/shared/ContentBlock.vue'
-import BaseHeading from '~/components/base/BaseHeading.vue'
-import BaseImageUpload from '~/components/base/BaseImageUpload.vue'
-
-const sponsorTypeOptions = ['venue', 'food', 'drinks', 'swag', 'gold', 'silver', 'bronze', 'platinum']
+import AdminShell from '~/components/admin/ui/AdminShell.vue'
+import AdminButton from '~/components/admin/ui/AdminButton.vue'
+import SponsorFormFields from '~/components/admin/SponsorFormFields.vue'
 
 const form = useForm({
   name: '',
@@ -16,18 +13,9 @@ const form = useForm({
   logoFile: null as File | null,
   logomarkFile: null as File | null,
   sponsorTypes: [] as string[],
-  logoBg: '' as string,
+  logoBg: '',
   status: 'active' as 'active' | 'inactive',
 })
-
-function toggleSponsorType(type: string) {
-  const index = form.sponsorTypes.indexOf(type)
-  if (index === -1) {
-    form.sponsorTypes.push(type)
-  } else {
-    form.sponsorTypes.splice(index, 1)
-  }
-}
 
 function handleSubmit() {
   form.post('/admin/sponsors', { forceFormData: true })
@@ -35,210 +23,25 @@ function handleSubmit() {
 </script>
 
 <template>
-  <Head title="Add Sponsor" />
-  <main class="relative min-h-screen pt-40 pb-20">
-      <ContentBlock>
-        <div class="max-w-2xl mx-auto">
-        <!-- Breadcrumb -->
-        <nav class="mb-6 flex items-center gap-2 text-sm">
-          <Link href="/admin" class="text-verse-600 hover:text-verse-800 dark:text-verse-400 dark:hover:text-verse-200">
-            Admin
-          </Link>
-          <span class="text-verse-400">/</span>
-          <Link href="/admin/sponsors" class="text-verse-600 hover:text-verse-800 dark:text-verse-400 dark:hover:text-verse-200">
-            Sponsors
-          </Link>
-          <span class="text-verse-400">/</span>
-          <span class="text-verse-900 dark:text-verse-100">Add Sponsor</span>
-        </nav>
+  <Head title="Add sponsor · Admin" />
+  <AdminShell
+    title="Add sponsor"
+    description="Sponsors can be attached to events and shown across the public site."
+    :breadcrumbs="[
+      { label: 'Admin', href: '/admin' },
+      { label: 'Sponsors', href: '/admin/sponsors' },
+      { label: 'Add sponsor' },
+    ]"
+  >
+    <form class="max-w-3xl space-y-6" @submit.prevent="handleSubmit">
+      <SponsorFormFields :form="form" />
 
-        <BaseHeading :level="1" class="mb-8">Add Sponsor</BaseHeading>
-
-        <form @submit.prevent="handleSubmit" class="space-y-6">
-          <!-- Name -->
-          <div>
-            <label for="name" class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-2">
-              Name <span class="text-red-500">*</span>
-            </label>
-            <input
-              id="name"
-              v-model="form.name"
-              type="text"
-              required
-              class="w-full px-4 py-2 border border-verse-300 dark:border-verse-600 squircle rounded-lg bg-white dark:bg-verse-800 text-verse-900 dark:text-verse-100 focus:ring-2 focus:ring-verse-500 focus:border-transparent"
-            />
-            <p v-if="form.errors.name" class="mt-1 text-sm text-red-500">{{ form.errors.name }}</p>
-          </div>
-
-          <!-- Website -->
-          <div>
-            <label for="website" class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-2">
-              Website
-            </label>
-            <input
-              id="website"
-              v-model="form.website"
-              type="url"
-              placeholder="https://..."
-              class="w-full px-4 py-2 border border-verse-300 dark:border-verse-600 squircle rounded-lg bg-white dark:bg-verse-800 text-verse-900 dark:text-verse-100 focus:ring-2 focus:ring-verse-500 focus:border-transparent"
-            />
-            <p v-if="form.errors.website" class="mt-1 text-sm text-red-500">{{ form.errors.website }}</p>
-          </div>
-
-          <!-- Description -->
-          <div>
-            <label for="description" class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-2">
-              Description
-            </label>
-            <textarea
-              id="description"
-              v-model="form.description"
-              rows="4"
-              class="w-full px-4 py-2 border border-verse-300 dark:border-verse-600 squircle rounded-lg bg-white dark:bg-verse-800 text-verse-900 dark:text-verse-100 focus:ring-2 focus:ring-verse-500 focus:border-transparent"
-            />
-            <p v-if="form.errors.description" class="mt-1 text-sm text-red-500">{{ form.errors.description }}</p>
-          </div>
-
-          <!-- Logo Upload -->
-          <div class="grid md:grid-cols-2 gap-6">
-            <div>
-              <label class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-2">
-                Logo
-              </label>
-              <BaseImageUpload
-                v-model="form.logoFile"
-                :dark-preview="!!form.logoBg"
-                :error="form.errors.logoFile || form.errors.logoUrl"
-                @update:url="(v) => form.logoUrl = v"
-              />
-            </div>
-
-            <div>
-              <label class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-2">
-                Logomark
-              </label>
-              <BaseImageUpload
-                v-model="form.logomarkFile"
-                :dark-preview="!!form.logoBg"
-                :error="form.errors.logomarkFile || form.errors.logomarkUrl"
-                @update:url="(v) => form.logomarkUrl = v"
-              />
-            </div>
-          </div>
-
-          <!-- Sponsor Types -->
-          <div>
-            <label class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-2">
-              Sponsor Types
-            </label>
-            <div class="flex flex-wrap gap-2">
-              <button
-                v-for="type in sponsorTypeOptions"
-                :key="type"
-                type="button"
-                @click="toggleSponsorType(type)"
-                :class="[
-                  'px-3 py-1.5 squircle rounded-lg text-sm font-medium transition-colors capitalize',
-                  form.sponsorTypes.includes(type)
-                    ? 'bg-verse-600 text-white'
-                    : 'bg-verse-100 dark:bg-verse-700 text-verse-700 dark:text-verse-300 hover:bg-verse-200 dark:hover:bg-verse-600'
-                ]"
-              >
-                {{ type }}
-              </button>
-            </div>
-          </div>
-
-          <!-- Logo Background -->
-          <div>
-            <label class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-2">
-              Logo Background
-            </label>
-            <div class="flex flex-wrap items-center gap-2">
-              <button
-                type="button"
-                @click="form.logoBg = ''"
-                :class="[
-                  'px-3 py-1.5 squircle rounded-lg text-sm font-medium transition-colors',
-                  !form.logoBg
-                    ? 'bg-verse-600 text-white'
-                    : 'bg-verse-100 dark:bg-verse-700 text-verse-700 dark:text-verse-300 hover:bg-verse-200 dark:hover:bg-verse-600'
-                ]"
-              >
-                Transparent
-              </button>
-              <button
-                type="button"
-                @click="form.logoBg = '#ffffff'"
-                :class="[
-                  'px-3 py-1.5 squircle rounded-lg text-sm font-medium transition-colors',
-                  form.logoBg === '#ffffff'
-                    ? 'bg-verse-600 text-white'
-                    : 'bg-verse-100 dark:bg-verse-700 text-verse-700 dark:text-verse-300 hover:bg-verse-200 dark:hover:bg-verse-600'
-                ]"
-              >
-                White
-              </button>
-              <button
-                type="button"
-                @click="form.logoBg = '#111827'"
-                :class="[
-                  'px-3 py-1.5 squircle rounded-lg text-sm font-medium transition-colors',
-                  form.logoBg === '#111827'
-                    ? 'bg-verse-600 text-white'
-                    : 'bg-verse-100 dark:bg-verse-700 text-verse-700 dark:text-verse-300 hover:bg-verse-200 dark:hover:bg-verse-600'
-                ]"
-              >
-                Black
-              </button>
-              <div class="flex items-center gap-2">
-                <input
-                  type="color"
-                  :value="form.logoBg || '#ffffff'"
-                  @input="form.logoBg = ($event.target as HTMLInputElement).value"
-                  class="w-8 h-8 rounded cursor-pointer border border-verse-300 dark:border-verse-600"
-                />
-                <span v-if="form.logoBg && !['#ffffff', '#111827', ''].includes(form.logoBg)" class="text-xs font-mono text-verse-500">
-                  {{ form.logoBg }}
-                </span>
-              </div>
-            </div>
-          </div>
-
-          <!-- Status -->
-          <div>
-            <label for="status" class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-2">
-              Status
-            </label>
-            <select
-              id="status"
-              v-model="form.status"
-              class="w-full px-4 py-2 border border-verse-300 dark:border-verse-600 squircle rounded-lg bg-white dark:bg-verse-800 text-verse-900 dark:text-verse-100 focus:ring-2 focus:ring-verse-500 focus:border-transparent"
-            >
-              <option value="active">Active</option>
-              <option value="inactive">Inactive</option>
-            </select>
-          </div>
-
-          <!-- Submit -->
-          <div class="flex justify-end gap-4 pt-4">
-            <Link
-              href="/admin/sponsors"
-              class="px-6 py-2 text-verse-700 dark:text-verse-300 hover:bg-verse-100 dark:hover:bg-verse-700 squircle rounded-lg transition-colors"
-            >
-              Cancel
-            </Link>
-            <button
-              type="submit"
-              :disabled="form.processing"
-              class="px-6 py-2 bg-verse-600 hover:bg-verse-700 text-white font-medium squircle rounded-lg transition-colors disabled:opacity-50"
-            >
-              <span v-if="form.processing">Creating...</span>
-              <span v-else>Create Sponsor</span>
-            </button>
-          </div>
-        </form>
+      <div class="sticky bottom-3 z-10 flex justify-end gap-2 bg-white/85 dark:bg-verse-950/85 backdrop-blur-md p-3 rounded-xl border border-verse-200 dark:border-verse-800">
+        <AdminButton href="/admin/sponsors" variant="secondary">Cancel</AdminButton>
+        <AdminButton type="submit" variant="primary" :loading="form.processing">
+          {{ form.processing ? 'Creating…' : 'Create sponsor' }}
+        </AdminButton>
       </div>
-    </ContentBlock>
-  </main>
+    </form>
+  </AdminShell>
 </template>

--- a/packages/frontendmu-adonis/inertia/pages/admin/sponsors/edit.vue
+++ b/packages/frontendmu-adonis/inertia/pages/admin/sponsors/edit.vue
@@ -1,9 +1,8 @@
 <script setup lang="ts">
 import { Head, useForm } from '@inertiajs/vue3'
-import { Link } from '@inertiajs/vue3'
-import ContentBlock from '~/components/shared/ContentBlock.vue'
-import BaseHeading from '~/components/base/BaseHeading.vue'
-import BaseImageUpload from '~/components/base/BaseImageUpload.vue'
+import AdminShell from '~/components/admin/ui/AdminShell.vue'
+import AdminButton from '~/components/admin/ui/AdminButton.vue'
+import SponsorFormFields from '~/components/admin/SponsorFormFields.vue'
 
 interface Sponsor {
   id: string
@@ -24,8 +23,6 @@ interface Props {
 
 const props = defineProps<Props>()
 
-const sponsorTypeOptions = ['venue', 'food', 'drinks', 'swag', 'gold', 'silver', 'bronze', 'platinum']
-
 const form = useForm({
   name: props.sponsor.name,
   website: props.sponsor.website || '',
@@ -41,251 +38,57 @@ const form = useForm({
   status: props.sponsor.status,
 })
 
-function toggleSponsorType(type: string) {
-  const index = form.sponsorTypes.indexOf(type)
-  if (index === -1) {
-    form.sponsorTypes.push(type)
-  } else {
-    form.sponsorTypes.splice(index, 1)
-  }
-}
-
 function handleSubmit() {
-  form.put(`/admin/sponsors/${props.sponsor.id}`, {
-    forceFormData: true,
-  })
+  form.put(`/admin/sponsors/${props.sponsor.id}`, { forceFormData: true })
 }
 </script>
 
 <template>
-  <Head :title="`Edit: ${sponsor.name}`" />
-  <main class="relative min-h-screen pt-40 pb-20">
-      <ContentBlock>
-        <div class="max-w-2xl mx-auto">
-        <!-- Breadcrumb -->
-        <nav class="mb-6 flex items-center gap-2 text-sm">
-          <Link href="/admin" class="text-verse-600 hover:text-verse-800 dark:text-verse-400 dark:hover:text-verse-200">
-            Admin
-          </Link>
-          <span class="text-verse-400">/</span>
-          <Link href="/admin/sponsors" class="text-verse-600 hover:text-verse-800 dark:text-verse-400 dark:hover:text-verse-200">
-            Sponsors
-          </Link>
-          <span class="text-verse-400">/</span>
-          <span class="text-verse-900 dark:text-verse-100">{{ sponsor.name }}</span>
-        </nav>
-
-        <!-- Header -->
-        <div class="flex items-center gap-4 mb-8">
-          <div
-            v-if="sponsor.logoUrl"
-            :class="['w-16 h-16 squircle rounded-lg flex items-center justify-center p-2', sponsor.logoBg ? '' : 'bg-white dark:bg-white border border-verse-200']"
-            :style="sponsor.logoBg ? { backgroundColor: sponsor.logoBg } : {}"
-          >
-            <img :src="sponsor.logoUrl" :alt="sponsor.name" class="max-w-full max-h-full object-contain" />
-          </div>
-          <div>
-            <BaseHeading :level="1">Edit Sponsor</BaseHeading>
-            <p class="text-verse-600 dark:text-verse-400">
-              {{ sponsor.name }}
-              <span v-if="sponsor.eventCount" class="text-sm">
-                ({{ sponsor.eventCount }} event{{ sponsor.eventCount !== 1 ? 's' : '' }})
-              </span>
-            </p>
-          </div>
-        </div>
-
-        <form @submit.prevent="handleSubmit" class="space-y-6">
-          <!-- Name -->
-          <div>
-            <label for="name" class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-2">
-              Name <span class="text-red-500">*</span>
-            </label>
-            <input
-              id="name"
-              v-model="form.name"
-              type="text"
-              required
-              class="w-full px-4 py-2 border border-verse-300 dark:border-verse-600 squircle rounded-lg bg-white dark:bg-verse-800 text-verse-900 dark:text-verse-100 focus:ring-2 focus:ring-verse-500 focus:border-transparent"
-            />
-            <p v-if="form.errors.name" class="mt-1 text-sm text-red-500">{{ form.errors.name }}</p>
-          </div>
-
-          <!-- Website -->
-          <div>
-            <label for="website" class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-2">
-              Website
-            </label>
-            <input
-              id="website"
-              v-model="form.website"
-              type="url"
-              placeholder="https://..."
-              class="w-full px-4 py-2 border border-verse-300 dark:border-verse-600 squircle rounded-lg bg-white dark:bg-verse-800 text-verse-900 dark:text-verse-100 focus:ring-2 focus:ring-verse-500 focus:border-transparent"
-            />
-            <p v-if="form.errors.website" class="mt-1 text-sm text-red-500">{{ form.errors.website }}</p>
-          </div>
-
-          <!-- Description -->
-          <div>
-            <label for="description" class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-2">
-              Description
-            </label>
-            <textarea
-              id="description"
-              v-model="form.description"
-              rows="4"
-              class="w-full px-4 py-2 border border-verse-300 dark:border-verse-600 squircle rounded-lg bg-white dark:bg-verse-800 text-verse-900 dark:text-verse-100 focus:ring-2 focus:ring-verse-500 focus:border-transparent"
-            />
-            <p v-if="form.errors.description" class="mt-1 text-sm text-red-500">{{ form.errors.description }}</p>
-          </div>
-
-          <!-- Logo Upload -->
-          <div class="grid md:grid-cols-2 gap-6">
-            <div>
-              <label class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-2">
-                Logo
-              </label>
-              <BaseImageUpload
-                v-model="form.logoFile"
-                :current-url="sponsor.logoUrl"
-                :dark-preview="!!form.logoBg"
-                :error="form.errors.logoFile || form.errors.logoUrl"
-                @update:url="(v) => { form.logoUrl = v; form.clearLogo = false }"
-                @update:model-value="() => { form.clearLogo = false }"
-                @clear="form.clearLogo = true"
-              />
-            </div>
-
-            <div>
-              <label class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-2">
-                Logomark
-              </label>
-              <BaseImageUpload
-                v-model="form.logomarkFile"
-                :current-url="sponsor.logomarkUrl"
-                :dark-preview="!!form.logoBg"
-                :error="form.errors.logomarkFile || form.errors.logomarkUrl"
-                @update:url="(v) => { form.logomarkUrl = v; form.clearLogomark = false }"
-                @update:model-value="() => { form.clearLogomark = false }"
-                @clear="form.clearLogomark = true"
-              />
-            </div>
-          </div>
-
-          <!-- Sponsor Types -->
-          <div>
-            <label class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-2">
-              Sponsor Types
-            </label>
-            <div class="flex flex-wrap gap-2">
-              <button
-                v-for="type in sponsorTypeOptions"
-                :key="type"
-                type="button"
-                @click="toggleSponsorType(type)"
-                :class="[
-                  'px-3 py-1.5 squircle rounded-lg text-sm font-medium transition-colors capitalize',
-                  form.sponsorTypes.includes(type)
-                    ? 'bg-verse-600 text-white'
-                    : 'bg-verse-100 dark:bg-verse-700 text-verse-700 dark:text-verse-300 hover:bg-verse-200 dark:hover:bg-verse-600'
-                ]"
-              >
-                {{ type }}
-              </button>
-            </div>
-          </div>
-
-          <!-- Logo Background -->
-          <div>
-            <label class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-2">
-              Logo Background
-            </label>
-            <div class="flex flex-wrap items-center gap-2">
-              <button
-                type="button"
-                @click="form.logoBg = ''"
-                :class="[
-                  'px-3 py-1.5 squircle rounded-lg text-sm font-medium transition-colors',
-                  !form.logoBg
-                    ? 'bg-verse-600 text-white'
-                    : 'bg-verse-100 dark:bg-verse-700 text-verse-700 dark:text-verse-300 hover:bg-verse-200 dark:hover:bg-verse-600'
-                ]"
-              >
-                Transparent
-              </button>
-              <button
-                type="button"
-                @click="form.logoBg = '#ffffff'"
-                :class="[
-                  'px-3 py-1.5 squircle rounded-lg text-sm font-medium transition-colors',
-                  form.logoBg === '#ffffff'
-                    ? 'bg-verse-600 text-white'
-                    : 'bg-verse-100 dark:bg-verse-700 text-verse-700 dark:text-verse-300 hover:bg-verse-200 dark:hover:bg-verse-600'
-                ]"
-              >
-                White
-              </button>
-              <button
-                type="button"
-                @click="form.logoBg = '#111827'"
-                :class="[
-                  'px-3 py-1.5 squircle rounded-lg text-sm font-medium transition-colors',
-                  form.logoBg === '#111827'
-                    ? 'bg-verse-600 text-white'
-                    : 'bg-verse-100 dark:bg-verse-700 text-verse-700 dark:text-verse-300 hover:bg-verse-200 dark:hover:bg-verse-600'
-                ]"
-              >
-                Black
-              </button>
-              <div class="flex items-center gap-2">
-                <input
-                  type="color"
-                  :value="form.logoBg || '#ffffff'"
-                  @input="form.logoBg = ($event.target as HTMLInputElement).value"
-                  class="w-8 h-8 rounded cursor-pointer border border-verse-300 dark:border-verse-600"
-                />
-                <span v-if="form.logoBg && !['#ffffff', '#111827', ''].includes(form.logoBg)" class="text-xs font-mono text-verse-500">
-                  {{ form.logoBg }}
-                </span>
-              </div>
-            </div>
-          </div>
-
-          <!-- Status -->
-          <div>
-            <label for="status" class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-2">
-              Status
-            </label>
-            <select
-              id="status"
-              v-model="form.status"
-              class="w-full px-4 py-2 border border-verse-300 dark:border-verse-600 squircle rounded-lg bg-white dark:bg-verse-800 text-verse-900 dark:text-verse-100 focus:ring-2 focus:ring-verse-500 focus:border-transparent"
-            >
-              <option value="active">Active</option>
-              <option value="inactive">Inactive</option>
-            </select>
-          </div>
-
-          <!-- Submit -->
-          <div class="flex justify-end gap-4 pt-4">
-            <Link
-              href="/admin/sponsors"
-              class="px-6 py-2 text-verse-700 dark:text-verse-300 hover:bg-verse-100 dark:hover:bg-verse-700 squircle rounded-lg transition-colors"
-            >
-              Cancel
-            </Link>
-            <button
-              type="submit"
-              :disabled="form.processing"
-              class="px-6 py-2 bg-verse-600 hover:bg-verse-700 text-white font-medium squircle rounded-lg transition-colors disabled:opacity-50"
-            >
-              <span v-if="form.processing">Saving...</span>
-              <span v-else>Save Changes</span>
-            </button>
-          </div>
-        </form>
+  <Head :title="`${sponsor.name} · Admin`" />
+  <AdminShell
+    :title="sponsor.name"
+    :description="
+      sponsor.eventCount
+        ? `Linked to ${sponsor.eventCount} event${sponsor.eventCount === 1 ? '' : 's'}.`
+        : 'Sponsor profile and branding.'
+    "
+    :breadcrumbs="[
+      { label: 'Admin', href: '/admin' },
+      { label: 'Sponsors', href: '/admin/sponsors' },
+      { label: sponsor.name },
+    ]"
+  >
+    <template #media>
+      <div
+        :class="[
+          'w-14 h-14 rounded-2xl flex items-center justify-center p-2 border border-verse-200 dark:border-verse-800',
+          sponsor.logoBg ? '' : 'bg-white dark:bg-white',
+        ]"
+        :style="sponsor.logoBg ? { backgroundColor: sponsor.logoBg } : {}"
+      >
+        <img
+          v-if="sponsor.logoUrl"
+          :src="sponsor.logoUrl"
+          :alt="sponsor.name"
+          class="max-w-full max-h-full object-contain"
+        />
+        <span v-else class="text-verse-400 text-lg">{{ sponsor.name.charAt(0) }}</span>
       </div>
-    </ContentBlock>
-  </main>
+    </template>
+
+    <form class="max-w-3xl space-y-6" @submit.prevent="handleSubmit">
+      <SponsorFormFields
+        :form="form"
+        :current-logo-url="sponsor.logoUrl"
+        :current-logomark-url="sponsor.logomarkUrl"
+      />
+
+      <div class="sticky bottom-3 z-10 flex justify-end gap-2 bg-white/85 dark:bg-verse-950/85 backdrop-blur-md p-3 rounded-xl border border-verse-200 dark:border-verse-800">
+        <AdminButton href="/admin/sponsors" variant="secondary">Cancel</AdminButton>
+        <AdminButton type="submit" variant="primary" :loading="form.processing">
+          {{ form.processing ? 'Saving…' : 'Save changes' }}
+        </AdminButton>
+      </div>
+    </form>
+  </AdminShell>
 </template>

--- a/packages/frontendmu-adonis/inertia/pages/admin/sponsors/index.vue
+++ b/packages/frontendmu-adonis/inertia/pages/admin/sponsors/index.vue
@@ -75,7 +75,7 @@ function doDelete() {
         :chips="filterChips"
         aria-label="Filter by status"
       />
-      <p class="text-xs font-mono text-verse-500 dark:text-verse-400 tabular-nums">
+      <p class="text-xs font-mono text-verse-500 dark:text-verse-300 tabular-nums">
         {{ sponsors.length }} sponsor{{ sponsors.length === 1 ? '' : 's' }}
       </p>
     </div>
@@ -131,7 +131,7 @@ function doDelete() {
                 </Link>
                 <p
                   v-if="sponsor.website"
-                  class="text-xs text-verse-500 dark:text-verse-400 truncate max-w-[280px]"
+                  class="text-xs text-verse-500 dark:text-verse-300 truncate max-w-[280px]"
                 >
                   {{ sponsor.website }}
                 </p>

--- a/packages/frontendmu-adonis/inertia/pages/admin/sponsors/index.vue
+++ b/packages/frontendmu-adonis/inertia/pages/admin/sponsors/index.vue
@@ -1,8 +1,14 @@
 <script setup lang="ts">
-import { Head, router } from '@inertiajs/vue3'
-import { Link } from '@inertiajs/vue3'
-import ContentBlock from '~/components/shared/ContentBlock.vue'
-import BaseHeading from '~/components/base/BaseHeading.vue'
+import { computed } from 'vue'
+import { Head, Link, router } from '@inertiajs/vue3'
+import AdminShell from '~/components/admin/ui/AdminShell.vue'
+import AdminCard from '~/components/admin/ui/AdminCard.vue'
+import AdminButton from '~/components/admin/ui/AdminButton.vue'
+import AdminBadge from '~/components/admin/ui/AdminBadge.vue'
+import AdminTable from '~/components/admin/ui/AdminTable.vue'
+import AdminFilterChips from '~/components/admin/ui/AdminFilterChips.vue'
+import AdminEmptyState from '~/components/admin/ui/AdminEmptyState.vue'
+import AdminConfirmModal from '~/components/admin/ui/AdminConfirmModal.vue'
 import { useAuth } from '~/composables/use_auth'
 import { useDeleteConfirmation } from '~/composables/use_delete_confirmation'
 
@@ -28,325 +34,212 @@ const {
   showModal: showDeleteModal,
   itemToDelete: sponsorToDelete,
   isDeleting,
-  confirmDelete: confirmDeleteItem,
+  confirmDelete,
   cancelDelete,
-  executeDelete: execDelete,
+  executeDelete,
 } = useDeleteConfirmation<Sponsor>()
 
-// Status badge styles
-const getStatusBadge = (status: string) => {
-  return status === 'active'
-    ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300'
-    : 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400'
-}
+const filterChips = [
+  { key: 'all', label: 'All' },
+  { key: 'active', label: 'Active' },
+  { key: 'inactive', label: 'Inactive' },
+]
 
-// Filter by status
-function filterByStatus(status: string) {
-  router.get('/admin/sponsors', { status }, { preserveState: true })
-}
-
-function confirmDelete(sponsor: Sponsor) {
-  confirmDeleteItem(sponsor)
-}
+const currentStatus = computed({
+  get: () => props.statusFilter,
+  set: (v) => router.get('/admin/sponsors', { status: v }, { preserveState: true }),
+})
 
 function doDelete() {
   if (!sponsorToDelete.value) return
-  execDelete(`/admin/sponsors/${sponsorToDelete.value.id}`)
+  executeDelete(`/admin/sponsors/${sponsorToDelete.value.id}`)
 }
 </script>
 
 <template>
-  <Head title="Manage Sponsors" />
-  <main class="relative min-h-screen pt-40 pb-20">
-    <ContentBlock>
-      <!-- Header -->
-      <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-8">
-        <div>
-          <BaseHeading :level="1">Manage Sponsors</BaseHeading>
-          <p class="text-verse-600 dark:text-verse-400 mt-2">View and manage sponsor profiles.</p>
-        </div>
-        <Link
-          href="/admin/sponsors/create"
-          class="inline-flex items-center gap-2 px-4 py-2 bg-verse-600 hover:bg-verse-700 text-white text-sm font-medium squircle rounded-lg transition-colors"
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            class="h-4 w-4"
-            viewBox="0 0 20 20"
-            fill="currentColor"
-          >
-            <path
-              fill-rule="evenodd"
-              d="M10 3a1 1 0 011 1v5h5a1 1 0 110 2h-5v5a1 1 0 11-2 0v-5H4a1 1 0 110-2h5V4a1 1 0 011-1z"
-              clip-rule="evenodd"
-            />
-          </svg>
-          Add Sponsor
-        </Link>
-      </div>
+  <Head title="Sponsors · Admin" />
+  <AdminShell title="Sponsors" description="Track sponsors, partnerships and how they show up across events.">
+    <template #actions>
+      <AdminButton href="/admin/sponsors/create" variant="primary">
+        <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <line x1="12" y1="5" x2="12" y2="19" />
+          <line x1="5" y1="12" x2="19" y2="12" />
+        </svg>
+        Add sponsor
+      </AdminButton>
+    </template>
 
-      <!-- Filters -->
-      <div class="flex flex-wrap gap-2 mb-6">
-        <button
-          @click="filterByStatus('all')"
-          :class="[
-            'px-4 py-2 squircle rounded-lg text-sm font-medium transition-colors',
-            statusFilter === 'all'
-              ? 'bg-verse-600 text-white'
-              : 'bg-verse-100 dark:bg-verse-800 text-verse-700 dark:text-verse-300 hover:bg-verse-200 dark:hover:bg-verse-700',
-          ]"
-        >
-          All
-        </button>
-        <button
-          @click="filterByStatus('active')"
-          :class="[
-            'px-4 py-2 squircle rounded-lg text-sm font-medium transition-colors',
-            statusFilter === 'active'
-              ? 'bg-green-600 text-white'
-              : 'bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-300 hover:bg-green-200 dark:hover:bg-green-900/50',
-          ]"
-        >
-          Active
-        </button>
-        <button
-          @click="filterByStatus('inactive')"
-          :class="[
-            'px-4 py-2 squircle rounded-lg text-sm font-medium transition-colors',
-            statusFilter === 'inactive'
-              ? 'bg-gray-600 text-white'
-              : 'bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700',
-          ]"
-        >
-          Inactive
-        </button>
-      </div>
+    <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between mb-5">
+      <AdminFilterChips
+        v-model="currentStatus"
+        :chips="filterChips"
+        aria-label="Filter by status"
+      />
+      <p class="text-xs font-mono text-verse-500 dark:text-verse-400 tabular-nums">
+        {{ sponsors.length }} sponsor{{ sponsors.length === 1 ? '' : 's' }}
+      </p>
+    </div>
 
-      <!-- Sponsors Table -->
-      <div
-        class="bg-white dark:bg-verse-800/50 squircle rounded-xl border border-verse-200 dark:border-verse-700 overflow-hidden"
+    <AdminCard :padded="false">
+      <AdminTable
+        v-if="sponsors.length"
+        :columns="[
+          { label: 'Sponsor' },
+          { label: 'Types' },
+          { label: 'Status' },
+          { label: 'Actions', align: 'right' },
+        ]"
       >
-        <div class="overflow-x-auto">
-          <table class="w-full">
-            <thead
-              class="bg-verse-50 dark:bg-verse-800 border-b border-verse-200 dark:border-verse-700"
-            >
-              <tr>
-                <th
-                  class="px-6 py-3 text-left text-xs font-semibold text-verse-600 dark:text-verse-400 uppercase tracking-wider"
-                >
-                  Sponsor
-                </th>
-                <th
-                  class="px-6 py-3 text-left text-xs font-semibold text-verse-600 dark:text-verse-400 uppercase tracking-wider"
-                >
-                  Types
-                </th>
-                <th
-                  class="px-6 py-3 text-left text-xs font-semibold text-verse-600 dark:text-verse-400 uppercase tracking-wider"
-                >
-                  Status
-                </th>
-                <th
-                  class="px-6 py-3 text-right text-xs font-semibold text-verse-600 dark:text-verse-400 uppercase tracking-wider"
-                >
-                  Actions
-                </th>
-              </tr>
-            </thead>
-            <tbody class="divide-y divide-verse-200 dark:divide-verse-700">
-              <tr
-                v-for="sponsor in sponsors"
-                :key="sponsor.id"
-                class="hover:bg-verse-50 dark:hover:bg-verse-800/80 transition-colors"
+        <tr
+          v-for="sponsor in sponsors"
+          :key="sponsor.id"
+          class="hover:bg-verse-50/50 dark:hover:bg-verse-800/40 transition-colors"
+        >
+          <td class="px-5 py-3.5">
+            <div class="flex items-center gap-3 min-w-0">
+              <div
+                v-if="sponsor.logoUrl"
+                :class="[
+                  'w-10 h-10 rounded-xl flex items-center justify-center p-1 border border-verse-100 dark:border-verse-800 shrink-0',
+                  sponsor.logoBg ? '' : 'bg-white dark:bg-white',
+                ]"
+                :style="sponsor.logoBg ? { backgroundColor: sponsor.logoBg } : {}"
               >
-                <td class="px-6 py-4">
-                  <div class="flex items-center gap-3">
-                    <div
-                      v-if="sponsor.logoUrl"
-                      :class="[
-                        'w-10 h-10 squircle rounded-lg flex items-center justify-center p-1',
-                        sponsor.logoBg ? '' : 'bg-white',
-                      ]"
-                      :style="sponsor.logoBg ? { backgroundColor: sponsor.logoBg } : {}"
-                    >
-                      <img
-                        :src="sponsor.logoUrl"
-                        :alt="sponsor.name"
-                        class="max-w-full max-h-full object-contain"
-                      />
-                    </div>
-                    <div
-                      v-else
-                      class="w-10 h-10 squircle rounded-lg bg-verse-200 dark:bg-verse-700 flex items-center justify-center"
-                    >
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        class="h-5 w-5 text-verse-400"
-                        viewBox="0 0 20 20"
-                        fill="currentColor"
-                      >
-                        <path
-                          fill-rule="evenodd"
-                          d="M4 3a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V5a2 2 0 00-2-2H4zm12 12H4l4-8 3 6 2-4 3 6z"
-                          clip-rule="evenodd"
-                        />
-                      </svg>
-                    </div>
-                    <div>
-                      <span class="font-medium text-verse-900 dark:text-verse-100">
-                        {{ sponsor.name }}
-                      </span>
-                      <p
-                        v-if="sponsor.website"
-                        class="text-xs text-verse-500 dark:text-verse-400 truncate max-w-[200px]"
-                      >
-                        {{ sponsor.website }}
-                      </p>
-                    </div>
-                  </div>
-                </td>
-                <td class="px-6 py-4">
-                  <div class="flex flex-wrap gap-1">
-                    <span
-                      v-for="type in sponsor.sponsorTypes"
-                      :key="type"
-                      class="px-2 py-0.5 text-xs font-medium bg-verse-100 dark:bg-verse-700 text-verse-600 dark:text-verse-300 rounded capitalize"
-                    >
-                      {{ type }}
-                    </span>
-                    <span
-                      v-if="!sponsor.sponsorTypes?.length"
-                      class="text-verse-400 dark:text-verse-500 text-sm"
-                    >
-                      -
-                    </span>
-                  </div>
-                </td>
-                <td class="px-6 py-4">
-                  <span
-                    :class="[
-                      'px-2.5 py-1 rounded-full text-xs font-medium capitalize',
-                      getStatusBadge(sponsor.status),
-                    ]"
-                  >
-                    {{ sponsor.status }}
-                  </span>
-                </td>
-                <td class="px-6 py-4 text-right">
-                  <div class="flex items-center justify-end gap-2">
-                    <Link
-                      :href="`/sponsor/${sponsor.id}`"
-                      class="p-2 text-verse-500 hover:text-verse-700 dark:text-verse-400 dark:hover:text-verse-200 transition-colors"
-                      title="View"
-                    >
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        class="h-5 w-5"
-                        viewBox="0 0 20 20"
-                        fill="currentColor"
-                      >
-                        <path d="M10 12a2 2 0 100-4 2 2 0 000 4z" />
-                        <path
-                          fill-rule="evenodd"
-                          d="M.458 10C1.732 5.943 5.522 3 10 3s8.268 2.943 9.542 7c-1.274 4.057-5.064 7-9.542 7S1.732 14.057.458 10zM14 10a4 4 0 11-8 0 4 4 0 018 0z"
-                          clip-rule="evenodd"
-                        />
-                      </svg>
-                    </Link>
-                    <Link
-                      :href="`/admin/sponsors/${sponsor.id}/edit`"
-                      class="p-2 text-verse-500 hover:text-verse-700 dark:text-verse-400 dark:hover:text-verse-200 transition-colors"
-                      title="Edit"
-                    >
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        class="h-5 w-5"
-                        viewBox="0 0 20 20"
-                        fill="currentColor"
-                      >
-                        <path
-                          d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z"
-                        />
-                      </svg>
-                    </Link>
-                    <button
-                      v-if="canDelete"
-                      @click="confirmDelete(sponsor)"
-                      class="p-2 text-red-500 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300 transition-colors"
-                      title="Delete"
-                    >
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        class="h-5 w-5"
-                        viewBox="0 0 20 20"
-                        fill="currentColor"
-                      >
-                        <path
-                          fill-rule="evenodd"
-                          d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z"
-                          clip-rule="evenodd"
-                        />
-                      </svg>
-                    </button>
-                  </div>
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
+                <img
+                  :src="sponsor.logoUrl"
+                  :alt="sponsor.name"
+                  class="max-w-full max-h-full object-contain"
+                />
+              </div>
+              <div
+                v-else
+                class="w-10 h-10 rounded-xl bg-verse-100 dark:bg-verse-800 flex items-center justify-center text-verse-500 shrink-0"
+                aria-hidden="true"
+              >
+                <svg class="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+                  <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
+                  <circle cx="8.5" cy="8.5" r="1.5" />
+                  <polyline points="21 15 16 10 5 21" />
+                </svg>
+              </div>
+              <div class="min-w-0">
+                <Link
+                  :href="`/admin/sponsors/${sponsor.id}/edit`"
+                  class="font-medium text-verse-900 dark:text-verse-50 hover:underline decoration-coral-strong decoration-2 underline-offset-4 truncate block"
+                >
+                  {{ sponsor.name }}
+                </Link>
+                <p
+                  v-if="sponsor.website"
+                  class="text-xs text-verse-500 dark:text-verse-400 truncate max-w-[280px]"
+                >
+                  {{ sponsor.website }}
+                </p>
+              </div>
+            </div>
+          </td>
+          <td class="px-5 py-3.5">
+            <div class="flex flex-wrap gap-1">
+              <AdminBadge
+                v-for="type in sponsor.sponsorTypes"
+                :key="type"
+                tone="muted"
+              >
+                {{ type }}
+              </AdminBadge>
+              <span
+                v-if="!sponsor.sponsorTypes?.length"
+                class="text-verse-400 dark:text-verse-500 text-sm"
+              >—</span>
+            </div>
+          </td>
+          <td class="px-5 py-3.5">
+            <AdminBadge :tone="sponsor.status === 'active' ? 'success' : 'muted'" dot>
+              {{ sponsor.status }}
+            </AdminBadge>
+          </td>
+          <td class="px-5 py-3.5">
+            <div class="flex items-center justify-end gap-1">
+              <AdminButton
+                :href="`/sponsor/${sponsor.id}`"
+                variant="ghost"
+                size="sm"
+                icon-only
+                title="View public page"
+              >
+                <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+                  <circle cx="12" cy="12" r="3" />
+                </svg>
+              </AdminButton>
+              <AdminButton
+                :href="`/admin/sponsors/${sponsor.id}/edit`"
+                variant="ghost"
+                size="sm"
+                icon-only
+                title="Edit sponsor"
+              >
+                <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
+                  <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
+                </svg>
+              </AdminButton>
+              <button
+                v-if="canDelete"
+                type="button"
+                class="p-2 rounded-lg text-red-500 hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-900/20 dark:text-red-400 dark:hover:text-red-300 transition-colors"
+                title="Delete sponsor"
+                aria-label="Delete sponsor"
+                @click="confirmDelete(sponsor)"
+              >
+                <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <polyline points="3 6 5 6 21 6" />
+                  <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+                </svg>
+              </button>
+            </div>
+          </td>
+        </tr>
+      </AdminTable>
 
-        <!-- Empty state -->
-        <div v-if="!sponsors.length" class="px-6 py-12 text-center">
-          <p class="text-verse-500 dark:text-verse-400 mb-4">
-            No sponsors found<span v-if="statusFilter !== 'all'">
-              with status "{{ statusFilter }}"</span
-            >.
-          </p>
-          <Link
+      <AdminEmptyState
+        v-else
+        :title="
+          statusFilter !== 'all' ? `No ${statusFilter} sponsors` : 'No sponsors yet'
+        "
+        :description="
+          statusFilter !== 'all'
+            ? 'Try a different filter, or clear filters to see them all.'
+            : 'Add your first sponsor to get started.'
+        "
+        icon="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"
+      >
+        <template #actions>
+          <AdminButton
             v-if="statusFilter !== 'all'"
             href="/admin/sponsors"
-            class="inline-block text-verse-600 hover:text-verse-800 dark:text-verse-400 dark:hover:text-verse-200 underline"
+            variant="secondary"
           >
-            View all sponsors
-          </Link>
-        </div>
-      </div>
-    </ContentBlock>
-  </main>
+            Clear filters
+          </AdminButton>
+          <AdminButton href="/admin/sponsors/create" variant="primary">
+            Add sponsor
+          </AdminButton>
+        </template>
+      </AdminEmptyState>
+    </AdminCard>
+  </AdminShell>
 
-  <!-- Delete Confirmation Modal -->
-  <Teleport to="body">
-    <div v-if="showDeleteModal" class="fixed inset-0 z-50 flex items-center justify-center p-4">
-      <div class="absolute inset-0 bg-black/50" @click="cancelDelete" />
-      <div
-        class="relative bg-white dark:bg-verse-800 squircle rounded-xl shadow-xl max-w-md w-full p-6"
-      >
-        <h3 class="text-lg font-semibold text-verse-900 dark:text-verse-100 mb-2">
-          Delete Sponsor
-        </h3>
-        <p class="text-verse-600 dark:text-verse-400 mb-4">
-          Are you sure you want to delete "<strong>{{ sponsorToDelete?.name }}</strong
-          >"? This action cannot be undone.
-        </p>
-        <div class="flex justify-end gap-3">
-          <button
-            @click="cancelDelete"
-            :disabled="isDeleting"
-            class="px-4 py-2 text-sm font-medium text-verse-700 dark:text-verse-300 bg-verse-100 dark:bg-verse-700 hover:bg-verse-200 dark:hover:bg-verse-600 squircle rounded-lg transition-colors disabled:opacity-50"
-          >
-            Cancel
-          </button>
-          <button
-            @click="doDelete"
-            :disabled="isDeleting"
-            class="px-4 py-2 text-sm font-medium text-white bg-red-600 hover:bg-red-700 squircle rounded-lg transition-colors disabled:opacity-50"
-          >
-            <span v-if="isDeleting">Deleting...</span>
-            <span v-else>Delete</span>
-          </button>
-        </div>
-      </div>
-    </div>
-  </Teleport>
+  <AdminConfirmModal
+    :open="showDeleteModal"
+    title="Delete sponsor"
+    :loading="isDeleting"
+    confirm-label="Delete sponsor"
+    @cancel="cancelDelete"
+    @confirm="doDelete"
+  >
+    Are you sure you want to delete
+    <strong class="text-verse-900 dark:text-verse-100">{{ sponsorToDelete?.name }}</strong
+    >? This action cannot be undone.
+  </AdminConfirmModal>
 </template>

--- a/packages/frontendmu-adonis/inertia/pages/admin/users/edit.vue
+++ b/packages/frontendmu-adonis/inertia/pages/admin/users/edit.vue
@@ -1,11 +1,15 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
-import { Head, useForm, usePage } from '@inertiajs/vue3'
-import { Link } from '@inertiajs/vue3'
+import { Head, useForm, usePage, Link } from '@inertiajs/vue3'
 import type { Data } from '@generated/data'
-import ContentBlock from '~/components/shared/ContentBlock.vue'
-import BaseHeading from '~/components/base/BaseHeading.vue'
-import { getRoleBadgeClass } from '~/utils/roles'
+import AdminShell from '~/components/admin/ui/AdminShell.vue'
+import AdminCard from '~/components/admin/ui/AdminCard.vue'
+import AdminButton from '~/components/admin/ui/AdminButton.vue'
+import AdminInput from '~/components/admin/ui/AdminInput.vue'
+import AdminTextarea from '~/components/admin/ui/AdminTextarea.vue'
+import AdminCheckbox from '~/components/admin/ui/AdminCheckbox.vue'
+import AdminBadge from '~/components/admin/ui/AdminBadge.vue'
+import AdminAvatar from '~/components/admin/ui/AdminAvatar.vue'
 
 type SharedProps = Data.SharedProps
 
@@ -18,7 +22,6 @@ interface Rsvp {
 }
 
 type AdminRole = Data.Role.Variants['forAdminEdit']
-type AdminSession = Data.Session.Variants['forSpeakerProfile']
 type AdminUser = Data.AdminUser.Variants['forAdminEdit'] & { rsvps: Rsvp[] }
 
 interface Props {
@@ -31,7 +34,6 @@ const page = usePage<SharedProps>()
 const currentUser = computed(() => page.props.auth.user)
 const isEditingSelf = computed(() => props.user.id === currentUser.value?.id)
 
-// Track which role is expanded for permission viewing
 const expandedRole = ref<number | null>(null)
 
 const form = useForm({
@@ -57,11 +59,8 @@ function toggleRole(roleId: number) {
   const index = form.roleIds.indexOf(roleId)
   if (index === -1) {
     form.roleIds.push(roleId)
-  } else {
-    // Don't allow removing the last role
-    if (form.roleIds.length > 1) {
-      form.roleIds.splice(index, 1)
-    }
+  } else if (form.roleIds.length > 1) {
+    form.roleIds.splice(index, 1)
   }
 }
 
@@ -73,20 +72,16 @@ function toggleExpandRole(roleId: number) {
   expandedRole.value = expandedRole.value === roleId ? null : roleId
 }
 
-// Compute effective permissions based on selected roles
 const effectivePermissions = computed(() => {
   const permissions = new Set<string>()
   for (const role of props.allRoles) {
     if (form.roleIds.includes(role.id)) {
-      for (const perm of role.permissions) {
-        permissions.add(perm.name)
-      }
+      for (const perm of role.permissions) permissions.add(perm.name)
     }
   }
   return Array.from(permissions).sort()
 })
 
-// Check if superadmin is trying to remove their own superadmin role
 const isTryingToRemoveSuperadmin = computed(() => {
   if (!isEditingSelf.value) return false
   const superadminRole = props.allRoles.find((r) => r.name === 'superadmin')
@@ -96,7 +91,6 @@ const isTryingToRemoveSuperadmin = computed(() => {
   return hadSuperadmin && !hasSuperadmin
 })
 
-// Permission category grouping
 function getPermissionCategory(permName: string) {
   if (permName.includes('event')) return 'Events'
   if (permName.includes('rsvp')) return 'RSVPs'
@@ -113,541 +107,297 @@ const groupedPermissions = computed(() => {
   const groups: Record<string, string[]> = {}
   for (const perm of effectivePermissions.value) {
     const category = getPermissionCategory(perm)
-    if (!groups[category]) {
-      groups[category] = []
-    }
+    if (!groups[category]) groups[category] = []
     groups[category].push(perm)
   }
   return groups
 })
+
+function roleTone(name: string) {
+  switch (name) {
+    case 'superadmin':
+      return 'danger'
+    case 'organizer':
+      return 'accent'
+    case 'member':
+      return 'info'
+    case 'viewer':
+      return 'muted'
+    default:
+      return 'neutral'
+  }
+}
 </script>
 
 <template>
-  <Head :title="`Edit User: ${user.name}`" />
-  <main class="relative min-h-screen pt-40 pb-20">
-    <ContentBlock>
-      <div class="max-w-3xl mx-auto">
-        <!-- Breadcrumb -->
-        <nav class="mb-6 flex items-center gap-2 text-sm">
-          <Link
-            href="/admin"
-            class="text-verse-600 hover:text-verse-800 dark:text-verse-400 dark:hover:text-verse-200"
-          >
-            Admin
-          </Link>
-          <span class="text-verse-400">/</span>
-          <Link
-            href="/admin/users"
-            class="text-verse-600 hover:text-verse-800 dark:text-verse-400 dark:hover:text-verse-200"
-          >
-            Users
-          </Link>
-          <span class="text-verse-400">/</span>
-          <span class="text-verse-900 dark:text-verse-100">{{ user.name }}</span>
-        </nav>
+  <Head :title="`${user.name} · Admin`" />
+  <AdminShell
+    :title="user.name"
+    :description="
+      isEditingSelf ? 'You are editing your own account.' : 'Account, roles and permissions.'
+    "
+    :breadcrumbs="[
+      { label: 'Admin', href: '/admin' },
+      { label: 'Users', href: '/admin/users' },
+      { label: user.name },
+    ]"
+  >
+    <template #media>
+      <AdminAvatar :src="user.avatarUrl" :name="user.name" size="xl" rounded="2xl" />
+    </template>
+    <template #meta>
+      <div class="flex flex-wrap gap-1.5">
+        <AdminBadge v-for="role in user.roles" :key="role.id" :tone="roleTone(role.name)">
+          {{ role.name }}
+        </AdminBadge>
+      </div>
+    </template>
 
-        <!-- Header with Avatar -->
-        <div class="flex items-center gap-4 mb-8">
-          <img
-            v-if="user.avatarUrl"
-            :src="user.avatarUrl"
-            :alt="user.name"
-            class="w-20 h-20 rounded-full object-cover"
+    <form class="space-y-6 max-w-3xl" @submit.prevent="handleSubmit">
+      <AdminCard title="Basic info">
+        <div class="space-y-5">
+          <AdminInput v-model="form.name" label="Name" required :error="form.errors.name" />
+          <AdminInput v-model="form.email" label="Email" type="email" :error="form.errors.email" />
+          <AdminInput
+            v-model="form.githubUsername"
+            label="GitHub username"
+            leading-text="@"
+            hint="Used to fetch the avatar from GitHub"
           />
+          <AdminInput
+            v-model="form.title"
+            label="Title"
+            placeholder="e.g. Lead Organiser, Software Engineer"
+            hint="Shown on the team page under the user's name"
+          />
+          <AdminTextarea v-model="form.bio" label="Bio" :rows="3" />
+        </div>
+      </AdminCard>
+
+      <AdminCard
+        title="Roles & permissions"
+        description="Assign one or more roles. Permissions are derived from the selected roles."
+      >
+        <div class="space-y-2">
           <div
-            v-else
-            class="w-20 h-20 rounded-full bg-verse-200 dark:bg-verse-700 flex items-center justify-center"
+            v-for="role in allRoles"
+            :key="role.id"
+            :class="[
+              'rounded-xl border transition-colors overflow-hidden',
+              isRoleSelected(role.id)
+                ? 'border-verse-400 dark:border-verse-600 bg-verse-50/50 dark:bg-verse-900/40'
+                : 'border-verse-200 dark:border-verse-800',
+            ]"
           >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              class="h-10 w-10 text-verse-400"
-              viewBox="0 0 20 20"
-              fill="currentColor"
-            >
-              <path
-                fill-rule="evenodd"
-                d="M10 9a3 3 0 100-6 3 3 0 000 6zm-7 9a7 7 0 1114 0H3z"
-                clip-rule="evenodd"
+            <div class="flex items-center gap-3 p-3.5">
+              <input
+                type="checkbox"
+                :checked="isRoleSelected(role.id)"
+                :disabled="
+                  isEditingSelf && role.name === 'superadmin' && isRoleSelected(role.id)
+                "
+                class="h-4 w-4 text-verse-600 focus:ring-verse-500 border-verse-300 dark:border-verse-700 rounded cursor-pointer"
+                :aria-labelledby="`role-${role.id}-label`"
+                @change="toggleRole(role.id)"
               />
-            </svg>
-          </div>
-          <div>
-            <BaseHeading :level="1">Edit User</BaseHeading>
-            <p class="text-verse-600 dark:text-verse-400">
-              {{ user.name }}
-              <span v-if="isEditingSelf" class="text-sm text-verse-500">(Your account)</span>
-            </p>
-            <!-- Current roles badges -->
-            <div class="flex flex-wrap gap-1 mt-2">
-              <span
-                v-for="role in user.roles"
-                :key="role.id"
-                :class="[
-                  'px-2 py-0.5 text-xs font-medium rounded-full',
-                  getRoleBadgeClass(role.name),
-                ]"
+              <div class="flex-1 min-w-0">
+                <div :id="`role-${role.id}-label`" class="flex items-center gap-2 flex-wrap">
+                  <AdminBadge :tone="roleTone(role.name)">{{ role.name }}</AdminBadge>
+                  <span class="text-sm text-verse-600 dark:text-verse-300">
+                    {{ role.description }}
+                  </span>
+                </div>
+              </div>
+              <button
+                type="button"
+                class="p-1 rounded-md text-verse-400 hover:text-verse-700 dark:hover:text-verse-200"
+                :aria-label="expandedRole === role.id ? 'Hide permissions' : 'Show permissions'"
+                @click="toggleExpandRole(role.id)"
               >
-                {{ role.name }}
-              </span>
+                <svg
+                  :class="['w-4 h-4 transition-transform', expandedRole === role.id ? 'rotate-180' : '']"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  aria-hidden="true"
+                >
+                  <polyline points="6 9 12 15 18 9" />
+                </svg>
+              </button>
+            </div>
+            <div
+              v-if="expandedRole === role.id"
+              class="px-3.5 pb-3.5 pt-1 border-t border-verse-200 dark:border-verse-800"
+            >
+              <p class="text-[11px] font-mono uppercase tracking-wide text-verse-500 dark:text-verse-400 mb-2">
+                Permissions in this role
+              </p>
+              <div class="flex flex-wrap gap-1">
+                <span
+                  v-for="perm in role.permissions"
+                  :key="perm.id"
+                  class="px-2 py-0.5 text-xs font-mono bg-verse-100 dark:bg-verse-800 text-verse-700 dark:text-verse-200 rounded"
+                >
+                  {{ perm.name }}
+                </span>
+                <span
+                  v-if="role.permissions.length === 0"
+                  class="text-xs text-verse-400 italic"
+                >No permissions</span>
+              </div>
             </div>
           </div>
         </div>
 
-        <form @submit.prevent="handleSubmit" class="space-y-8">
-          <!-- Basic Info Section -->
-          <div
-            class="bg-white dark:bg-verse-800 squircle rounded-lg border border-verse-200 dark:border-verse-700 p-6"
-          >
-            <h2 class="text-lg font-semibold text-verse-900 dark:text-verse-100 mb-4">
-              Basic Information
-            </h2>
+        <div
+          v-if="isTryingToRemoveSuperadmin"
+          class="mt-4 px-3.5 py-3 rounded-lg bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-900/40 text-sm text-amber-800 dark:text-amber-200"
+        >
+          You cannot remove the superadmin role from yourself.
+        </div>
 
-            <div class="space-y-4">
-              <!-- Name -->
-              <div>
-                <label
-                  for="name"
-                  class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-2"
-                >
-                  Name <span class="text-red-500">*</span>
-                </label>
-                <input
-                  id="name"
-                  v-model="form.name"
-                  type="text"
-                  required
-                  class="w-full px-4 py-2 border border-verse-300 dark:border-verse-600 squircle rounded-lg bg-white dark:bg-verse-800 text-verse-900 dark:text-verse-100 focus:ring-2 focus:ring-verse-500 focus:border-transparent"
-                />
-                <p v-if="form.errors.name" class="mt-1 text-sm text-red-500">
-                  {{ form.errors.name }}
-                </p>
-              </div>
+        <p v-if="form.errors.roleIds" class="mt-2 text-sm text-red-600 dark:text-red-400">
+          {{ form.errors.roleIds }}
+        </p>
+      </AdminCard>
 
-              <!-- Email -->
-              <div>
-                <label
-                  for="email"
-                  class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-2"
-                >
-                  Email
-                </label>
-                <input
-                  id="email"
-                  v-model="form.email"
-                  type="email"
-                  class="w-full px-4 py-2 border border-verse-300 dark:border-verse-600 squircle rounded-lg bg-white dark:bg-verse-800 text-verse-900 dark:text-verse-100 focus:ring-2 focus:ring-verse-500 focus:border-transparent"
-                />
-                <p v-if="form.errors.email" class="mt-1 text-sm text-red-500">
-                  {{ form.errors.email }}
-                </p>
-              </div>
-
-              <!-- GitHub Username -->
-              <div>
-                <label
-                  for="githubUsername"
-                  class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-2"
-                >
-                  GitHub Username
-                </label>
-                <div class="flex">
-                  <span
-                    class="inline-flex items-center px-3 border border-r-0 border-verse-300 dark:border-verse-600 rounded-l-lg bg-verse-50 dark:bg-verse-700 text-verse-500 dark:text-verse-400"
-                  >
-                    @
-                  </span>
-                  <input
-                    id="githubUsername"
-                    v-model="form.githubUsername"
-                    type="text"
-                    class="flex-1 px-4 py-2 border border-verse-300 dark:border-verse-600 rounded-r-lg bg-white dark:bg-verse-800 text-verse-900 dark:text-verse-100 focus:ring-2 focus:ring-verse-500 focus:border-transparent"
-                  />
-                </div>
-                <p class="mt-1 text-xs text-verse-500 dark:text-verse-400">
-                  Used to fetch avatar from GitHub
-                </p>
-              </div>
-
-              <!-- Title -->
-              <div>
-                <label
-                  for="title"
-                  class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-2"
-                >
-                  Title
-                </label>
-                <input
-                  id="title"
-                  v-model="form.title"
-                  type="text"
-                  placeholder="e.g. Lead Organiser, Co-Organiser, Software Engineer"
-                  class="w-full px-4 py-2 border border-verse-300 dark:border-verse-600 squircle rounded-lg bg-white dark:bg-verse-800 text-verse-900 dark:text-verse-100 focus:ring-2 focus:ring-verse-500 focus:border-transparent"
-                />
-                <p class="mt-1 text-xs text-verse-500 dark:text-verse-400">
-                  Displayed on the team page under the user's name
-                </p>
-              </div>
-
-              <!-- Bio -->
-              <div>
-                <label
-                  for="bio"
-                  class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-2"
-                >
-                  Bio
-                </label>
-                <textarea
-                  id="bio"
-                  v-model="form.bio"
-                  rows="3"
-                  class="w-full px-4 py-2 border border-verse-300 dark:border-verse-600 squircle rounded-lg bg-white dark:bg-verse-800 text-verse-900 dark:text-verse-100 focus:ring-2 focus:ring-verse-500 focus:border-transparent"
-                />
-              </div>
+      <AdminCard
+        title="Effective permissions"
+        :description="`${effectivePermissions.length} permission${effectivePermissions.length === 1 ? '' : 's'} based on the selected roles.`"
+      >
+        <div v-if="effectivePermissions.length > 0" class="space-y-3">
+          <div v-for="(perms, category) in groupedPermissions" :key="category">
+            <p class="text-[11px] font-mono uppercase tracking-wide text-verse-500 dark:text-verse-400 mb-1.5">
+              {{ category }}
+            </p>
+            <div class="flex flex-wrap gap-1">
+              <span
+                v-for="perm in perms"
+                :key="perm"
+                class="px-2 py-0.5 text-xs font-mono bg-emerald-100 dark:bg-emerald-900/30 text-emerald-800 dark:text-emerald-200 rounded"
+              >
+                {{ perm }}
+              </span>
             </div>
           </div>
+        </div>
+        <p v-else class="text-sm text-verse-500 dark:text-verse-400 italic">
+          No permissions. Select at least one role.
+        </p>
+      </AdminCard>
 
-          <!-- Roles Section -->
+      <AdminCard title="Social links">
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <AdminInput v-model="form.linkedinUrl" label="LinkedIn" type="url" placeholder="https://linkedin.com/in/…" />
+          <AdminInput v-model="form.twitterUrl" label="Twitter" type="url" placeholder="https://twitter.com/…" />
+          <AdminInput v-model="form.websiteUrl" label="Website" type="url" placeholder="https://…" />
+        </div>
+      </AdminCard>
+
+      <AdminCard title="Display flags" description="Where this person appears on the public site.">
+        <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
+          <AdminCheckbox
+            v-model="form.featured"
+            label="Featured"
+            description="Shown prominently on the speakers page."
+          />
+          <AdminCheckbox
+            v-model="form.isOrganizer"
+            label="Organizer"
+            description="Listed as an organizer on the team page."
+          />
+          <AdminCheckbox
+            v-model="form.isCommunityMember"
+            label="Community member"
+            description="Listed as a community member on the team page."
+          />
+        </div>
+      </AdminCard>
+
+      <AdminCard
+        v-if="user.sessions.length"
+        :title="`Sessions (${user.sessions.length})`"
+        description="Read-only — manage assignments from the event edit page."
+      >
+        <div class="space-y-2">
           <div
-            class="bg-white dark:bg-verse-800 squircle rounded-lg border border-verse-200 dark:border-verse-700 p-6"
+            v-for="session in user.sessions"
+            :key="session.id"
+            class="flex items-center justify-between gap-3 px-3.5 py-2.5 rounded-lg bg-verse-50 dark:bg-verse-900/40 border border-verse-200 dark:border-verse-800"
           >
-            <h2 class="text-lg font-semibold text-verse-900 dark:text-verse-100 mb-2">
-              Roles & Permissions
-            </h2>
-            <p class="text-sm text-verse-600 dark:text-verse-400 mb-4">
-              Assign one or more roles to this user. Permissions are derived from the selected
-              roles.
-            </p>
-
-            <div class="space-y-3">
-              <div
-                v-for="role in allRoles"
-                :key="role.id"
-                :class="[
-                  'border squircle rounded-lg overflow-hidden transition-all',
-                  isRoleSelected(role.id)
-                    ? 'border-verse-500 bg-verse-50 dark:bg-verse-700/50'
-                    : 'border-verse-200 dark:border-verse-700',
-                ]"
-              >
-                <!-- Role Header -->
-                <div
-                  class="flex items-center gap-3 p-4 cursor-pointer"
-                  @click="toggleRole(role.id)"
-                >
-                  <input
-                    type="checkbox"
-                    :checked="isRoleSelected(role.id)"
-                    :disabled="
-                      isEditingSelf && role.name === 'superadmin' && isRoleSelected(role.id)
-                    "
-                    class="h-5 w-5 text-verse-600 focus:ring-verse-500 border-verse-300 rounded"
-                    @click.stop="toggleRole(role.id)"
-                  />
-                  <div class="flex-1">
-                    <div class="flex items-center gap-2">
-                      <span
-                        :class="[
-                          'px-2 py-0.5 text-xs font-semibold rounded-full',
-                          getRoleBadgeClass(role.name),
-                        ]"
-                      >
-                        {{ role.name }}
-                      </span>
-                      <span class="text-sm text-verse-600 dark:text-verse-400">
-                        {{ role.description }}
-                      </span>
-                    </div>
-                  </div>
-                  <button
-                    type="button"
-                    class="p-1 text-verse-400 hover:text-verse-600 dark:hover:text-verse-200"
-                    @click.stop="toggleExpandRole(role.id)"
-                  >
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      :class="[
-                        'h-5 w-5 transition-transform',
-                        expandedRole === role.id ? 'rotate-180' : '',
-                      ]"
-                      viewBox="0 0 20 20"
-                      fill="currentColor"
-                    >
-                      <path
-                        fill-rule="evenodd"
-                        d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
-                        clip-rule="evenodd"
-                      />
-                    </svg>
-                  </button>
-                </div>
-
-                <!-- Role Permissions (Expandable) -->
-                <div
-                  v-if="expandedRole === role.id"
-                  class="border-t border-verse-200 dark:border-verse-600 bg-verse-50 dark:bg-verse-800 p-4"
-                >
-                  <p class="text-xs font-medium text-verse-500 dark:text-verse-400 mb-2">
-                    Permissions included in this role:
-                  </p>
-                  <div class="flex flex-wrap gap-1">
-                    <span
-                      v-for="perm in role.permissions"
-                      :key="perm.id"
-                      class="px-2 py-0.5 text-xs bg-verse-200 dark:bg-verse-600 text-verse-700 dark:text-verse-300 rounded"
-                    >
-                      {{ perm.name }}
-                    </span>
-                    <span
-                      v-if="role.permissions.length === 0"
-                      class="text-xs text-verse-400 italic"
-                    >
-                      No permissions
-                    </span>
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            <!-- Warning for self-edit -->
-            <div
-              v-if="isTryingToRemoveSuperadmin"
-              class="mt-4 p-3 bg-amber-50 dark:bg-amber-900/30 border border-amber-200 dark:border-amber-800 squircle rounded-lg"
-            >
-              <p class="text-sm text-amber-800 dark:text-amber-200">
-                You cannot remove the superadmin role from yourself.
+            <div class="min-w-0">
+              <p class="font-medium text-verse-900 dark:text-verse-100 truncate">{{ session.title }}</p>
+              <p v-if="session.eventTitle" class="text-xs text-verse-500 dark:text-verse-400 truncate">
+                {{ session.eventTitle }}
+                <span v-if="session.eventDate"> · {{ session.eventDate }}</span>
               </p>
             </div>
-
-            <p v-if="form.errors.roleIds" class="mt-2 text-sm text-red-500">
-              {{ form.errors.roleIds }}
-            </p>
-          </div>
-
-          <!-- Effective Permissions Preview -->
-          <div
-            class="bg-verse-50 dark:bg-verse-900 squircle rounded-lg border border-verse-200 dark:border-verse-700 p-6"
-          >
-            <h3 class="text-sm font-semibold text-verse-700 dark:text-verse-300 mb-3">
-              Effective Permissions ({{ effectivePermissions.length }})
-            </h3>
-            <div v-if="effectivePermissions.length > 0" class="space-y-3">
-              <div v-for="(perms, category) in groupedPermissions" :key="category">
-                <p class="text-xs font-medium text-verse-500 dark:text-verse-400 mb-1">
-                  {{ category }}
-                </p>
-                <div class="flex flex-wrap gap-1">
-                  <span
-                    v-for="perm in perms"
-                    :key="perm"
-                    class="px-2 py-0.5 text-xs bg-green-100 dark:bg-green-900 text-green-800 dark:text-green-200 rounded"
-                  >
-                    {{ perm }}
-                  </span>
-                </div>
-              </div>
-            </div>
-            <p v-else class="text-sm text-verse-500 dark:text-verse-400 italic">
-              No permissions. Select at least one role.
-            </p>
-          </div>
-
-          <!-- Social Links -->
-          <div
-            class="bg-white dark:bg-verse-800 squircle rounded-lg border border-verse-200 dark:border-verse-700 p-6"
-          >
-            <h2 class="text-lg font-semibold text-verse-900 dark:text-verse-100 mb-4">
-              Social Links
-            </h2>
-            <div class="grid md:grid-cols-3 gap-4">
-              <div>
-                <label
-                  for="linkedinUrl"
-                  class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-2"
-                >
-                  LinkedIn
-                </label>
-                <input
-                  id="linkedinUrl"
-                  v-model="form.linkedinUrl"
-                  type="url"
-                  placeholder="https://linkedin.com/in/..."
-                  class="w-full px-4 py-2 border border-verse-300 dark:border-verse-600 squircle rounded-lg bg-white dark:bg-verse-800 text-verse-900 dark:text-verse-100 focus:ring-2 focus:ring-verse-500 focus:border-transparent"
-                />
-              </div>
-              <div>
-                <label
-                  for="twitterUrl"
-                  class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-2"
-                >
-                  Twitter
-                </label>
-                <input
-                  id="twitterUrl"
-                  v-model="form.twitterUrl"
-                  type="url"
-                  placeholder="https://twitter.com/..."
-                  class="w-full px-4 py-2 border border-verse-300 dark:border-verse-600 squircle rounded-lg bg-white dark:bg-verse-800 text-verse-900 dark:text-verse-100 focus:ring-2 focus:ring-verse-500 focus:border-transparent"
-                />
-              </div>
-              <div>
-                <label
-                  for="websiteUrl"
-                  class="block text-sm font-medium text-verse-700 dark:text-verse-300 mb-2"
-                >
-                  Website
-                </label>
-                <input
-                  id="websiteUrl"
-                  v-model="form.websiteUrl"
-                  type="url"
-                  placeholder="https://..."
-                  class="w-full px-4 py-2 border border-verse-300 dark:border-verse-600 squircle rounded-lg bg-white dark:bg-verse-800 text-verse-900 dark:text-verse-100 focus:ring-2 focus:ring-verse-500 focus:border-transparent"
-                />
-              </div>
-            </div>
-          </div>
-
-          <!-- Flags -->
-          <div
-            class="bg-white dark:bg-verse-800 squircle rounded-lg border border-verse-200 dark:border-verse-700 p-6"
-          >
-            <h2 class="text-lg font-semibold text-verse-900 dark:text-verse-100 mb-4">
-              Display Flags
-            </h2>
-            <div class="space-y-3">
-              <div class="flex items-center gap-3">
-                <input
-                  id="featured"
-                  v-model="form.featured"
-                  type="checkbox"
-                  class="h-4 w-4 text-verse-600 focus:ring-verse-500 border-verse-300 rounded"
-                />
-                <label for="featured" class="text-sm text-verse-700 dark:text-verse-300">
-                  Featured (shown prominently on speakers page)
-                </label>
-              </div>
-              <div class="flex items-center gap-3">
-                <input
-                  id="isOrganizer"
-                  v-model="form.isOrganizer"
-                  type="checkbox"
-                  class="h-4 w-4 text-verse-600 focus:ring-verse-500 border-verse-300 rounded"
-                />
-                <label for="isOrganizer" class="text-sm text-verse-700 dark:text-verse-300">
-                  Show as organizer on team page
-                </label>
-              </div>
-              <div class="flex items-center gap-3">
-                <input
-                  id="isCommunityMember"
-                  v-model="form.isCommunityMember"
-                  type="checkbox"
-                  class="h-4 w-4 text-verse-600 focus:ring-verse-500 border-verse-300 rounded"
-                />
-                <label for="isCommunityMember" class="text-sm text-verse-700 dark:text-verse-300">
-                  Show as community member
-                </label>
-              </div>
-            </div>
-          </div>
-
-          <!-- Sessions (read-only) -->
-          <div
-            v-if="user.sessions.length"
-            class="bg-white dark:bg-verse-800 squircle rounded-lg border border-verse-200 dark:border-verse-700 p-6"
-          >
-            <h2 class="text-lg font-semibold text-verse-900 dark:text-verse-100 mb-4">
-              Sessions ({{ user.sessions.length }})
-            </h2>
-            <div class="space-y-2">
-              <div
-                v-for="session in user.sessions"
-                :key="session.id"
-                class="flex items-center justify-between p-3 bg-verse-50 dark:bg-verse-900/50 squircle rounded-lg"
-              >
-                <div>
-                  <p class="font-medium text-verse-900 dark:text-verse-100">{{ session.title }}</p>
-                  <p v-if="session.eventTitle" class="text-sm text-verse-500 dark:text-verse-400">
-                    {{ session.eventTitle }}
-                    <span v-if="session.eventDate"> — {{ session.eventDate }}</span>
-                  </p>
-                </div>
-                <Link
-                  v-if="session.eventId"
-                  :href="`/admin/events/${session.eventId}/edit`"
-                  class="text-xs text-verse-500 hover:text-verse-700 dark:text-verse-400 dark:hover:text-verse-200 transition-colors"
-                >
-                  View event
-                </Link>
-              </div>
-            </div>
-          </div>
-
-          <!-- RSVPs (read-only) -->
-          <div
-            v-if="user.rsvps.length"
-            class="bg-white dark:bg-verse-800 squircle rounded-lg border border-verse-200 dark:border-verse-700 p-6"
-          >
-            <h2 class="text-lg font-semibold text-verse-900 dark:text-verse-100 mb-4">
-              RSVPs ({{ user.rsvps.length }})
-            </h2>
-            <div class="space-y-2">
-              <div
-                v-for="rsvp in user.rsvps"
-                :key="rsvp.id"
-                class="flex items-center justify-between p-3 bg-verse-50 dark:bg-verse-900/50 squircle rounded-lg"
-              >
-                <div class="min-w-0">
-                  <p class="font-medium text-verse-900 dark:text-verse-100 truncate">
-                    {{ rsvp.eventTitle }}
-                  </p>
-                  <p v-if="rsvp.eventDate" class="text-sm text-verse-500 dark:text-verse-400">
-                    {{ rsvp.eventDate }}
-                  </p>
-                </div>
-                <div class="flex items-center gap-3 ml-3 shrink-0">
-                  <span
-                    :class="[
-                      'px-2 py-0.5 text-xs font-medium rounded-full',
-                      rsvp.status === 'confirmed'
-                        ? 'bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-400'
-                        : rsvp.status === 'waitlist'
-                          ? 'bg-yellow-100 dark:bg-yellow-900/30 text-yellow-700 dark:text-yellow-400'
-                          : 'bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-400',
-                    ]"
-                  >
-                    {{ rsvp.status }}
-                  </span>
-                  <Link
-                    :href="`/admin/events/${rsvp.eventId}/edit`"
-                    class="text-xs text-verse-500 hover:text-verse-700 dark:text-verse-400 dark:hover:text-verse-200 transition-colors"
-                  >
-                    View event
-                  </Link>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <!-- Submit -->
-          <div class="flex justify-end gap-4 pt-4">
             <Link
-              href="/admin/users"
-              class="px-6 py-2 text-verse-700 dark:text-verse-300 hover:bg-verse-100 dark:hover:bg-verse-700 squircle rounded-lg transition-colors"
+              v-if="session.eventId"
+              :href="`/admin/events/${session.eventId}/edit`"
+              class="text-xs font-medium text-verse-700 dark:text-verse-300 hover:text-verse-900 dark:hover:text-white whitespace-nowrap"
             >
-              Cancel
+              View event →
             </Link>
-            <button
-              type="submit"
-              :disabled="form.processing || isTryingToRemoveSuperadmin || form.roleIds.length === 0"
-              class="px-6 py-2 bg-verse-600 hover:bg-verse-700 text-white font-medium squircle rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              <span v-if="form.processing">Saving...</span>
-              <span v-else>Save Changes</span>
-            </button>
           </div>
-        </form>
+        </div>
+      </AdminCard>
+
+      <AdminCard
+        v-if="user.rsvps.length"
+        :title="`RSVPs (${user.rsvps.length})`"
+        description="History of events this user has signed up for."
+      >
+        <div class="space-y-2">
+          <div
+            v-for="rsvp in user.rsvps"
+            :key="rsvp.id"
+            class="flex items-center justify-between gap-3 px-3.5 py-2.5 rounded-lg bg-verse-50 dark:bg-verse-900/40 border border-verse-200 dark:border-verse-800"
+          >
+            <div class="min-w-0">
+              <p class="font-medium text-verse-900 dark:text-verse-100 truncate">{{ rsvp.eventTitle }}</p>
+              <p v-if="rsvp.eventDate" class="text-xs text-verse-500 dark:text-verse-400">
+                {{ rsvp.eventDate }}
+              </p>
+            </div>
+            <div class="flex items-center gap-3 shrink-0">
+              <AdminBadge
+                :tone="
+                  rsvp.status === 'confirmed'
+                    ? 'success'
+                    : rsvp.status === 'waitlist'
+                      ? 'warning'
+                      : 'danger'
+                "
+                dot
+              >
+                {{ rsvp.status }}
+              </AdminBadge>
+              <Link
+                :href="`/admin/events/${rsvp.eventId}/edit`"
+                class="text-xs font-medium text-verse-700 dark:text-verse-300 hover:text-verse-900 dark:hover:text-white whitespace-nowrap"
+              >
+                View →
+              </Link>
+            </div>
+          </div>
+        </div>
+      </AdminCard>
+
+      <div class="sticky bottom-3 z-10 flex justify-end gap-2 bg-white/85 dark:bg-verse-950/85 backdrop-blur-md p-3 rounded-xl border border-verse-200 dark:border-verse-800">
+        <AdminButton href="/admin/users" variant="secondary">Cancel</AdminButton>
+        <AdminButton
+          type="submit"
+          variant="primary"
+          :loading="form.processing"
+          :disabled="isTryingToRemoveSuperadmin || form.roleIds.length === 0"
+        >
+          {{ form.processing ? 'Saving…' : 'Save changes' }}
+        </AdminButton>
       </div>
-    </ContentBlock>
-  </main>
+    </form>
+  </AdminShell>
 </template>

--- a/packages/frontendmu-adonis/inertia/pages/admin/users/edit.vue
+++ b/packages/frontendmu-adonis/inertia/pages/admin/users/edit.vue
@@ -232,7 +232,7 @@ function roleTone(name: string) {
               v-if="expandedRole === role.id"
               class="px-3.5 pb-3.5 pt-1 border-t border-verse-200 dark:border-verse-800"
             >
-              <p class="text-[11px] font-mono uppercase tracking-wide text-verse-500 dark:text-verse-400 mb-2">
+              <p class="text-[11px] font-mono uppercase tracking-wide text-verse-500 dark:text-verse-300 mb-2">
                 Permissions in this role
               </p>
               <div class="flex flex-wrap gap-1">
@@ -270,7 +270,7 @@ function roleTone(name: string) {
       >
         <div v-if="effectivePermissions.length > 0" class="space-y-3">
           <div v-for="(perms, category) in groupedPermissions" :key="category">
-            <p class="text-[11px] font-mono uppercase tracking-wide text-verse-500 dark:text-verse-400 mb-1.5">
+            <p class="text-[11px] font-mono uppercase tracking-wide text-verse-500 dark:text-verse-300 mb-1.5">
               {{ category }}
             </p>
             <div class="flex flex-wrap gap-1">
@@ -284,7 +284,7 @@ function roleTone(name: string) {
             </div>
           </div>
         </div>
-        <p v-else class="text-sm text-verse-500 dark:text-verse-400 italic">
+        <p v-else class="text-sm text-verse-500 dark:text-verse-300 italic">
           No permissions. Select at least one role.
         </p>
       </AdminCard>
@@ -330,7 +330,7 @@ function roleTone(name: string) {
           >
             <div class="min-w-0">
               <p class="font-medium text-verse-900 dark:text-verse-100 truncate">{{ session.title }}</p>
-              <p v-if="session.eventTitle" class="text-xs text-verse-500 dark:text-verse-400 truncate">
+              <p v-if="session.eventTitle" class="text-xs text-verse-500 dark:text-verse-300 truncate">
                 {{ session.eventTitle }}
                 <span v-if="session.eventDate"> · {{ session.eventDate }}</span>
               </p>
@@ -359,7 +359,7 @@ function roleTone(name: string) {
           >
             <div class="min-w-0">
               <p class="font-medium text-verse-900 dark:text-verse-100 truncate">{{ rsvp.eventTitle }}</p>
-              <p v-if="rsvp.eventDate" class="text-xs text-verse-500 dark:text-verse-400">
+              <p v-if="rsvp.eventDate" class="text-xs text-verse-500 dark:text-verse-300">
                 {{ rsvp.eventDate }}
               </p>
             </div>

--- a/packages/frontendmu-adonis/inertia/pages/admin/users/index.vue
+++ b/packages/frontendmu-adonis/inertia/pages/admin/users/index.vue
@@ -138,7 +138,7 @@ function doDelete() {
                 </div>
                 <p
                   v-if="user.githubUsername"
-                  class="text-xs text-verse-500 dark:text-verse-400 truncate"
+                  class="text-xs text-verse-500 dark:text-verse-300 truncate"
                 >
                   @{{ user.githubUsername }}
                 </p>
@@ -165,7 +165,7 @@ function doDelete() {
               </span>
             </div>
           </td>
-          <td class="px-5 py-3.5 text-sm text-verse-600 dark:text-verse-400 whitespace-nowrap">
+          <td class="px-5 py-3.5 text-sm text-verse-600 dark:text-verse-300 whitespace-nowrap">
             {{ formatEventDate(user.createdAt) }}
           </td>
           <td class="px-5 py-3.5">

--- a/packages/frontendmu-adonis/inertia/pages/admin/users/index.vue
+++ b/packages/frontendmu-adonis/inertia/pages/admin/users/index.vue
@@ -1,13 +1,19 @@
 <script setup lang="ts">
-import { ref, computed } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { Head, router } from '@inertiajs/vue3'
-import { Link } from '@inertiajs/vue3'
 import type { Data } from '@generated/data'
-import ContentBlock from '~/components/shared/ContentBlock.vue'
-import BaseHeading from '~/components/base/BaseHeading.vue'
+import AdminShell from '~/components/admin/ui/AdminShell.vue'
+import AdminCard from '~/components/admin/ui/AdminCard.vue'
+import AdminButton from '~/components/admin/ui/AdminButton.vue'
+import AdminBadge from '~/components/admin/ui/AdminBadge.vue'
+import AdminAvatar from '~/components/admin/ui/AdminAvatar.vue'
+import AdminTable from '~/components/admin/ui/AdminTable.vue'
+import AdminFilterChips from '~/components/admin/ui/AdminFilterChips.vue'
+import AdminSearchInput from '~/components/admin/ui/AdminSearchInput.vue'
+import AdminEmptyState from '~/components/admin/ui/AdminEmptyState.vue'
+import AdminConfirmModal from '~/components/admin/ui/AdminConfirmModal.vue'
 import { useAuth } from '~/composables/use_auth'
 import { useDeleteConfirmation } from '~/composables/use_delete_confirmation'
-import { getRoleBadgeClass } from '~/utils/roles'
 import { formatEventDate } from '~/utils/date'
 
 interface Props {
@@ -29,338 +35,209 @@ const {
   executeDelete,
 } = useDeleteConfirmation<Data.AdminUser.Variants['forAdminIndex']>()
 
-// Search input
 const searchInput = ref(props.search)
 
-// Get the primary role (first role or highest priority)
-function getPrimaryRole(user: Data.AdminUser.Variants['forAdminIndex']): string {
-  if (!user.roles || user.roles.length === 0) return 'viewer'
-  // Priority order
-  const priority = ['superadmin', 'organizer', 'member', 'viewer']
-  for (const p of priority) {
-    if (user.roles.some((r) => r.name === p)) return p
+let debounceTimer: ReturnType<typeof setTimeout> | null = null
+watch(searchInput, (value) => {
+  if (debounceTimer) clearTimeout(debounceTimer)
+  debounceTimer = setTimeout(() => {
+    router.get(
+      '/admin/users',
+      { role: props.roleFilter, search: value },
+      { preserveState: true, replace: true }
+    )
+  }, 300)
+})
+
+const currentRole = computed({
+  get: () => props.roleFilter,
+  set: (value) =>
+    router.get(
+      '/admin/users',
+      { role: value, search: searchInput.value },
+      { preserveState: true, replace: true }
+    ),
+})
+
+const filterChips = computed(() => {
+  const all = [{ key: 'all', label: 'All', count: props.counts.all || 0 }]
+  for (const role of props.allRoles) {
+    all.push({
+      key: role.name,
+      label: role.name.charAt(0).toUpperCase() + role.name.slice(1),
+      count: props.counts[role.name] || 0,
+    })
   }
-  return user.roles[0]?.name || 'viewer'
-}
+  return all
+})
 
-// Filter by role
-function filterByRole(role: string) {
-  router.get('/admin/users', { role, search: searchInput.value }, { preserveState: true })
-}
-
-// Search
-function handleSearch() {
-  router.get(
-    '/admin/users',
-    { role: props.roleFilter, search: searchInput.value },
-    { preserveState: true }
-  )
-}
-
-function handleDelete(user: Data.AdminUser.Variants['forAdminIndex']) {
-  confirmDelete(user)
-}
-
-function doDelete() {
-  if (!userToDelete.value) return
-  executeDelete(`/admin/users/${userToDelete.value.id}`)
+function roleTone(name: string) {
+  switch (name) {
+    case 'superadmin':
+      return 'danger'
+    case 'organizer':
+      return 'accent'
+    case 'member':
+      return 'info'
+    case 'viewer':
+      return 'muted'
+    default:
+      return 'neutral'
+  }
 }
 
 function canDeleteUser(user: Data.AdminUser.Variants['forAdminIndex']) {
   return user.id !== currentUser.value?.id
 }
 
-// Available role filters
-const roleFilters = computed(() => {
-  const filters = [{ name: 'all', label: 'All', count: props.counts.all || 0 }]
-  if (props.allRoles) {
-    for (const role of props.allRoles) {
-      filters.push({
-        name: role.name,
-        label: role.name.charAt(0).toUpperCase() + role.name.slice(1),
-        count: props.counts[role.name] || 0,
-      })
-    }
-  }
-  return filters
-})
-
-// Get filter button class
-function getFilterButtonClass(roleName: string, isActive: boolean) {
-  if (isActive) {
-    switch (roleName) {
-      case 'superadmin':
-        return 'bg-red-600 text-white'
-      case 'organizer':
-        return 'bg-purple-600 text-white'
-      case 'member':
-        return 'bg-blue-600 text-white'
-      case 'viewer':
-        return 'bg-gray-600 text-white'
-      default:
-        return 'bg-verse-600 text-white'
-    }
-  }
-  switch (roleName) {
-    case 'superadmin':
-      return 'bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-300 hover:bg-red-200 dark:hover:bg-red-900/50'
-    case 'organizer':
-      return 'bg-purple-100 dark:bg-purple-900/30 text-purple-700 dark:text-purple-300 hover:bg-purple-200 dark:hover:bg-purple-900/50'
-    case 'member':
-      return 'bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 hover:bg-blue-200 dark:hover:bg-blue-900/50'
-    case 'viewer':
-      return 'bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700'
-    default:
-      return 'bg-verse-100 dark:bg-verse-800 text-verse-700 dark:text-verse-300 hover:bg-verse-200 dark:hover:bg-verse-700'
-  }
+function doDelete() {
+  if (!userToDelete.value) return
+  executeDelete(`/admin/users/${userToDelete.value.id}`)
 }
 </script>
 
 <template>
-  <Head title="Manage Users" />
-  <main class="relative min-h-screen pt-40 pb-20">
-    <ContentBlock>
-      <!-- Header -->
-      <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-8">
-        <div>
-          <BaseHeading :level="1">Manage Users</BaseHeading>
-          <p class="text-verse-600 dark:text-verse-400 mt-2">
-            View and manage user accounts and roles.
-          </p>
-        </div>
-      </div>
-
-      <!-- Search -->
-      <div class="mb-6">
-        <form @submit.prevent="handleSearch" class="flex gap-2">
-          <input
-            v-model="searchInput"
-            type="text"
-            placeholder="Search by name, email, or GitHub username..."
-            class="flex-1 px-4 py-2 border border-verse-300 dark:border-verse-600 squircle rounded-lg bg-white dark:bg-verse-800 text-verse-900 dark:text-verse-100 focus:ring-2 focus:ring-verse-500 focus:border-transparent"
-          />
-          <button
-            type="submit"
-            class="px-4 py-2 bg-verse-600 hover:bg-verse-700 text-white font-medium squircle rounded-lg transition-colors"
-          >
-            Search
-          </button>
-        </form>
-      </div>
-
-      <!-- Filters -->
-      <div class="flex flex-wrap gap-2 mb-6">
-        <button
-          v-for="filter in roleFilters"
-          :key="filter.name"
-          @click="filterByRole(filter.name)"
-          :class="[
-            'px-4 py-2 squircle rounded-lg text-sm font-medium transition-colors',
-            getFilterButtonClass(filter.name, roleFilter === filter.name),
-          ]"
-        >
-          {{ filter.label }} ({{ filter.count }})
-        </button>
-      </div>
-
-      <!-- Users Table -->
-      <div
-        class="bg-white dark:bg-verse-800/50 squircle rounded-xl border border-verse-200 dark:border-verse-700 overflow-hidden"
-      >
-        <div class="overflow-x-auto">
-          <table class="w-full">
-            <thead
-              class="bg-verse-50 dark:bg-verse-800 border-b border-verse-200 dark:border-verse-700"
-            >
-              <tr>
-                <th
-                  class="px-6 py-3 text-left text-xs font-semibold text-verse-600 dark:text-verse-400 uppercase tracking-wider"
-                >
-                  User
-                </th>
-                <th
-                  class="px-6 py-3 text-left text-xs font-semibold text-verse-600 dark:text-verse-400 uppercase tracking-wider"
-                >
-                  Email
-                </th>
-                <th
-                  class="px-6 py-3 text-left text-xs font-semibold text-verse-600 dark:text-verse-400 uppercase tracking-wider"
-                >
-                  Roles
-                </th>
-                <th
-                  class="px-6 py-3 text-left text-xs font-semibold text-verse-600 dark:text-verse-400 uppercase tracking-wider"
-                >
-                  Joined
-                </th>
-                <th
-                  class="px-6 py-3 text-right text-xs font-semibold text-verse-600 dark:text-verse-400 uppercase tracking-wider"
-                >
-                  Actions
-                </th>
-              </tr>
-            </thead>
-            <tbody class="divide-y divide-verse-200 dark:divide-verse-700">
-              <tr
-                v-for="user in users"
-                :key="user.id"
-                class="hover:bg-verse-50 dark:hover:bg-verse-800/80 transition-colors"
-              >
-                <td class="px-6 py-4">
-                  <div class="flex items-center gap-3">
-                    <img
-                      v-if="user.avatarUrl"
-                      :src="user.avatarUrl"
-                      :alt="user.name"
-                      class="w-10 h-10 rounded-full object-cover"
-                    />
-                    <div
-                      v-else
-                      class="w-10 h-10 rounded-full bg-verse-200 dark:bg-verse-700 flex items-center justify-center"
-                    >
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        class="h-5 w-5 text-verse-400"
-                        viewBox="0 0 20 20"
-                        fill="currentColor"
-                      >
-                        <path
-                          fill-rule="evenodd"
-                          d="M10 9a3 3 0 100-6 3 3 0 000 6zm-7 9a7 7 0 1114 0H3z"
-                          clip-rule="evenodd"
-                        />
-                      </svg>
-                    </div>
-                    <div>
-                      <span class="font-medium text-verse-900 dark:text-verse-100">
-                        {{ user.name }}
-                      </span>
-                      <p
-                        v-if="user.githubUsername"
-                        class="text-xs text-verse-500 dark:text-verse-400"
-                      >
-                        @{{ user.githubUsername }}
-                      </p>
-                    </div>
-                    <span
-                      v-if="user.id === currentUser?.id"
-                      class="px-2 py-0.5 text-xs font-medium bg-verse-200 dark:bg-verse-700 text-verse-600 dark:text-verse-300 rounded"
-                    >
-                      You
-                    </span>
-                  </div>
-                </td>
-                <td class="px-6 py-4 text-sm text-verse-600 dark:text-verse-400">
-                  {{ user.email || '-' }}
-                </td>
-                <td class="px-6 py-4">
-                  <div class="flex flex-wrap gap-1">
-                    <span
-                      v-for="role in user.roles"
-                      :key="role.id"
-                      :class="[
-                        'px-2 py-0.5 rounded-full text-xs font-medium',
-                        getRoleBadgeClass(role.name),
-                      ]"
-                    >
-                      {{ role.name }}
-                    </span>
-                    <span
-                      v-if="!user.roles || user.roles.length === 0"
-                      class="text-xs text-verse-400 italic"
-                    >
-                      No roles
-                    </span>
-                  </div>
-                </td>
-                <td class="px-6 py-4 text-sm text-verse-600 dark:text-verse-400">
-                  {{ formatEventDate(user.createdAt) }}
-                </td>
-                <td class="px-6 py-4 text-right">
-                  <div class="flex items-center justify-end gap-2">
-                    <Link
-                      :href="`/admin/users/${user.id}/edit`"
-                      class="p-2 text-verse-500 hover:text-verse-700 dark:text-verse-400 dark:hover:text-verse-200 transition-colors"
-                      title="Edit"
-                    >
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        class="h-5 w-5"
-                        viewBox="0 0 20 20"
-                        fill="currentColor"
-                      >
-                        <path
-                          d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z"
-                        />
-                      </svg>
-                    </Link>
-                    <button
-                      v-if="canDeleteUser(user)"
-                      @click="handleDelete(user)"
-                      class="p-2 text-red-500 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300 transition-colors"
-                      title="Delete"
-                    >
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        class="h-5 w-5"
-                        viewBox="0 0 20 20"
-                        fill="currentColor"
-                      >
-                        <path
-                          fill-rule="evenodd"
-                          d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z"
-                          clip-rule="evenodd"
-                        />
-                      </svg>
-                    </button>
-                  </div>
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-
-        <!-- Empty state -->
-        <div v-if="!users.length" class="px-6 py-12 text-center">
-          <p class="text-verse-500 dark:text-verse-400">
-            No users found<span v-if="roleFilter !== 'all'"> with role "{{ roleFilter }}"</span
-            ><span v-if="search"> matching "{{ search }}"</span>.
-          </p>
-        </div>
-      </div>
-    </ContentBlock>
-  </main>
-
-  <!-- Delete Confirmation Modal -->
-  <Teleport to="body">
-    <div v-if="showDeleteModal" class="fixed inset-0 z-50 flex items-center justify-center p-4">
-      <div class="absolute inset-0 bg-black/50" @click="cancelDelete" />
-      <div
-        class="relative bg-white dark:bg-verse-800 squircle rounded-xl shadow-xl max-w-md w-full p-6"
-      >
-        <h3 class="text-lg font-semibold text-verse-900 dark:text-verse-100 mb-2">Delete User</h3>
-        <p class="text-verse-600 dark:text-verse-400 mb-4">
-          Are you sure you want to delete "<strong>{{ userToDelete?.name }}</strong
-          >"? This action cannot be undone.
-        </p>
-        <div class="flex justify-end gap-3">
-          <button
-            @click="cancelDelete"
-            :disabled="isDeleting"
-            class="px-4 py-2 text-sm font-medium text-verse-700 dark:text-verse-300 bg-verse-100 dark:bg-verse-700 hover:bg-verse-200 dark:hover:bg-verse-600 squircle rounded-lg transition-colors disabled:opacity-50"
-          >
-            Cancel
-          </button>
-          <button
-            @click="doDelete"
-            :disabled="isDeleting"
-            class="px-4 py-2 text-sm font-medium text-white bg-red-600 hover:bg-red-700 squircle rounded-lg transition-colors disabled:opacity-50"
-          >
-            <span v-if="isDeleting">Deleting...</span>
-            <span v-else>Delete</span>
-          </button>
-        </div>
+  <Head title="Users · Admin" />
+  <AdminShell title="Users" description="Manage accounts, roles and permissions for the community.">
+    <div class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between mb-5">
+      <AdminFilterChips
+        v-model="currentRole"
+        :chips="filterChips"
+        aria-label="Filter by role"
+      />
+      <div class="lg:w-80">
+        <AdminSearchInput v-model="searchInput" placeholder="Name, email or GitHub" />
       </div>
     </div>
-  </Teleport>
+
+    <AdminCard :padded="false">
+      <AdminTable
+        v-if="users.length"
+        :columns="[
+          { label: 'User' },
+          { label: 'Email' },
+          { label: 'Roles' },
+          { label: 'Joined' },
+          { label: 'Actions', align: 'right' },
+        ]"
+      >
+        <tr
+          v-for="user in users"
+          :key="user.id"
+          class="hover:bg-verse-50/50 dark:hover:bg-verse-800/40 transition-colors"
+        >
+          <td class="px-5 py-3.5">
+            <div class="flex items-center gap-3 min-w-0">
+              <AdminAvatar :src="user.avatarUrl" :name="user.name" size="md" />
+              <div class="min-w-0">
+                <div class="flex items-center gap-2 flex-wrap">
+                  <span class="font-medium text-verse-900 dark:text-verse-50 truncate">
+                    {{ user.name }}
+                  </span>
+                  <AdminBadge v-if="user.id === currentUser?.id" tone="muted">You</AdminBadge>
+                </div>
+                <p
+                  v-if="user.githubUsername"
+                  class="text-xs text-verse-500 dark:text-verse-400 truncate"
+                >
+                  @{{ user.githubUsername }}
+                </p>
+              </div>
+            </div>
+          </td>
+          <td class="px-5 py-3.5 text-sm text-verse-700 dark:text-verse-300 truncate max-w-[260px]">
+            {{ user.email || '—' }}
+          </td>
+          <td class="px-5 py-3.5">
+            <div class="flex flex-wrap gap-1">
+              <AdminBadge
+                v-for="role in user.roles"
+                :key="role.id"
+                :tone="roleTone(role.name)"
+              >
+                {{ role.name }}
+              </AdminBadge>
+              <span
+                v-if="!user.roles?.length"
+                class="text-xs text-verse-400 dark:text-verse-500 italic"
+              >
+                No roles
+              </span>
+            </div>
+          </td>
+          <td class="px-5 py-3.5 text-sm text-verse-600 dark:text-verse-400 whitespace-nowrap">
+            {{ formatEventDate(user.createdAt) }}
+          </td>
+          <td class="px-5 py-3.5">
+            <div class="flex items-center justify-end gap-1">
+              <AdminButton
+                :href="`/admin/users/${user.id}/edit`"
+                variant="ghost"
+                size="sm"
+                icon-only
+                title="Edit user"
+              >
+                <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
+                  <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
+                </svg>
+              </AdminButton>
+              <button
+                v-if="canDeleteUser(user)"
+                type="button"
+                class="p-2 rounded-lg text-red-500 hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-900/20 dark:text-red-400 dark:hover:text-red-300 transition-colors"
+                title="Delete user"
+                aria-label="Delete user"
+                @click="confirmDelete(user)"
+              >
+                <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <polyline points="3 6 5 6 21 6" />
+                  <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+                </svg>
+              </button>
+            </div>
+          </td>
+        </tr>
+      </AdminTable>
+
+      <AdminEmptyState
+        v-else
+        title="No users match your filters"
+        :description="
+          search || roleFilter !== 'all'
+            ? 'Try a different role or clear your search.'
+            : 'No users found.'
+        "
+        icon="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2M9 11a4 4 0 1 0 0-8 4 4 0 0 0 0 8z"
+      >
+        <template #actions>
+          <AdminButton
+            v-if="search || roleFilter !== 'all'"
+            variant="secondary"
+            @click="
+              () => {
+                searchInput = ''
+                currentRole = 'all'
+              }
+            "
+          >
+            Clear filters
+          </AdminButton>
+        </template>
+      </AdminEmptyState>
+    </AdminCard>
+  </AdminShell>
+
+  <AdminConfirmModal
+    :open="showDeleteModal"
+    title="Delete user"
+    :loading="isDeleting"
+    confirm-label="Delete user"
+    @cancel="cancelDelete"
+    @confirm="doDelete"
+  >
+    Are you sure you want to delete
+    <strong class="text-verse-900 dark:text-verse-100">{{ userToDelete?.name }}</strong
+    >? This action cannot be undone.
+  </AdminConfirmModal>
 </template>


### PR DESCRIPTION
## Summary

Replaces the ad-hoc styling on every admin page with a small, coherent
design system, while preserving all existing behavior, routes and
payloads. Light/dark/responsive across the board.

### Design system

A new `inertia/components/admin/ui/*` set (shell, nav, page header,
breadcrumb, card, stat grid, badge, button, table, filter chips,
search/input/select/textarea/checkbox, avatar, empty state, confirm
modal). The shell renders a sticky left navigation on desktop and a
horizontally scrolling pill rail on mobile, so admins can move between
sections without bouncing back to the dashboard.

### Pages refactored

- **Dashboard** — stat tiles + grouped section cards with primary
  actions
- **Events list** — filter chips + count + ghost icon actions, empty
  state
- **Event create** — stacked cards (basics, where/when, RSVPs,
  visibility) with sticky save bar
- **Event edit** — same structure plus a side rail that holds the
  schedule (drag-to-reorder sessions, quick-add presets) and sponsors
  picker
- **Event attendees** — stats hero, embedded RSVP timeline chart,
  filter chips + search, attendee table
- **Speakers list** — searchable card grid
- **Speaker create** — stacked card form
- **Sponsors list** — logo + types + dot status row, filter chips
- **Sponsors create/edit** — shared `SponsorFormFields` component
- **Users list** — debounced server-side search, role chips, role
  badges
- **User edit** — stacked sections (basic info, roles & permissions
  with expandable role details, effective permissions grouped by
  domain, social, display flags, sessions, RSVPs)

### Contrast pass

WCAG-AA audit on every admin page in dark mode found `dark:text-verse-400`
on `verse-950` failed at 2.66:1 — bumped all muted text to
`dark:text-verse-300` (~7.5:1). Light mode passed across the board.

## Test plan

- [ ] Dashboard renders stats and cards
- [ ] Events list filter chips switch correctly; delete confirm modal works
- [ ] Event create + edit save successfully; sessions can be added,
      reordered and deleted; sponsors can be attached/detached
- [ ] Attendees page shows stats, timeline chart, filter chips, CSV export
- [ ] Speakers list search filters; create form submits
- [ ] Sponsors list filters; create + edit save with logo upload + bg
- [ ] Users list debounced search and role filter both work; edit
      page lets you toggle roles and shows effective permissions
- [ ] Mobile (≤640px): horizontal pill rail nav, all pages usable
- [ ] Light + dark mode have legible contrast on every page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Redesigned admin interface with improved visual consistency across all pages (dashboard, events, speakers, sponsors, users)
  * Added search functionality to speakers and users pages
  * Added filtering capabilities to events, speakers, sponsors, and users pages
  * Added delete confirmation dialogs for safer content management
  * Enhanced event management with sponsor attachment and session reordering

* **Style**
  * Updated dark-mode text styling in event timeline chart

<!-- end of auto-generated comment: release notes by coderabbit.ai -->