### PR TITLE
Fix Google Search Console indexing issues

### DIFF
--- a/packages/frontendmu-adonis/SEO_FIX_PLAN.md
+++ b/packages/frontendmu-adonis/SEO_FIX_PLAN.md
@@ -1,0 +1,433 @@
+# SEO Fix Plan — coders.mu
+
+Plan derived from the Google Search Console "Page indexing" report for `sc-domain:coders.mu` (snapshot taken 2026-05-26, GSC last update 2026-05-22).
+
+GSC currently reports **421 not-indexed pages** and **161 indexed pages**, split across the seven reasons below.
+
+| # | Reason (GSC) | Pages | Source | Severity |
+|---|---|---|---|---|
+| 1 | Server error (5xx) | 91 | Website | Misclassified — actually 404 today (high) |
+| 2 | Not found (404) | 38 | Website | High |
+| 3 | Duplicate without user-selected canonical | 33 | Website | High |
+| 4 | Page with redirect | 12 | Website | Medium |
+| 5 | Excluded by `noindex` tag | 1 | Website | Low |
+| 6 | Blocked by robots.txt | 1 | Website | Low (dead host) |
+| 7 | Crawled — currently not indexed | 245 | Google | High (root cause = thin HTML / no SSR) |
+
+The fixes are grouped by root cause, not by GSC bucket, because most buckets share the same underlying problems. The whole plan is intended to land in one PR on a single branch.
+
+---
+
+## Root-cause summary (read this first)
+
+After probing the live site (see `curl` evidence under each section):
+
+1. **No `sitemap.xml`.** `https://coders.mu/sitemap.xml` returns `Cannot GET:/sitemap.xml`. Google has nothing authoritative to crawl, so it falls back to legacy URLs it saw from the old Directus/Nuxt site.
+2. **`robots.txt` is bare.** Just `User-agent: * / Allow: /`. No `Sitemap:` line, no disallow for auth/admin paths.
+3. **Inertia SSR is disabled** (`config/inertia.ts` → `ssr: { enabled: false }`). The initial HTML response contains only `<title>frontend.mu</title>` and no `<meta name="description">`, no `<link rel="canonical">`, no Open Graph tags. Even when `.vue` pages set `<Head title="...">`, that only patches the head client-side after the JS bundle boots. This explains "Crawled — currently not indexed" (Google sees identical shell HTML for every URL).
+4. **Trailing-slash variants serve identical HTML.** `https://coders.mu/team` and `https://coders.mu/team/` both 200 with the same body. With no canonical tag, Google has no way to pick one and files them under "Duplicate without user-selected canonical".
+5. **`frontend.coders.mu` subdomain is alive at Cloudflare** and 301-redirects every path to `https://coders.mu/<same-path>`. For most of the legacy paths (numeric meetup IDs, legacy speaker UUIDs, `/code_of_conduct`, `/coding_guidelines`) the apex 404s, so Google sees `301 → 404`. This is the source of the 91 "Server error (5xx)" and 38 "Not found (404)" entries that overlap with `frontend.coders.mu/*` paths.
+6. **Legacy URL slugs don't match new routes.** The new routes are `/code-of-conduct` and `/coding-guidelines` (kebab); Google indexed `/code_of_conduct` and `/coding_guidelines` (snake). And `/meetup/<numeric-id>` (e.g., `/meetup/17`) is no longer a valid route — new format is `/meetup/<yyyy-month-slug>` or `/meetup/<uuid>`.
+7. **`/privacy` and `/terms` 404.** GSC has them in the 404 bucket — they're missing entirely.
+8. **Sensitive routes are crawlable.** `/admin/*`, `/user/me`, `/profile`, `/auth/google`, `/auth/google/callback`, `/login`, `/register`, `/redirect` are all reachable and not flagged `noindex`. They show up in GSC under various buckets.
+
+Most "Server error (5xx)" entries are **GSC reporting historical state** — every URL I re-fetched in the 5xx list now returns 404 (e.g., `coders.mu/meetup/17`, `coders.mu/user/me`, `coders.mu/admin/verify`, `coders.mu/redirect`). So once we fix the 404 picture, the 5xx number will reconcile via validation.
+
+---
+
+## Fix 1 — Add an XML sitemap
+
+**Bucket(s) targeted:** Crawled — currently not indexed (245), and indirectly all others.
+
+**Why this matters:** Without a sitemap, Google relies on whatever it saw in the past — which is largely the dead frontend.coders.mu URLs from the previous Nuxt site.
+
+**Implementation:**
+- Add `GET /sitemap.xml` to `start/routes.ts` and a `SitemapController` under `app/controllers/sitemap_controller.ts`.
+- Include in the sitemap:
+  - Static pages: `/`, `/meetups`, `/sponsors`, `/sponsor-us`, `/team`, `/about`, `/community`, `/contribute`, `/branding`, `/history`, `/code-of-conduct`, `/coding-guidelines`, `/api-docs`, `/speakers` (new — see Fix 3), `/privacy` (new — see Fix 8), `/terms` (new — see Fix 8).
+  - All `Event` rows with `status = 'published'` → `/meetup/<slug>` (use `slug`, never the numeric/UUID alternates — keep one canonical path per meetup).
+  - All speakers that have at least one published session → `/speaker/<uuid>`.
+- `lastmod` from `updatedAt`, no `priority`/`changefreq` (Google ignores them).
+- Always emit the canonical form: trailing-slash-free, lowercase, `https://coders.mu`.
+- Add `Sitemap: https://coders.mu/sitemap.xml` to `public/robots.txt`.
+
+**Verification:**
+```bash
+# Sitemap returns 200 and is valid XML
+curl -sI https://coders.mu/sitemap.xml | head -1   # → HTTP/2 200
+curl -s https://coders.mu/sitemap.xml | xmllint --noout -
+# Count URLs in the sitemap
+curl -s https://coders.mu/sitemap.xml | grep -c "<loc>"
+# robots.txt advertises the sitemap
+curl -s https://coders.mu/robots.txt | grep -i sitemap
+# Every URL in the sitemap returns 200 (no redirects, no 404s)
+for url in $(curl -s https://coders.mu/sitemap.xml | grep -oP '(?<=<loc>)[^<]+'); do
+  code=$(curl -s -o /dev/null -w '%{http_code}' -L --max-redirs 0 "$url")
+  [ "$code" != "200" ] && echo "BROKEN: $code $url"
+done
+# Expected output: empty (or a clear short list to investigate)
+```
+
+After deploy: in GSC → Sitemaps, submit `https://coders.mu/sitemap.xml`. Google should report "Success" within 24h. High-confidence local verification doesn't need GSC.
+
+---
+
+## Fix 2 — Enable Inertia SSR (or pre-render head metadata server-side)
+
+**Bucket(s) targeted:** Crawled — currently not indexed (245), Duplicate without user-selected canonical (33).
+
+**Why this matters:** The HTML response Google currently sees is the same shell for every URL: hardcoded `<title>frontend.mu</title>`, no meta description, no canonical, no OG tags, no `<h1>` in the body. JS-rendered crawling is a second-tier path; pages get queued for "render later" and often never finish.
+
+**Implementation (preferred — full SSR):**
+1. Install Inertia SSR: `pnpm --filter frontendmu-adonis add @inertiajs/vue3` is already there. Add `@vue/server-renderer` if missing.
+2. Create `inertia/ssr.ts` that mirrors `inertia/app.ts` but uses `createSSRApp` and `renderToString` from `@vue/server-renderer`. Use the `@inertiajs/vue3` SSR docs verbatim.
+3. Flip `config/inertia.ts` → `ssr: { enabled: true, entrypoint: 'inertia/ssr.ts' }`.
+4. Update build pipeline (`vite.config.ts`) to emit an SSR bundle alongside the client bundle. Adonis Inertia docs: `node ace inertia:build:ssr` plus `vite build --ssr`.
+5. Update `Dockerfile` to run the SSR build and ensure the SSR bundle is in the production image.
+6. In **every** page component, wrap the existing `<Head>` calls to also emit:
+   - `<title>` (already done in most pages, missing in `speakers/show.vue`)
+   - `<meta name="description" content="...">` per page (currently only `home.vue` does this)
+   - `<link rel="canonical" :href="canonicalUrl">` — see Fix 4
+   - OG basics: `og:title`, `og:description`, `og:type`, `og:image`, `og:url`
+
+**Implementation (fallback if SSR is too risky for one PR — partial fix):**
+- Move the title/description/canonical/OG tags out of Vue `<Head>` and into the Edge layout `resources/views/inertia_layout.edge`, populated by a shared inertia prop (`metaTags`) that every controller sets. Example: each controller calls a `setMeta(ctx, { title, description, path })` helper before `inertia.render(...)`. Edge then prints `<title>{{ meta.title }}</title>` etc.
+- This is uglier but doesn't require an SSR build pipeline.
+
+Recommendation: do the proper SSR option. It also unblocks shareable previews on Slack/Twitter/LinkedIn.
+
+**Verification:**
+```bash
+# Per-page <title> in initial HTML (no JS executed)
+for path in / /meetups /meetup/2024-august /speakers /team /sponsors /about; do
+  title=$(curl -s "https://coders.mu$path" | grep -oP '(?<=<title>)[^<]+')
+  printf '%-40s %s\n' "$path" "$title"
+done
+# Expected: each path has a distinct, descriptive title (NOT just "frontend.mu")
+
+# Meta description present and distinct per page
+for path in / /meetups /meetup/2024-august /team; do
+  desc=$(curl -s "https://coders.mu$path" | grep -oP 'name="description"\s+content="[^"]+' | head -1)
+  printf '%-30s %s\n' "$path" "$desc"
+done
+
+# Body actually contains the meetup/speaker content rendered server-side
+curl -s https://coders.mu/meetup/2024-august | grep -c '<h1'   # → ≥ 1
+
+# OG tags
+curl -s https://coders.mu/meetup/2024-august | grep -oE 'property="og:[a-z]+"' | sort -u
+# Expected: og:title, og:description, og:image, og:type, og:url
+```
+
+For the manual check, use Google's Rich Results Test (`https://search.google.com/test/rich-results?url=...`) on a meetup page; it must see a populated title/description without JS execution.
+
+---
+
+## Fix 3 — Per-page canonical URLs and trailing-slash normalisation
+
+**Bucket(s) targeted:** Duplicate without user-selected canonical (33).
+
+**Why this matters:** Today `/team` and `/team/` are both 200 with identical content. Same for every static page. Google flips a coin.
+
+**Implementation:**
+1. Decide the canonical shape: **no trailing slash** (matches the existing route definitions in `start/routes.ts`).
+2. Add a middleware at `app/middleware/canonical_url_middleware.ts` that runs on `GET` requests and:
+   - If the path ends with `/` and is not `/`, issue a `301` to the same path without the slash.
+   - If the URL has any query string param matching `^(ref|trk|utm_.*|fbclid|gclid)$`, strip those and `301` to the cleaned URL. (GSC has `?ref=sysadmin-journal.com`, `?trk=public_post_main-feed-card-text` instances.)
+3. Wire the middleware into the global router stack (after `forceJsonResponse` skip).
+4. Emit `<link rel="canonical" href="https://coders.mu<canonical-path>">` from the layout (or SSR head) — driven by the same canonical computation as the middleware.
+
+**Verification:**
+```bash
+# Trailing slash 301s to no-slash
+for p in /team/ /about/ /sponsors/ /meetup/2024-august/; do
+  curl -s -o /dev/null -w "$p -> %{http_code} %{redirect_url}\n" "https://coders.mu$p"
+done
+# Expected: 301 https://coders.mu<no-slash>
+
+# Tracking params stripped
+curl -s -o /dev/null -w "%{http_code} %{redirect_url}\n" "https://coders.mu/meetup/2024-august?ref=foo&utm_source=x"
+# Expected: 301 https://coders.mu/meetup/2024-august
+
+# Canonical tag points at the canonical URL
+curl -s https://coders.mu/team/ -L | grep -oE '<link rel="canonical"[^>]+>'
+curl -s "https://coders.mu/team?ref=x" -L | grep -oE '<link rel="canonical"[^>]+>'
+# Expected: both → href="https://coders.mu/team"
+```
+
+**Gotcha:** Don't 301 on inertia XHR (`X-Inertia: true`) — bypass the middleware in that case so SPA navigation doesn't break.
+
+---
+
+## Fix 4 — Restore legacy slugs (snake_case static pages) with 301s
+
+**Bucket(s) targeted:** Not found (404) — partial. Plus "Crawled — currently not indexed" pages on `frontend.coders.mu/code_of_conduct/`, `/coding_guidelines/`.
+
+**Why this matters:** Google indexed `https://coders.mu/code_of_conduct` and `https://coders.mu/coding_guidelines`. Today both 404. They should 301 to the new kebab versions.
+
+**Implementation:**
+- Add explicit redirect routes at the top of `start/routes.ts`:
+  ```ts
+  router.get('/code_of_conduct', ({ response }) => response.redirect('/code-of-conduct', false, 301))
+  router.get('/coding_guidelines', ({ response }) => response.redirect('/coding-guidelines', false, 301))
+  ```
+- While we're there, also handle the few oddities: `/contribute/`, `/sponsors/`, `/team/` etc. are already handled by the trailing-slash middleware from Fix 3.
+
+**Verification:**
+```bash
+for u in /code_of_conduct /coding_guidelines /code_of_conduct/ /coding_guidelines/; do
+  curl -s -o /dev/null -w "$u -> %{http_code} %{redirect_url}\n" "https://coders.mu$u"
+done
+# Expected: each 301 → the kebab equivalent
+```
+
+---
+
+## Fix 5 — Legacy numeric meetup IDs → new slug-based URLs (or clean 410)
+
+**Bucket(s) targeted:** Server error (5xx) — most of the 91 (now actually 404). Not found (404). "Crawled — currently not indexed" `frontend.coders.mu/meetup/<id>` entries.
+
+**Why this matters:** Google has indexed `/meetup/17` through `/meetup/70` (and frontend.coders.mu variants) from the old Directus-backed site. The new app uses date-slugs (`2024-august`) or UUIDs.
+
+**Implementation:**
+1. **Investigate** whether the `events` table still carries a `legacyId` / `directus_id` integer column. The migration history (commits `019bd47`, `f7eb5be`, etc.) suggests imports — confirm with:
+   ```bash
+   pnpm --filter frontendmu-adonis exec node ace make:script check-legacy-id   # or grep schema
+   grep -rn "legacy_id\|directusId\|legacyId" packages/frontendmu-adonis/app/models packages/frontendmu-adonis/database/migrations
+   ```
+2. **If a legacy-id column exists**, add a route:
+   ```ts
+   router.get('/meetup/:legacyId', async ({ params, response }) => {
+     const id = Number(params.legacyId)
+     if (!Number.isInteger(id) || id <= 0) return response.notFound()
+     const event = await Event.query().where('legacyId', id).first()
+     if (!event?.slug) return response.notFound()  // or .status(410)
+     return response.redirect(`/meetup/${event.slug}`, false, 301)
+   }).where('legacyId', /^\d+$/)
+   ```
+   Place this **before** the existing `/meetup/:idOrSlug` route to avoid shadow conflicts.
+3. **If the legacy IDs were never preserved**, build a static mapping file (`app/data/legacy_meetup_ids.ts`) by mapping the 60-odd IDs to slugs (some can be reconstructed from event dates the team remembers). For any ID we can't map, **respond `410 Gone`** so Google removes them from the index promptly (faster than 404).
+
+**Verification:**
+```bash
+# Sample mapped IDs (replace with whichever you confirm map to real meetups)
+for n in 17 24 30 45 60 68; do
+  curl -s -o /dev/null -w "/meetup/$n -> %{http_code} %{redirect_url}\n" "https://coders.mu/meetup/$n"
+done
+# Expected: 301 → /meetup/<slug>  (or 410 if unmapped)
+
+# Cross-check the redirect target resolves 200
+curl -sL -o /dev/null -w "%{http_code}\n" "https://coders.mu/meetup/17"
+# Expected: 200
+```
+
+---
+
+## Fix 6 — Speaker UUID 404s
+
+**Bucket(s) targeted:** Not found (404) — speaker entries. "Crawled — currently not indexed" — frontend.coders.mu speaker variants.
+
+**Why this matters:** GSC has ~25 `coders.mu/speaker/<uuid>` URLs that 404. `app/controllers/speakers_controller.ts` does `firstOrFail()`, so they 404 cleanly — but Google still has them indexed/queued.
+
+**Implementation:**
+1. Run a one-off check: `select id, full_name from users where id in (<uuids from GSC list>)` to figure out which legacy speaker UUIDs are present in the new DB. Some likely just don't exist (test users in old system) and some may have been re-created with new IDs.
+2. For UUIDs that **don't exist** in the new DB: return `410 Gone` instead of `404`. Update the catch in `speakers_controller.show()` to map the `E_ROW_NOT_FOUND` to a 410 response (or add a precheck).
+3. For UUIDs that **do** exist but the page itself looks thin (no sessions): keep 200 but emit `<meta name="robots" content="noindex">` on speakers with zero sessions, so they stop diluting the crawl budget.
+4. Ensure there's no internal link from any current page to legacy 404 speaker URLs (`grep -rn 'speaker/' inertia/`).
+
+**Verification:**
+```bash
+# UUIDs we believe are gone
+for uuid in 3166bf91-55ac-4702-a868-845b97bd9c29 60c638fd-2676-4a3b-a697-0c002752349e; do
+  curl -s -o /dev/null -w "%{http_code} $uuid\n" "https://coders.mu/speaker/$uuid"
+done
+# Expected: 410 (gone) for all
+
+# UUID that exists, low quality: noindex robots tag
+curl -s "https://coders.mu/speaker/<known-zero-sessions-uuid>" | grep -i 'name="robots"'
+# Expected: <meta name="robots" content="noindex">
+```
+
+---
+
+## Fix 7 — Stop `frontend.coders.mu` from preserving paths
+
+**Bucket(s) targeted:** Page with redirect (12), and the ~60 `frontend.coders.mu/*` entries in "Crawled — currently not indexed".
+
+**Why this matters:** Cloudflare currently rewrites `https://frontend.coders.mu/<anything>` to `https://coders.mu/<anything>` with a 301. For most paths the apex 404s, so Google sees `301 → 404` and keeps trying. We don't want to keep nudging it.
+
+**Implementation:**
+1. In Cloudflare → coders.mu zone → Rules → Redirect Rules: change the `frontend.coders.mu` rule from "preserve URI" to **"static destination `https://coders.mu/` 301"** (drop the path). This collapses the subdomain into a single redirect to the homepage.
+2. After the apex 404→410 work in Fix 5 and Fix 6, Google will drop the legacy paths within a few weeks.
+3. Optional: serve a tiny `robots.txt` from the subdomain that disallows everything. (Not strictly required since the redirect itself prevents crawling beyond `/`.)
+
+**Verification:**
+```bash
+for p in /  /team /meetup/49/ /speaker/2af3f3bb-0de2-45a2-bd31-a452c85db2da/ /code_of_conduct; do
+  curl -s -o /dev/null -w "$p -> %{http_code} %{redirect_url}\n" "https://frontend.coders.mu$p"
+done
+# Expected: every path -> 301 https://coders.mu/   (NOT preserving the path)
+```
+
+This step is the only one that doesn't go through the PR — it's a Cloudflare dashboard change. Call it out in the PR description so it gets done at deploy time.
+
+---
+
+## Fix 8 — Build the missing `/privacy` and `/terms` pages
+
+**Bucket(s) targeted:** Not found (404).
+
+**Why this matters:** Both URLs are in the 404 bucket, and they're table-stakes for a community site. Footer probably links to them.
+
+**Implementation:**
+- Add `/privacy` and `/terms` routes to `start/routes.ts` (mirror the existing `pages_controller.ts` pattern).
+- Add `inertia/pages/privacy.vue` and `inertia/pages/terms.vue` with placeholder copy (community policy + minimal terms boilerplate).
+- Add `<Head title="Privacy">` / `<Head title="Terms">` + meta description.
+- Include in sitemap (Fix 1).
+- If footer links currently point to `/privacy-policy` or some other slug, update them or add an alias route.
+
+**Verification:**
+```bash
+curl -sI https://coders.mu/privacy | head -1   # → HTTP/2 200
+curl -sI https://coders.mu/terms   | head -1   # → HTTP/2 200
+curl -s  https://coders.mu/privacy | grep -oE '<title>[^<]+</title>'
+# Expected: <title>Privacy — coders.mu</title> (or similar, distinct from /terms)
+```
+
+---
+
+## Fix 9 — `noindex` and `robots.txt` for non-public pages
+
+**Bucket(s) targeted:** Excluded by `noindex` tag (1), Blocked by robots.txt (1), and prevention for the future.
+
+**Why this matters:** The single existing `noindex` page is `/auth/google` and the single `robots.txt`-blocked URL is on the dead `directus.coders.mu` subdomain — both are fine as-is. The issue is what's **missing**: `/admin/*`, `/profile`, `/user/me`, `/login`, `/register`, `/redirect`, `/auth/google/callback` are all reachable and not flagged.
+
+**Implementation:**
+1. Update `public/robots.txt`:
+   ```
+   User-agent: *
+   Disallow: /admin/
+   Disallow: /profile
+   Disallow: /login
+   Disallow: /register
+   Disallow: /redirect
+   Disallow: /auth/
+   Disallow: /api/
+   Disallow: /user/
+
+   Sitemap: https://coders.mu/sitemap.xml
+   ```
+2. Emit `<meta name="robots" content="noindex,follow">` from the layout for any route that matches `/admin`, `/profile`, `/login`, `/register`, `/auth/*`. Easiest: a `noindexPaths` array consulted by the layout/SSR head builder.
+3. Make `/redirect` and `/user/me` either 410 or noindex — they exist in the GSC backlog and we don't want them in the future either.
+
+**Verification:**
+```bash
+curl -s https://coders.mu/robots.txt
+# Confirm all Disallow lines and the Sitemap: line are present
+
+# Sensitive routes carry noindex
+for u in /admin /profile /login /register /auth/google /redirect /user/me; do
+  echo "== $u =="
+  curl -s "https://coders.mu$u" | grep -i 'name="robots"' || echo '(no robots meta found)'
+done
+# Expected: noindex on each (or a 404/410 if the route was deleted)
+```
+
+---
+
+## Fix 10 — Replace the JSON 404 with the Inertia 404 page
+
+**Bucket(s) targeted:** indirectly all (the 404 page is what crawlers see for every dead URL).
+
+**Why this matters:** Today `curl -H 'Accept: text/html' https://coders.mu/whatever` returns `Cannot GET:/whatever` with `Content-Type: application/json`. That's the AdonisJS router default. It's not an SEO crisis (Google understands status code, not body) but it's an embarrassing 404 and we're rendering an Inertia `errors/not_found` page everywhere else.
+
+**Implementation:**
+- In `app/exceptions/handler.ts`, ensure the `404` status page also catches the "no route matched" case. AdonisJS has `Route.any('*', ...)` as the official approach. Add a wildcard fallback to `start/routes.ts` (last route in the file):
+  ```ts
+  router.any('*', ({ inertia, response }) => {
+    response.status(404)
+    return inertia.render('errors/not_found', {})
+  })
+  ```
+
+**Verification:**
+```bash
+code_ct=$(curl -s -o /dev/null -w '%{http_code} %{content_type}' -H 'Accept: text/html' https://coders.mu/this-does-not-exist)
+echo "$code_ct"
+# Expected: 404 text/html; charset=utf-8
+
+curl -s -H 'Accept: text/html' https://coders.mu/this-does-not-exist | grep -oE '<title>[^<]+</title>'
+# Expected: distinct 404 title (NOT "frontend.mu" default)
+```
+
+---
+
+## Cross-cutting verification: per-URL sweep against the GSC export
+
+For each fix above we have local `curl` checks. The final pre-merge sweep re-runs every URL from the GSC report through `curl` and asserts the expected new status:
+
+```bash
+# scripts/verify-seo.sh
+set -e
+
+declare -A EXPECT
+# from GSC "Not found" — should now 301 to apex equivalent (or 200 / 410 where appropriate)
+EXPECT[https://coders.mu/code_of_conduct]=301
+EXPECT[https://coders.mu/coding_guidelines]=301
+EXPECT[https://coders.mu/privacy]=200
+EXPECT[https://coders.mu/terms]=200
+# from "Page with redirect" — should now 301 to homepage cleanly
+EXPECT[https://frontend.coders.mu/team]=301
+# from "Server error" / "Not found" — legacy meetup numeric ids: 301 if mapped, 410 otherwise
+EXPECT[https://coders.mu/meetup/17]=301   # adjust if 410
+# from "Duplicate" — should now canonicalise
+EXPECT[https://coders.mu/team/]=301
+# from "Excluded by noindex" — should stay 200 with noindex (don't regress)
+EXPECT[https://coders.mu/auth/google]=302
+# from "Blocked by robots.txt" — dead directus host, leave as 000/dead
+# (skip — not under our control)
+
+fail=0
+for url in "${!EXPECT[@]}"; do
+  want=${EXPECT[$url]}
+  got=$(curl -s -o /dev/null -w '%{http_code}' --max-redirs 0 "$url")
+  if [ "$got" != "$want" ]; then
+    echo "FAIL $url  expected=$want got=$got"; fail=1
+  else
+    echo "ok   $url  $got"
+  fi
+done
+exit $fail
+```
+
+Drop a fuller version (~100 lines) in `scripts/verify-seo.sh` covering one URL per GSC bucket plus a representative sample from the 245-strong "Crawled" bucket. Make it CI-runnable post-deploy.
+
+---
+
+## What we still can't prove without GSC
+
+After this PR ships:
+- "Crawled — currently not indexed" recovery requires Google to re-crawl. Expect 2–6 weeks. The signal we *can* observe locally is that the HTML now contains real titles/descriptions and the sitemap is being fetched.
+- Use GSC's "Request indexing" on 10–20 high-value pages (homepage, /meetups, top 5 recent meetups, /sponsors, /team) to accelerate.
+- After 2 weeks, re-pull the GSC indexing report and diff against the snapshot in this PR description. Expected movement:
+  - 5xx (91) → near zero (most resolve to 410/301).
+  - 404 (38) → near zero (legacy slugs redirected, /privacy /terms shipped, speakers 410'd).
+  - Duplicate canonical (33) → drop sharply once canonical tags + slash-normaliser are live.
+  - Page with redirect (12) → drop once Cloudflare rule changes.
+  - Crawled — not indexed (245) → drop gradually as SSR-rendered HTML re-passes the content-quality bar.
+
+---
+
+## Suggested PR structure (one branch, logically grouped commits)
+
+1. `feat(adonis): add sitemap.xml route and link from robots.txt` — Fix 1, Fix 9.
+2. `feat(adonis): enable Inertia SSR and per-page meta tags` — Fix 2.
+3. `feat(adonis): canonical url middleware and tracking-param stripper` — Fix 3.
+4. `feat(adonis): legacy slug redirects (code_of_conduct, coding_guidelines)` — Fix 4.
+5. `feat(adonis): redirect legacy numeric meetup ids to slug urls` — Fix 5.
+6. `chore(adonis): 410 dead speaker uuids and noindex empty profiles` — Fix 6.
+7. `feat(adonis): add /privacy and /terms pages` — Fix 8.
+8. `fix(adonis): inertia 404 page for unmatched routes` — Fix 10.
+9. `chore: scripts/verify-seo.sh for post-deploy sweep` — Cross-cutting verification.
+
+(Fix 7 is a Cloudflare dashboard change, not in the PR — mention in PR description and do at deploy time.)

--- a/packages/frontendmu-adonis/app/controllers/events_controller.ts
+++ b/packages/frontendmu-adonis/app/controllers/events_controller.ts
@@ -7,9 +7,17 @@ import EventPolicy from '#policies/event_policy'
 import EventTransformer from '#transformers/event_transformer'
 import RsvpTransformer from '#transformers/rsvp_transformer'
 import PublicAttendeeTransformer from '#transformers/public_attendee_transformer'
+import { setSeoMeta } from '#utils/seo'
 
 export default class EventsController {
-  async index({ inertia, auth, bouncer }: HttpContext) {
+  async index(ctx: HttpContext) {
+    const { inertia, auth, bouncer } = ctx
+    setSeoMeta(ctx, {
+      title: 'All Meetups',
+      description:
+        'Every coders.mu meetup — past, upcoming, sessions, and speakers. Browse the full history of Front-End Coders Mauritius.',
+      canonical: '/meetups',
+    })
     const events = await Event.query()
       .where('status', 'published')
       .orderBy('eventDate', 'desc')
@@ -76,9 +84,7 @@ export default class EventsController {
       .filter((iso): iso is string => Boolean(iso))
 
     const firstRsvpAt = confirmedRsvps[0]?.createdAt ?? null
-    const rsvpOpenAt = firstRsvpAt
-      ? firstRsvpAt.minus({ days: 2 }).toISO()
-      : DateTime.now().toISO()
+    const rsvpOpenAt = firstRsvpAt ? firstRsvpAt.minus({ days: 2 }).toISO() : DateTime.now().toISO()
 
     const timeline = {
       rsvpOpenAt,
@@ -114,6 +120,21 @@ export default class EventsController {
         githubUsername: null,
       }))
     }
+
+    const meetupDescription =
+      (event.description ?? '')
+        .replace(/<[^>]+>/g, '')
+        .replace(/\s+/g, ' ')
+        .trim()
+        .slice(0, 200) || `Details, sessions and RSVP for ${event.title} on coders.mu.`
+
+    setSeoMeta(ctx, {
+      title: event.title,
+      description: meetupDescription,
+      canonical: `/meetup/${event.slug}`,
+      ogType: 'article',
+      ogImage: event.coverImageUrl ?? undefined,
+    })
 
     return inertia.render('meetups/show', {
       meetup: EventTransformer.transform(event).useVariant('detail'),

--- a/packages/frontendmu-adonis/app/controllers/home_controller.ts
+++ b/packages/frontendmu-adonis/app/controllers/home_controller.ts
@@ -6,9 +6,18 @@ import Rsvp from '#models/rsvp'
 import EventTransformer from '#transformers/event_transformer'
 import SpeakerTransformer from '#transformers/speaker_transformer'
 import SponsorTransformer from '#transformers/sponsor_transformer'
+import { setSeoMeta } from '#utils/seo'
 
 export default class HomeController {
-  async index({ inertia, auth }: HttpContext) {
+  async index(ctx: HttpContext) {
+    const { inertia, auth } = ctx
+
+    setSeoMeta(ctx, {
+      title: 'Front-End Coders Mauritius',
+      description:
+        'A community of passionate developers in Mauritius. Join us for monthly meetups, workshops, and tech talks.',
+      canonical: '/',
+    })
     const dbEvents = await Event.query()
       .where('status', 'published')
       .orderBy('eventDate', 'desc')

--- a/packages/frontendmu-adonis/app/controllers/pages_controller.ts
+++ b/packages/frontendmu-adonis/app/controllers/pages_controller.ts
@@ -1,66 +1,127 @@
 import type { HttpContext } from '@adonisjs/core/http'
+import { setSeoMeta, type SeoMetaInput } from '#utils/seo'
+
+const META: Record<string, SeoMetaInput> = {
+  sponsorUs: {
+    title: 'Sponsor us',
+    description:
+      'Support coders.mu by sponsoring a meetup. Help fund venues, food, equipment, and travel for speakers.',
+    canonical: '/sponsor-us',
+  },
+  about: {
+    title: 'About',
+    description:
+      'About Front-End Coders Mauritius — who we are, what we do, and the values that drive our monthly meetups.',
+    canonical: '/about',
+  },
+  community: {
+    title: 'Community',
+    description:
+      'Join the coders.mu community on Discord, GitHub, WhatsApp, Twitter, Instagram, and LinkedIn.',
+    canonical: '/community',
+  },
+  branding: {
+    title: 'Branding',
+    description:
+      'Logos, colours, and brand assets for partners and contributors using the coders.mu identity.',
+    canonical: '/branding',
+  },
+  history: {
+    title: 'History',
+    description:
+      'The story of Front-End Coders Mauritius — how the community started and how it has grown.',
+    canonical: '/history',
+  },
+  contribute: {
+    title: 'Contribute',
+    description:
+      'Help build coders.mu — submit talks, contribute to the open-source site, organise a meetup, or sponsor an event.',
+    canonical: '/contribute',
+  },
+  codingGuidelines: {
+    title: 'Coding guidelines',
+    description: 'Conventions, style rules, and patterns the coders.mu site is built with.',
+    canonical: '/coding-guidelines',
+  },
+  codeOfConduct: {
+    title: 'Code of Conduct',
+    description:
+      'The expectations we hold for everyone participating in the coders.mu community — at meetups, online, and in the repo.',
+    canonical: '/code-of-conduct',
+  },
+  apiDocs: {
+    title: 'Public API',
+    description:
+      'Documentation for the public, read-only coders.mu API — perfect for embedding upcoming meetups on your own site.',
+    canonical: '/api-docs',
+  },
+  privacy: {
+    title: 'Privacy',
+    description:
+      'How coders.mu handles your personal data — what we collect, why, and how to ask us to remove it.',
+    canonical: '/privacy',
+  },
+  terms: {
+    title: 'Terms',
+    description:
+      'The rules of the road for using coders.mu — what we expect of you, what you can expect of us.',
+    canonical: '/terms',
+  },
+}
 
 export default class PagesController {
-  /**
-   * Display sponsor-us page
-   */
-  async sponsorUs({ inertia }: HttpContext) {
-    return inertia.render('sponsor-us', {})
+  async sponsorUs(ctx: HttpContext) {
+    setSeoMeta(ctx, META.sponsorUs)
+    return ctx.inertia.render('sponsor-us', {})
   }
 
-  /**
-   * Display about page
-   */
-  async about({ inertia }: HttpContext) {
-    return inertia.render('about', {})
+  async about(ctx: HttpContext) {
+    setSeoMeta(ctx, META.about)
+    return ctx.inertia.render('about', {})
   }
 
-  /**
-   * Display community page
-   */
-  async community({ inertia }: HttpContext) {
-    return inertia.render('community', {})
+  async community(ctx: HttpContext) {
+    setSeoMeta(ctx, META.community)
+    return ctx.inertia.render('community', {})
   }
 
-  /**
-   * Display branding page
-   */
-  async branding({ inertia }: HttpContext) {
-    return inertia.render('branding', {})
+  async branding(ctx: HttpContext) {
+    setSeoMeta(ctx, META.branding)
+    return ctx.inertia.render('branding', {})
   }
 
-  /**
-   * Display history page
-   */
-  async history({ inertia }: HttpContext) {
-    return inertia.render('history', {})
+  async history(ctx: HttpContext) {
+    setSeoMeta(ctx, META.history)
+    return ctx.inertia.render('history', {})
   }
 
-  /**
-   * Display contribute page
-   */
-  async contribute({ inertia }: HttpContext) {
-    return inertia.render('contribute', {})
+  async contribute(ctx: HttpContext) {
+    setSeoMeta(ctx, META.contribute)
+    return ctx.inertia.render('contribute', {})
   }
 
-  /**
-   * Display coding guidelines page
-   */
-  async codingGuidelines({ inertia }: HttpContext) {
-    return inertia.render('coding-guidelines', {})
+  async codingGuidelines(ctx: HttpContext) {
+    setSeoMeta(ctx, META.codingGuidelines)
+    return ctx.inertia.render('coding-guidelines', {})
   }
 
-  /**
-   * Display code of conduct page
-   */
-  async codeOfConduct({ inertia }: HttpContext) {
-    return inertia.render('code-of-conduct', {})
+  async codeOfConduct(ctx: HttpContext) {
+    setSeoMeta(ctx, META.codeOfConduct)
+    return ctx.inertia.render('code-of-conduct', {})
   }
 
-  /**
-   * Display public API documentation page
-   */
-  async apiDocs({ inertia }: HttpContext) {
-    return inertia.render('api-docs', {})
+  async apiDocs(ctx: HttpContext) {
+    setSeoMeta(ctx, META.apiDocs)
+    return ctx.inertia.render('api-docs', {})
+  }
+
+  async privacy(ctx: HttpContext) {
+    setSeoMeta(ctx, META.privacy)
+    return ctx.inertia.render('privacy', {})
+  }
+
+  async terms(ctx: HttpContext) {
+    setSeoMeta(ctx, META.terms)
+    return ctx.inertia.render('terms', {})
   }
 }

--- a/packages/frontendmu-adonis/app/controllers/sitemap_controller.ts
+++ b/packages/frontendmu-adonis/app/controllers/sitemap_controller.ts
@@ -1,0 +1,93 @@
+import type { HttpContext } from '@adonisjs/core/http'
+import { type DateTime } from 'luxon'
+import db from '@adonisjs/lucid/services/db'
+import Event from '#models/event'
+import User from '#models/user'
+import { canonicalUrl } from '#utils/site_url'
+
+type Entry = {
+  loc: string
+  lastmod?: string
+}
+
+const STATIC_PATHS = [
+  '/',
+  '/meetups',
+  '/speakers',
+  '/sponsors',
+  '/sponsor-us',
+  '/team',
+  '/about',
+  '/community',
+  '/contribute',
+  '/branding',
+  '/history',
+  '/code-of-conduct',
+  '/coding-guidelines',
+  '/api-docs',
+  '/privacy',
+  '/terms',
+]
+
+function toIso(dt: DateTime | null | undefined): string | undefined {
+  return dt?.toUTC().toISO() ?? undefined
+}
+
+function xmlEscape(input: string): string {
+  return input
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;')
+}
+
+function renderSitemap(entries: Entry[]): string {
+  const lines = ['<?xml version="1.0" encoding="UTF-8"?>']
+  lines.push('<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">')
+  for (const entry of entries) {
+    lines.push('  <url>')
+    lines.push(`    <loc>${xmlEscape(entry.loc)}</loc>`)
+    if (entry.lastmod) lines.push(`    <lastmod>${entry.lastmod}</lastmod>`)
+    lines.push('  </url>')
+  }
+  lines.push('</urlset>')
+  return lines.join('\n')
+}
+
+export default class SitemapController {
+  async index({ response }: HttpContext) {
+    const entries: Entry[] = STATIC_PATHS.map((path) => ({ loc: canonicalUrl(path) }))
+
+    const events = await Event.query()
+      .where('status', 'published')
+      .select('slug', 'updatedAt')
+      .orderBy('eventDate', 'desc')
+
+    for (const event of events) {
+      if (!event.slug) continue
+      entries.push({
+        loc: canonicalUrl(`/meetup/${event.slug}`),
+        lastmod: toIso(event.updatedAt),
+      })
+    }
+
+    // Speakers with at least one session — avoids polluting the index with
+    // attendee accounts that never spoke.
+    const speakerRows = await db.from('session_speakers').distinct('speaker_id')
+    const speakerIds = speakerRows.map((r) => r.speaker_id as string).filter(Boolean)
+    if (speakerIds.length > 0) {
+      const speakers = await User.query().whereIn('id', speakerIds).select('id', 'updatedAt')
+      for (const speaker of speakers) {
+        entries.push({
+          loc: canonicalUrl(`/speaker/${speaker.id}`),
+          lastmod: toIso(speaker.updatedAt as DateTime | null | undefined),
+        })
+      }
+    }
+
+    response.header('Content-Type', 'application/xml; charset=utf-8')
+    response.header('Cache-Control', 'public, max-age=3600')
+    return response.send(renderSitemap(entries))
+  }
+}

--- a/packages/frontendmu-adonis/app/controllers/speakers_controller.ts
+++ b/packages/frontendmu-adonis/app/controllers/speakers_controller.ts
@@ -3,9 +3,18 @@ import User from '#models/user'
 import SpeakerPolicy from '#policies/speaker_policy'
 import SpeakerTransformer from '#transformers/speaker_transformer'
 import SessionTransformer from '#transformers/session_transformer'
+import { setSeoMeta } from '#utils/seo'
 
 export default class SpeakersController {
-  async index({ inertia }: HttpContext) {
+  async index(ctx: HttpContext) {
+    const { inertia } = ctx
+    setSeoMeta(ctx, {
+      title: 'Speakers',
+      description:
+        'People who have shared their knowledge at coders.mu meetups — from junior devs to seasoned engineers.',
+      canonical: '/speakers',
+    })
+
     const dbSpeakers = await User.query()
       .whereHas('sessions', () => {})
       .orderBy('featured', 'desc')
@@ -18,13 +27,22 @@ export default class SpeakersController {
     })
   }
 
-  async show({ inertia, params, bouncer, auth }: HttpContext) {
+  async show(ctx: HttpContext) {
+    const { inertia, params, bouncer, auth, response } = ctx
     const dbSpeaker = await User.query()
       .where('id', params.id)
       .preload('sessions', (query) => {
         query.preload('event')
       })
-      .firstOrFail()
+      .first()
+
+    // Many legacy speaker UUIDs from the old Directus site no longer exist in
+    // the new DB. Returning 410 (instead of the default 404 from firstOrFail)
+    // signals "permanently gone" so Google drops them from the index faster.
+    if (!dbSpeaker) {
+      response.status(410)
+      return inertia.render('errors/not_found', {})
+    }
 
     const speaker = SpeakerTransformer.transform(dbSpeaker)
     const sessions = (dbSpeaker.sessions ?? []).sort((a, b) => {
@@ -41,6 +59,20 @@ export default class SpeakersController {
     if (auth.user) {
       canEdit = await bouncer.with(SpeakerPolicy).allows('edit')
     }
+
+    const speakerDescription =
+      sessions.length > 0
+        ? `${dbSpeaker.name} has spoken at ${sessions.length} coders.mu meetup${sessions.length === 1 ? '' : 's'}.`
+        : `${dbSpeaker.name} on coders.mu.`
+
+    setSeoMeta(ctx, {
+      title: dbSpeaker.name,
+      description: speakerDescription,
+      canonical: `/speaker/${dbSpeaker.id}`,
+      ogType: 'profile',
+      ogImage: dbSpeaker.avatarUrl ?? undefined,
+      noindex: sessions.length === 0,
+    })
 
     return inertia.render('speakers/show', {
       speaker,

--- a/packages/frontendmu-adonis/app/controllers/sponsors_controller.ts
+++ b/packages/frontendmu-adonis/app/controllers/sponsors_controller.ts
@@ -2,9 +2,18 @@ import type { HttpContext } from '@adonisjs/core/http'
 import Sponsor from '#models/sponsor'
 import EventTransformer from '#transformers/event_transformer'
 import SponsorTransformer from '#transformers/sponsor_transformer'
+import { setSeoMeta } from '#utils/seo'
 
 export default class SponsorsController {
-  async index({ inertia }: HttpContext) {
+  async index(ctx: HttpContext) {
+    const { inertia } = ctx
+    setSeoMeta(ctx, {
+      title: 'Sponsors',
+      description:
+        'Companies that help keep coders.mu meetups running — sponsoring venues, food, and equipment.',
+      canonical: '/sponsors',
+    })
+
     const dbSponsors = await Sponsor.query().where('status', 'active').orderBy('name', 'asc')
 
     const sponsors = SponsorTransformer.transform(dbSponsors)
@@ -14,7 +23,8 @@ export default class SponsorsController {
     })
   }
 
-  async show({ params, inertia }: HttpContext) {
+  async show(ctx: HttpContext) {
+    const { params, inertia } = ctx
     const dbSponsor = await Sponsor.findOrFail(params.id)
 
     const sponsor = SponsorTransformer.transform(dbSponsor)
@@ -22,6 +32,13 @@ export default class SponsorsController {
     const events = await dbSponsor.related('events').query().orderBy('event_date', 'desc')
 
     const meetups = EventTransformer.transform(events)
+
+    setSeoMeta(ctx, {
+      title: dbSponsor.name,
+      description: `${dbSponsor.name} sponsors coders.mu. View their support history and learn more about them.`,
+      canonical: `/sponsor/${dbSponsor.id}`,
+      ogType: 'profile',
+    })
 
     return inertia.render('sponsor', {
       sponsor,

--- a/packages/frontendmu-adonis/app/controllers/team_controller.ts
+++ b/packages/frontendmu-adonis/app/controllers/team_controller.ts
@@ -4,6 +4,7 @@ import { readFile } from 'node:fs/promises'
 import app from '@adonisjs/core/services/app'
 import { resolveAvatarUrl } from '../lib/avatar_url.js'
 import SpeakerTransformer from '#transformers/speaker_transformer'
+import { setSeoMeta } from '#utils/seo'
 
 const GITHUB_RAW_BASE =
   'https://raw.githubusercontent.com/frontendmu/frontend.mu/main/packages/frontendmu-data/data'
@@ -34,7 +35,15 @@ function toTeamMember(user: User, defaultRole: string) {
 }
 
 export default class TeamController {
-  async index({ inertia }: HttpContext) {
+  async index(ctx: HttpContext) {
+    const { inertia } = ctx
+    setSeoMeta(ctx, {
+      title: 'Team',
+      description:
+        'The organizers and community members who keep coders.mu meetups going, plus the contributors behind the open-source site itself.',
+      canonical: '/team',
+    })
+
     const dbOrganizers = await User.query().where('isOrganizer', true).orderBy('name', 'asc')
 
     const organizers = dbOrganizers.map((u) => toTeamMember(u, 'Organizer'))

--- a/packages/frontendmu-adonis/app/middleware/canonical_url_middleware.ts
+++ b/packages/frontendmu-adonis/app/middleware/canonical_url_middleware.ts
@@ -1,0 +1,52 @@
+import type { HttpContext } from '@adonisjs/core/http'
+import type { NextFn } from '@adonisjs/core/types/http'
+
+const TRACKING_PARAM = /^(utm_[a-z_]+|fbclid|gclid|mc_eid|mc_cid|ref|trk)$/i
+
+/**
+ * Canonicalises GET URLs so search engines (and shares) all converge on the
+ * same form:
+ *   - trailing-slash stripped (except for "/")
+ *   - tracking params (utm_*, ref, trk, fbclid, gclid, …) stripped
+ * Inertia XHRs (X-Inertia: true) and non-GET requests are skipped so SPA
+ * navigation and form posts don't get redirected.
+ */
+export default class CanonicalUrlMiddleware {
+  async handle(ctx: HttpContext, next: NextFn) {
+    const request = ctx.request
+
+    if (request.method() !== 'GET') return next()
+    if (request.header('x-inertia')) return next()
+
+    const pathname = request.url(false)
+    const qs = request.parsedUrl.query as string | null | undefined
+
+    let canonicalPath = pathname
+    if (canonicalPath.length > 1 && canonicalPath.endsWith('/')) {
+      canonicalPath = canonicalPath.replace(/\/+$/, '')
+    }
+
+    let canonicalQuery = ''
+    if (qs) {
+      const params = new URLSearchParams(qs)
+      const cleaned = new URLSearchParams()
+      let dropped = false
+      for (const [key, value] of params.entries()) {
+        if (TRACKING_PARAM.test(key)) {
+          dropped = true
+          continue
+        }
+        cleaned.append(key, value)
+      }
+      canonicalQuery = cleaned.toString()
+      if (!dropped && canonicalPath === pathname) {
+        return next()
+      }
+    } else if (canonicalPath === pathname) {
+      return next()
+    }
+
+    const target = canonicalQuery ? `${canonicalPath}?${canonicalQuery}` : canonicalPath
+    return ctx.response.redirect(target, false, 301)
+  }
+}

--- a/packages/frontendmu-adonis/app/middleware/canonical_url_middleware.ts
+++ b/packages/frontendmu-adonis/app/middleware/canonical_url_middleware.ts
@@ -1,7 +1,7 @@
 import type { HttpContext } from '@adonisjs/core/http'
 import type { NextFn } from '@adonisjs/core/types/http'
 
-const TRACKING_PARAM = /^(utm_[a-z_]+|fbclid|gclid|mc_eid|mc_cid|ref|trk)$/i
+const TRACKING_PARAM = /^(utm_[a-z_]+|fbclid|gclid|mc_[a-z0-9_]+|ref|trk)$/i
 
 /**
  * Canonicalises GET URLs so search engines (and shares) all converge on the

--- a/packages/frontendmu-adonis/app/middleware/inertia_middleware.ts
+++ b/packages/frontendmu-adonis/app/middleware/inertia_middleware.ts
@@ -4,6 +4,7 @@ import BaseInertiaMiddleware from '@adonisjs/inertia/inertia_middleware'
 import type { InferSharedProps } from '@adonisjs/inertia/types'
 import { googleOauthEnabled } from '#config/ally'
 import featureFlags from '#config/feature_flags'
+import { setSeoMeta } from '#utils/seo'
 
 async function getSharedAuthUser(ctx: HttpContext) {
   const user = ctx.auth.user
@@ -54,6 +55,11 @@ export default class InertiaMiddleware extends BaseInertiaMiddleware {
 
   async handle(ctx: HttpContext, next: NextFn) {
     await this.init(ctx)
+
+    // Seed sensible default SEO meta for every request. Controllers can
+    // override via setSeoMeta() before rendering — this just guarantees the
+    // Edge layout always has a `seoMeta` object to read from.
+    setSeoMeta(ctx)
 
     const output = await next()
 

--- a/packages/frontendmu-adonis/app/utils/seo.ts
+++ b/packages/frontendmu-adonis/app/utils/seo.ts
@@ -1,0 +1,81 @@
+import type { HttpContext } from '@adonisjs/core/http'
+import { canonicalUrl, siteUrl } from '#utils/site_url'
+
+export type SeoMeta = {
+  title: string
+  description: string
+  canonical: string
+  ogTitle: string
+  ogDescription: string
+  ogImage: string
+  ogType: 'website' | 'article' | 'profile'
+  noindex: boolean
+}
+
+const SITE_NAME = 'coders.mu'
+const TITLE_SUFFIX = ' · coders.mu'
+const DEFAULT_DESCRIPTION =
+  'A community of frontend, backend, and full-stack developers in Mauritius. Monthly meetups, talks, and open conversations on the craft.'
+const DEFAULT_OG_IMAGE = '/og-default.png'
+
+const NOINDEX_PATH_PREFIXES = ['/admin', '/profile', '/login', '/register', '/auth']
+
+function defaultsFor(ctx: HttpContext): SeoMeta {
+  const path = ctx.request.url(false)
+  const noindex = NOINDEX_PATH_PREFIXES.some(
+    (prefix) => path === prefix || path.startsWith(`${prefix}/`)
+  )
+  return {
+    title: SITE_NAME,
+    description: DEFAULT_DESCRIPTION,
+    canonical: canonicalUrl(path),
+    ogTitle: SITE_NAME,
+    ogDescription: DEFAULT_DESCRIPTION,
+    ogImage: siteUrl() + DEFAULT_OG_IMAGE,
+    ogType: 'website',
+    noindex,
+  }
+}
+
+export type SeoMetaInput = Partial<Omit<SeoMeta, 'canonical'>> & {
+  /** Path relative to site root, e.g. "/meetup/2024-august". If omitted, the current request URL is used. */
+  canonical?: string
+}
+
+/**
+ * Compute the final SEO meta for the current request and stash it on the Edge
+ * view so the inertia layout template can render <title>/<meta>/<link rel=canonical>/og:* tags
+ * into the initial HTML response — important for Google because we don't run SSR.
+ */
+export function setSeoMeta(ctx: HttpContext, input: SeoMetaInput = {}): SeoMeta {
+  const defaults = defaultsFor(ctx)
+
+  const title = input.title ? `${input.title}${TITLE_SUFFIX}` : defaults.title
+  const description = input.description ?? defaults.description
+
+  const canonical = input.canonical
+    ? input.canonical.startsWith('http')
+      ? input.canonical
+      : canonicalUrl(input.canonical)
+    : defaults.canonical
+
+  const ogImage = input.ogImage
+    ? input.ogImage.startsWith('http')
+      ? input.ogImage
+      : siteUrl() + (input.ogImage.startsWith('/') ? input.ogImage : `/${input.ogImage}`)
+    : defaults.ogImage
+
+  const meta: SeoMeta = {
+    title,
+    description,
+    canonical,
+    ogTitle: input.ogTitle ?? title,
+    ogDescription: input.ogDescription ?? description,
+    ogImage,
+    ogType: input.ogType ?? defaults.ogType,
+    noindex: input.noindex ?? defaults.noindex,
+  }
+
+  ctx.view.share({ seoMeta: meta })
+  return meta
+}

--- a/packages/frontendmu-adonis/app/utils/seo.ts
+++ b/packages/frontendmu-adonis/app/utils/seo.ts
@@ -7,7 +7,7 @@ export type SeoMeta = {
   canonical: string
   ogTitle: string
   ogDescription: string
-  ogImage: string
+  ogImage: string | null
   ogType: 'website' | 'article' | 'profile'
   noindex: boolean
 }
@@ -16,7 +16,6 @@ const SITE_NAME = 'coders.mu'
 const TITLE_SUFFIX = ' · coders.mu'
 const DEFAULT_DESCRIPTION =
   'A community of frontend, backend, and full-stack developers in Mauritius. Monthly meetups, talks, and open conversations on the craft.'
-const DEFAULT_OG_IMAGE = '/og-default.png'
 
 const NOINDEX_PATH_PREFIXES = ['/admin', '/profile', '/login', '/register', '/auth']
 
@@ -31,7 +30,7 @@ function defaultsFor(ctx: HttpContext): SeoMeta {
     canonical: canonicalUrl(path),
     ogTitle: SITE_NAME,
     ogDescription: DEFAULT_DESCRIPTION,
-    ogImage: siteUrl() + DEFAULT_OG_IMAGE,
+    ogImage: null,
     ogType: 'website',
     noindex,
   }
@@ -63,7 +62,7 @@ export function setSeoMeta(ctx: HttpContext, input: SeoMetaInput = {}): SeoMeta 
     ? input.ogImage.startsWith('http')
       ? input.ogImage
       : siteUrl() + (input.ogImage.startsWith('/') ? input.ogImage : `/${input.ogImage}`)
-    : defaults.ogImage
+    : null
 
   const meta: SeoMeta = {
     title,

--- a/packages/frontendmu-adonis/app/utils/site_url.ts
+++ b/packages/frontendmu-adonis/app/utils/site_url.ts
@@ -1,0 +1,20 @@
+import env from '#start/env'
+
+const CANONICAL_HOST = 'https://coders.mu'
+
+function rawSiteUrl(): string {
+  const fromEnv = env.get('APP_URL')
+  if (fromEnv && /^https?:\/\//i.test(fromEnv)) return fromEnv
+  return CANONICAL_HOST
+}
+
+export function siteUrl(): string {
+  return rawSiteUrl().replace(/\/$/, '')
+}
+
+export function canonicalUrl(path: string): string {
+  const base = siteUrl()
+  if (!path || path === '/') return base + '/'
+  const normalised = path.startsWith('/') ? path : `/${path}`
+  return base + normalised
+}

--- a/packages/frontendmu-adonis/inertia/app.ts
+++ b/packages/frontendmu-adonis/inertia/app.ts
@@ -8,12 +8,19 @@ import { createInertiaApp } from '@inertiajs/vue3'
 import { resolvePageComponent } from '@adonisjs/inertia/helpers'
 import DefaultLayout from '~/layouts/DefaultLayout.vue'
 
-const appName = import.meta.env.VITE_APP_NAME || 'frontend.mu'
-
 createInertiaApp({
   progress: { color: '#3B82F6' },
 
-  title: (title: string) => `${title} - ${appName}`,
+  // Match the server-side TITLE_SUFFIX in app/utils/seo.ts so the title
+  // stays consistent across the SSR HTML → hydration handoff. Pages that
+  // already include the brand in their own <Head title=…> are checked
+  // here to avoid double-suffixing.
+  title: (title: string) => {
+    const trimmed = title.trim()
+    if (!trimmed) return 'coders.mu'
+    if (/coders\.mu|frontend\.mu/i.test(trimmed)) return trimmed
+    return `${trimmed} · coders.mu`
+  },
 
   resolve: async (name: string) => {
     const page = await resolvePageComponent(

--- a/packages/frontendmu-adonis/inertia/pages/errors/not_found.vue
+++ b/packages/frontendmu-adonis/inertia/pages/errors/not_found.vue
@@ -4,7 +4,9 @@ import { Link } from '@inertiajs/vue3'
 </script>
 
 <template>
-  <Head title="Not Found" />
+  <Head title="Not Found">
+    <meta head-key="robots" name="robots" content="noindex,follow">
+  </Head>
   <main class="relative min-h-screen flex items-center justify-center">
     <div class="text-center space-y-8">
       <h1 class="text-8xl font-display tracking-tight text-verse-500">404</h1>

--- a/packages/frontendmu-adonis/inertia/pages/privacy.vue
+++ b/packages/frontendmu-adonis/inertia/pages/privacy.vue
@@ -1,0 +1,83 @@
+<script setup lang="ts">
+import { Head } from '@inertiajs/vue3'
+</script>
+
+<template>
+  <Head title="Privacy">
+    <meta
+      head-key="description"
+      name="description"
+      content="How coders.mu handles your personal data — what we collect, why, and how to ask us to remove it."
+    >
+  </Head>
+  <main class="relative min-h-screen pt-40 pb-24">
+    <div class="contain relative z-10">
+      <!-- Page Header -->
+      <div class="max-w-3xl mb-20 space-y-4">
+        <p class="text-sm font-medium text-gray-400 dark:text-gray-500">Policy</p>
+        <h1 class="text-5xl md:text-6xl font-display tracking-tight dark:text-white leading-[0.9]">
+          Privacy
+        </h1>
+        <p class="text-base text-gray-500 dark:text-gray-400 max-w-2xl leading-relaxed">
+          We run coders.mu as a community project. We collect as little personal data as possible
+          and never sell it. This page explains exactly what we keep and why.
+        </p>
+      </div>
+
+      <!-- Content -->
+      <div class="max-w-3xl space-y-16 prose prose-lg prose-gray dark:prose-invert">
+        <section class="space-y-4">
+          <h2 class="text-sm font-semibold uppercase tracking-wider text-verse-500">What we collect</h2>
+          <p>
+            When you sign in with Google we receive your name, email address, profile picture, and a
+            stable Google account identifier. When you RSVP to a meetup, we record that RSVP against
+            your account so we can manage attendance.
+          </p>
+          <p>
+            We don't run third-party advertising or behavioural tracking on the site. We use
+            standard server logs (IP, user agent, request path) for short-term debugging and abuse
+            mitigation.
+          </p>
+        </section>
+
+        <section class="space-y-4">
+          <h2 class="text-sm font-semibold uppercase tracking-wider text-verse-500">How we use it</h2>
+          <p>
+            Your name and photo appear on attendee lists and (if you spoke at a meetup) on the
+            relevant session page. Your email is only used to contact you about the meetup you
+            RSVP'd to or, occasionally, about community announcements.
+          </p>
+        </section>
+
+        <section class="space-y-4">
+          <h2 class="text-sm font-semibold uppercase tracking-wider text-verse-500">Who we share with</h2>
+          <p>
+            We don't share your data with third parties. The site is hosted on infrastructure we
+            operate, with Cloudflare in front for DNS and CDN. Photos and assets live on Cloudflare
+            R2. Sign-in is provided by Google OAuth.
+          </p>
+        </section>
+
+        <section class="space-y-4">
+          <h2 class="text-sm font-semibold uppercase tracking-wider text-verse-500">Your data, your choice</h2>
+          <p>
+            You can ask us to delete your account, your RSVP history, or your speaker profile at any
+            time by emailing
+            <a href="mailto:hello@frontend.mu" class="text-verse-500 font-semibold no-underline hover:underline">hello@frontend.mu</a>.
+            We'll remove your data within 30 days unless we're legally required to keep it.
+          </p>
+        </section>
+
+        <section class="space-y-4">
+          <h2 class="text-sm font-semibold uppercase tracking-wider text-verse-500">Changes to this page</h2>
+          <p>
+            We'll update this page if our data practices change in any meaningful way. The current
+            version is maintained at
+            <a href="https://github.com/coders-mu/frontend.mu" class="text-verse-500 font-semibold no-underline hover:underline">github.com/coders-mu/frontend.mu</a>
+            in the open.
+          </p>
+        </section>
+      </div>
+    </div>
+  </main>
+</template>

--- a/packages/frontendmu-adonis/inertia/pages/terms.vue
+++ b/packages/frontendmu-adonis/inertia/pages/terms.vue
@@ -1,0 +1,90 @@
+<script setup lang="ts">
+import { Head } from '@inertiajs/vue3'
+</script>
+
+<template>
+  <Head title="Terms">
+    <meta
+      head-key="description"
+      name="description"
+      content="The rules of the road for using coders.mu — what we expect of you, what you can expect of us."
+    >
+  </Head>
+  <main class="relative min-h-screen pt-40 pb-24">
+    <div class="contain relative z-10">
+      <!-- Page Header -->
+      <div class="max-w-3xl mb-20 space-y-4">
+        <p class="text-sm font-medium text-gray-400 dark:text-gray-500">Policy</p>
+        <h1 class="text-5xl md:text-6xl font-display tracking-tight dark:text-white leading-[0.9]">
+          Terms of use
+        </h1>
+        <p class="text-base text-gray-500 dark:text-gray-400 max-w-2xl leading-relaxed">
+          coders.mu is a community-run site. By using it you agree to a few simple rules.
+        </p>
+      </div>
+
+      <!-- Content -->
+      <div class="max-w-3xl space-y-16 prose prose-lg prose-gray dark:prose-invert">
+        <section class="space-y-4">
+          <h2 class="text-sm font-semibold uppercase tracking-wider text-verse-500">Be civil</h2>
+          <p>
+            Everything you do on the site — RSVPing, speaking at meetups, contributing to the open
+            source repo — falls under our
+            <a href="/code-of-conduct" class="text-verse-500 font-semibold no-underline hover:underline">Code of Conduct</a>.
+            Harassment, hate speech, or repeated bad-faith behaviour gets your account removed.
+          </p>
+        </section>
+
+        <section class="space-y-4">
+          <h2 class="text-sm font-semibold uppercase tracking-wider text-verse-500">Your account</h2>
+          <p>
+            You're responsible for the actions taken under your account. Sign in only with your own
+            Google account, and let us know if you suspect your account has been compromised.
+          </p>
+        </section>
+
+        <section class="space-y-4">
+          <h2 class="text-sm font-semibold uppercase tracking-wider text-verse-500">Content</h2>
+          <p>
+            Talks, slides, and session notes contributed by speakers remain the property of their
+            authors. By submitting content (a talk proposal, a meetup write-up, a profile photo) you
+            grant us a non-exclusive, royalty-free licence to display it on the site and in
+            community communications.
+          </p>
+          <p>
+            The site code itself is open source — see the
+            <a href="https://github.com/coders-mu/frontend.mu" class="text-verse-500 font-semibold no-underline hover:underline">repository</a>
+            for the licence.
+          </p>
+        </section>
+
+        <section class="space-y-4">
+          <h2 class="text-sm font-semibold uppercase tracking-wider text-verse-500">No commercial spam</h2>
+          <p>
+            Don't use the site, RSVP system, or speaker channel to push unsolicited commercial
+            offers. Sponsorship is welcome — get in touch via
+            <a href="/sponsor-us" class="text-verse-500 font-semibold no-underline hover:underline">sponsor us</a>.
+          </p>
+        </section>
+
+        <section class="space-y-4">
+          <h2 class="text-sm font-semibold uppercase tracking-wider text-verse-500">No warranties</h2>
+          <p>
+            The site is provided as-is. We do our best to keep it running and your data safe (see
+            our <a href="/privacy" class="text-verse-500 font-semibold no-underline hover:underline">privacy</a> page),
+            but we make no formal warranties about availability or fitness for any particular
+            purpose.
+          </p>
+        </section>
+
+        <section class="space-y-4">
+          <h2 class="text-sm font-semibold uppercase tracking-wider text-verse-500">Contact</h2>
+          <p>
+            Questions about these terms? Email
+            <a href="mailto:hello@frontend.mu" class="text-verse-500 font-semibold no-underline hover:underline">hello@frontend.mu</a>.
+          </p>
+        </section>
+      </div>
+    </div>
+  </main>
+</template>

--- a/packages/frontendmu-adonis/public/robots.txt
+++ b/packages/frontendmu-adonis/public/robots.txt
@@ -1,2 +1,11 @@
 User-agent: *
-Allow: /
+Disallow: /admin/
+Disallow: /profile
+Disallow: /login
+Disallow: /register
+Disallow: /redirect
+Disallow: /auth/
+Disallow: /api/
+Disallow: /user/
+
+Sitemap: https://coders.mu/sitemap.xml

--- a/packages/frontendmu-adonis/public/robots.txt
+++ b/packages/frontendmu-adonis/public/robots.txt
@@ -1,11 +1,11 @@
 User-agent: *
-Disallow: /admin/
+Disallow: /admin
 Disallow: /profile
 Disallow: /login
 Disallow: /register
 Disallow: /redirect
-Disallow: /auth/
-Disallow: /api/
-Disallow: /user/
+Disallow: /auth
+Disallow: /api
+Disallow: /user
 
 Sitemap: https://coders.mu/sitemap.xml

--- a/packages/frontendmu-adonis/resources/views/inertia_layout.edge
+++ b/packages/frontendmu-adonis/resources/views/inertia_layout.edge
@@ -15,11 +15,15 @@
       <meta property="og:title" content="{{ seoMeta.ogTitle }}">
       <meta property="og:description" content="{{ seoMeta.ogDescription }}">
       <meta property="og:url" content="{{ seoMeta.canonical }}">
-      <meta property="og:image" content="{{ seoMeta.ogImage }}">
-      <meta name="twitter:card" content="summary_large_image">
+      @if(seoMeta.ogImage)
+        <meta property="og:image" content="{{ seoMeta.ogImage }}">
+      @endif
+      <meta name="twitter:card" content="{{ seoMeta.ogImage ? 'summary_large_image' : 'summary' }}">
       <meta name="twitter:title" content="{{ seoMeta.ogTitle }}">
       <meta name="twitter:description" content="{{ seoMeta.ogDescription }}">
-      <meta name="twitter:image" content="{{ seoMeta.ogImage }}">
+      @if(seoMeta.ogImage)
+        <meta name="twitter:image" content="{{ seoMeta.ogImage }}">
+      @endif
     @else
       <title inertia>coders.mu</title>
     @endif

--- a/packages/frontendmu-adonis/resources/views/inertia_layout.edge
+++ b/packages/frontendmu-adonis/resources/views/inertia_layout.edge
@@ -3,7 +3,26 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title inertia>frontend.mu</title>
+    @if(seoMeta)
+      <title inertia>{{ seoMeta.title }}</title>
+      <meta name="description" content="{{ seoMeta.description }}">
+      <link rel="canonical" href="{{ seoMeta.canonical }}">
+      @if(seoMeta.noindex)
+        <meta name="robots" content="noindex,follow">
+      @endif
+      <meta property="og:site_name" content="coders.mu">
+      <meta property="og:type" content="{{ seoMeta.ogType }}">
+      <meta property="og:title" content="{{ seoMeta.ogTitle }}">
+      <meta property="og:description" content="{{ seoMeta.ogDescription }}">
+      <meta property="og:url" content="{{ seoMeta.canonical }}">
+      <meta property="og:image" content="{{ seoMeta.ogImage }}">
+      <meta name="twitter:card" content="summary_large_image">
+      <meta name="twitter:title" content="{{ seoMeta.ogTitle }}">
+      <meta name="twitter:description" content="{{ seoMeta.ogDescription }}">
+      <meta name="twitter:image" content="{{ seoMeta.ogImage }}">
+    @else
+      <title inertia>coders.mu</title>
+    @endif
     <link rel="icon" type="image/svg+xml" href="/favicon.svg">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/packages/frontendmu-adonis/start/kernel.ts
+++ b/packages/frontendmu-adonis/start/kernel.ts
@@ -38,6 +38,7 @@ router.use([
   () => import('@adonisjs/session/session_middleware'),
   () => import('@adonisjs/shield/shield_middleware'),
   () => import('@adonisjs/auth/initialize_auth_middleware'),
+  () => import('#middleware/canonical_url_middleware'),
   () => import('#middleware/inertia_middleware'),
   () => import('#middleware/initialize_bouncer_middleware'),
   () => import('@eznix/adonisjs-debugbar/middleware'),

--- a/packages/frontendmu-adonis/start/routes.ts
+++ b/packages/frontendmu-adonis/start/routes.ts
@@ -19,6 +19,22 @@ router
   .prefix('/api/public/v1')
   .use(middleware.forceJsonResponse())
 
+// SEO — sitemap discoverable at the conventional path
+router.get('/sitemap.xml', [() => import('#controllers/sitemap_controller'), 'index']).as('sitemap')
+
+// Legacy snake_case slugs from the old Directus/Nuxt site → 301 to current kebab routes
+router.get('/code_of_conduct', ({ response }) => response.redirect('/code-of-conduct', false, 301))
+router.get('/coding_guidelines', ({ response }) =>
+  response.redirect('/coding-guidelines', false, 301)
+)
+
+// Legacy numeric meetup IDs from the old site (e.g. /meetup/17). The new system
+// uses date-slugs / UUIDs and has no legacy_id mapping. Return 410 Gone so Google
+// removes them from the index faster than it would on a 404.
+router
+  .get('/meetup/:legacyId', ({ response }) => response.status(410).send('Gone'))
+  .where('legacyId', /^\d+$/)
+
 // Home page
 router.get('/', [() => import('#controllers/home_controller'), 'index']).as('home')
 
@@ -77,6 +93,10 @@ router
 router
   .get('/api-docs', [() => import('#controllers/pages_controller'), 'apiDocs'])
   .as('pages.apiDocs')
+router
+  .get('/privacy', [() => import('#controllers/pages_controller'), 'privacy'])
+  .as('pages.privacy')
+router.get('/terms', [() => import('#controllers/pages_controller'), 'terms']).as('pages.terms')
 
 // Auth routes
 router
@@ -391,3 +411,10 @@ router
     'uploadLocal',
   ])
   .as('admin.media.uploadLocal')
+
+// Wildcard fallback — every unmatched GET should render the Inertia 404 page
+// (the previous router default returned `Cannot GET:...` JSON).
+router.get('*', ({ inertia, response }) => {
+  response.status(404)
+  return inertia.render('errors/not_found', {})
+})


### PR DESCRIPTION
## Summary

The Google Search Console "Page indexing" report for `sc-domain:coders.mu` shows **421 not-indexed pages** across 7 buckets. This PR is the first of two passes: it lands every code-side fix in `SEO_FIX_PLAN.md`. The remaining item (Cloudflare redirect rule for `frontend.coders.mu`) is a dashboard change called out below.

`SEO_FIX_PLAN.md` (committed) is the source of truth for the audit, each fix, and per-fix verification.

## What changes

- **`/sitemap.xml`** — new controller emitting all canonical URLs (static pages, published events by slug, speakers with at least one session). Locally produces 131 entries.
- **`robots.txt`** — replaces the bare allow-all with `Disallow:` for `/admin/`, `/profile`, `/login`, `/register`, `/auth/`, `/api/`, `/user/`, `/redirect`, plus a `Sitemap:` reference.
- **Legacy URL handling**
  - 301 `/code_of_conduct` → `/code-of-conduct`, `/coding_guidelines` → `/coding-guidelines`.
  - 410 Gone for `/meetup/<numeric-id>` (old Directus IDs that don't map to current slugs).
  - 410 Gone for missing speaker UUIDs (`speakers_controller` now uses `first` + 410 rather than `firstOrFail`'s 404).
- **Wildcard 404** — `router.get('*', …)` returns the Inertia `errors/not_found` page so unknown paths get HTML 404 instead of `Cannot GET:` JSON.
- **Canonical URL middleware** — 301s trailing-slash paths to the no-slash form (matching the route definitions) and strips tracking params (`utm_*`, `ref`, `trk`, `fbclid`, `gclid`, `mc_*`). Skips Inertia XHRs and non-GET requests.
- **Per-page meta tags in initial HTML** — Inertia SSR stays disabled (separate, bigger lift). Instead, controllers push per-page `<title>` / `<meta description>` / `<link rel=canonical>` / OG / Twitter tags through a request-scoped view share read by the Edge layout. `app/utils/seo.ts` exposes `setSeoMeta(ctx, partial)`; `inertia_middleware` seeds defaults so the layout always has a `seoMeta` object.
- **`/admin`, `/login`, `/register`, `/profile`, `/auth/*`** automatically emit `<meta name="robots" content="noindex,follow">` via path-prefix detection. Empty speaker profiles (zero sessions) also noindex.
- **New pages** — `/privacy` and `/terms` with short, real copy linking to the Code of Conduct and `hello@frontend.mu`. Both appear in the sitemap.

## Out of scope (deploy-time follow-up)

Fix 7 from the plan is a **Cloudflare dashboard change**, not code: the redirect rule for `frontend.coders.mu` currently preserves the URI path when 301-ing to apex, so every legacy URL becomes `301 → 404`. Change it to a static-destination `https://coders.mu/` 301 (drop the path). After this PR ships, Google will drop the legacy paths within a few weeks.

## Test plan

- [x] `pnpm typecheck` — clean on my changes (only the pre-existing migration 2016-july/september literal-union error remains; unrelated).
- [x] `pnpm lint:fix` — clean on my changes (4 remaining errors are pre-existing in `safe_return_url.ts`, `1776950000000_backfill_event_sponsors.ts`, `tests/a11y/public-routes.spec.ts`).
- [x] Dev server: ran the SEO verification sweep against `http://localhost:3333` — all checks pass:
  - `/sitemap.xml` → 200, valid XML, 131 entries
  - `/robots.txt` → 200, expected disallows + sitemap
  - `/code_of_conduct` → 301 `/code-of-conduct`; `/coding_guidelines` → 301 `/coding-guidelines`
  - `/meetup/17`, `/meetup/45` → 410
  - `/speaker/00000000-…` → 410
  - `/privacy`, `/terms` → 200 with distinct title/description/canonical
  - `/team/`, `/about/` → 301 to no-slash; `/about?utm_source=x`, `/about?ref=foo` → 301 with tracking params stripped
  - `/this-page-does-not-exist` → 404 (Inertia HTML, not JSON)
  - `/login` → HTML contains `<meta name="robots" content="noindex,follow">`
  - Sample meetup page (`/meetup/2026-may`) → distinct `<title>`, canonical, meta description in initial HTML response
- [ ] After deploy: submit `https://coders.mu/sitemap.xml` in Search Console → Sitemaps and re-pull the indexing report in 2 weeks. Expected drops in 5xx, 404, Duplicate-canonical, Page-with-redirect; gradual drop in Crawled-not-indexed.
- [ ] After deploy: flip the Cloudflare `frontend.coders.mu` rule to static destination (per "Out of scope" above).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Privacy and Terms pages
  * Implemented XML sitemap for improved search engine discoverability
  * Enhanced SEO metadata (titles, descriptions, canonical URLs) across all pages
  * Improved handling of legacy URLs with automatic redirects

* **Bug Fixes**
  * Enhanced 404 error page presentation
  * Fixed trailing slash and query parameter normalization for canonical URLs
  * Improved speaker page handling for missing profiles

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/frontendmu/frontend.mu/pull/365?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->