### PR TITLE
SEO follow-ups: API/OAuth bypass, error-page meta, lastmod source

### DIFF
--- a/packages/frontendmu-adonis/app/controllers/events_controller.ts
+++ b/packages/frontendmu-adonis/app/controllers/events_controller.ts
@@ -8,6 +8,7 @@ import EventTransformer from '#transformers/event_transformer'
 import RsvpTransformer from '#transformers/rsvp_transformer'
 import PublicAttendeeTransformer from '#transformers/public_attendee_transformer'
 import { setSeoMeta } from '#utils/seo'
+import { htmlToPlainText } from '#utils/html_text'
 
 export default class EventsController {
   async index(ctx: HttpContext) {
@@ -122,11 +123,8 @@ export default class EventsController {
     }
 
     const meetupDescription =
-      (event.description ?? '')
-        .replace(/<[^>]+>/g, '')
-        .replace(/\s+/g, ' ')
-        .trim()
-        .slice(0, 200) || `Details, sessions and RSVP for ${event.title} on coders.mu.`
+      htmlToPlainText(event.description, 200) ||
+      `Details, sessions and RSVP for ${event.title} on coders.mu.`
 
     setSeoMeta(ctx, {
       title: event.title,

--- a/packages/frontendmu-adonis/app/controllers/sitemap_controller.ts
+++ b/packages/frontendmu-adonis/app/controllers/sitemap_controller.ts
@@ -1,8 +1,7 @@
 import type { HttpContext } from '@adonisjs/core/http'
-import { type DateTime } from 'luxon'
+import { DateTime } from 'luxon'
 import db from '@adonisjs/lucid/services/db'
 import Event from '#models/event'
-import User from '#models/user'
 import { canonicalUrl } from '#utils/site_url'
 
 type Entry = {
@@ -72,18 +71,32 @@ export default class SitemapController {
       })
     }
 
-    // Speakers with at least one session — avoids polluting the index with
-    // attendee accounts that never spoke.
-    const speakerRows = await db.from('session_speakers').distinct('speaker_id')
-    const speakerIds = speakerRows.map((r) => r.speaker_id as string).filter(Boolean)
-    if (speakerIds.length > 0) {
-      const speakers = await User.query().whereIn('id', speakerIds).select('id', 'updatedAt')
-      for (const speaker of speakers) {
-        entries.push({
-          loc: canonicalUrl(`/speaker/${speaker.id}`),
-          lastmod: toIso(speaker.updatedAt as DateTime | null | undefined),
-        })
-      }
+    // Speakers with at least one session. Lastmod tracks the most recent
+    // session they spoke at (not user.updatedAt, which would churn on every
+    // OAuth login refresh and other profile writes that don't change the
+    // public /speaker/<id> page).
+    const speakerRows = await db
+      .from('session_speakers')
+      .join('sessions', 'sessions.id', 'session_speakers.session_id')
+      .groupBy('session_speakers.speaker_id')
+      .select('session_speakers.speaker_id')
+      .max('sessions.updated_at as latest_session_updated_at')
+
+    for (const row of speakerRows) {
+      const id = row.speaker_id as string | undefined
+      if (!id) continue
+      const raw = row.latest_session_updated_at as Date | string | null | undefined
+      const lastmod = raw
+        ? toIso(
+            raw instanceof Date
+              ? DateTime.fromJSDate(raw)
+              : DateTime.fromISO(String(raw))
+          )
+        : undefined
+      entries.push({
+        loc: canonicalUrl(`/speaker/${id}`),
+        lastmod,
+      })
     }
 
     response.header('Content-Type', 'application/xml; charset=utf-8')

--- a/packages/frontendmu-adonis/app/controllers/speakers_controller.ts
+++ b/packages/frontendmu-adonis/app/controllers/speakers_controller.ts
@@ -40,6 +40,7 @@ export default class SpeakersController {
     // the new DB. Returning 410 (instead of the default 404 from firstOrFail)
     // signals "permanently gone" so Google drops them from the index faster.
     if (!dbSpeaker) {
+      setSeoMeta(ctx, { title: 'Speaker not found', noindex: true })
       response.status(410)
       return inertia.render('errors/not_found', {})
     }

--- a/packages/frontendmu-adonis/app/exceptions/handler.ts
+++ b/packages/frontendmu-adonis/app/exceptions/handler.ts
@@ -1,6 +1,7 @@
 import app from '@adonisjs/core/services/app'
 import { type HttpContext, ExceptionHandler } from '@adonisjs/core/http'
 import type { StatusPageRange, StatusPageRenderer } from '@adonisjs/core/types/http'
+import { setSeoMeta } from '#utils/seo'
 
 type ErrorWithStatus = {
   message?: string
@@ -46,6 +47,11 @@ function renderStatusPage(
         message: getErrorMessage(error, fallbackMessage),
       })
     }
+
+    // Error pages should always be noindex — and skip the canonical link so
+    // we don't tell Google that, e.g., /sponsor/<deleted-uuid> is the
+    // canonical version of itself.
+    setSeoMeta(ctx, { title: fallbackMessage, noindex: true })
 
     const inertia = (ctx as HttpContext & { inertia?: InertiaRenderer }).inertia
     if (inertia) {

--- a/packages/frontendmu-adonis/app/middleware/canonical_url_middleware.ts
+++ b/packages/frontendmu-adonis/app/middleware/canonical_url_middleware.ts
@@ -2,14 +2,16 @@ import type { HttpContext } from '@adonisjs/core/http'
 import type { NextFn } from '@adonisjs/core/types/http'
 
 const TRACKING_PARAM = /^(utm_[a-z_]+|fbclid|gclid|mc_[a-z0-9_]+|ref|trk)$/i
+const BYPASS_PREFIXES = ['/api/', '/auth/']
 
 /**
  * Canonicalises GET URLs so search engines (and shares) all converge on the
  * same form:
  *   - trailing-slash stripped (except for "/")
  *   - tracking params (utm_*, ref, trk, fbclid, gclid, …) stripped
- * Inertia XHRs (X-Inertia: true) and non-GET requests are skipped so SPA
- * navigation and form posts don't get redirected.
+ * Inertia XHRs (X-Inertia: true), non-GET requests, and JSON-only routes
+ * (/api/*, /auth/* OAuth callbacks) are skipped so API consumers and OAuth
+ * flows aren't 301-redirected mid-request.
  */
 export default class CanonicalUrlMiddleware {
   async handle(ctx: HttpContext, next: NextFn) {
@@ -19,6 +21,11 @@ export default class CanonicalUrlMiddleware {
     if (request.header('x-inertia')) return next()
 
     const pathname = request.url(false)
+
+    for (const prefix of BYPASS_PREFIXES) {
+      if (pathname.startsWith(prefix)) return next()
+    }
+
     const qs = request.parsedUrl.query as string | null | undefined
 
     let canonicalPath = pathname

--- a/packages/frontendmu-adonis/app/utils/html_text.ts
+++ b/packages/frontendmu-adonis/app/utils/html_text.ts
@@ -1,0 +1,64 @@
+/**
+ * Convert a snippet of HTML (e.g. a richtext description from an event row)
+ * into plain text suitable for a <meta name="description"> tag.
+ *
+ *  - Decodes common named entities and numeric entities.
+ *  - Strips tags.
+ *  - Collapses whitespace.
+ *  - Truncates to a max length.
+ *
+ * Order matters: tags first (so entities inside a stripped <script> are not
+ * decoded), then entities, then whitespace, then truncate.
+ */
+
+const NAMED_ENTITIES: Record<string, string> = {
+  amp: '&',
+  lt: '<',
+  gt: '>',
+  quot: '"',
+  apos: "'",
+  nbsp: ' ',
+  ndash: '–',
+  mdash: '—',
+  hellip: '…',
+  lsquo: '‘',
+  rsquo: '’',
+  ldquo: '“',
+  rdquo: '”',
+  laquo: '«',
+  raquo: '»',
+  copy: '©',
+  reg: '®',
+  trade: '™',
+}
+
+function decodeEntities(input: string): string {
+  return input.replace(/&(#x?[0-9a-fA-F]+|[a-zA-Z]+);/g, (match, ref: string) => {
+    if (ref[0] === '#') {
+      const isHex = ref[1] === 'x' || ref[1] === 'X'
+      const code = Number.parseInt(ref.slice(isHex ? 2 : 1), isHex ? 16 : 10)
+      if (Number.isFinite(code)) {
+        try {
+          return String.fromCodePoint(code)
+        } catch {
+          return match
+        }
+      }
+      return match
+    }
+    return NAMED_ENTITIES[ref.toLowerCase()] ?? match
+  })
+}
+
+export function htmlToPlainText(input: string | null | undefined, maxLen = 200): string {
+  if (!input) return ''
+  const stripped = input.replace(/<[^>]+>/g, ' ')
+  const decoded = decodeEntities(stripped)
+  const collapsed = decoded.replace(/\s+/g, ' ').trim()
+  if (collapsed.length <= maxLen) return collapsed
+  // Cut at a word boundary when possible, then trim and add an ellipsis.
+  const cut = collapsed.slice(0, maxLen)
+  const lastSpace = cut.lastIndexOf(' ')
+  const head = lastSpace > maxLen - 30 ? cut.slice(0, lastSpace) : cut
+  return `${head.trimEnd()}…`
+}

--- a/packages/frontendmu-adonis/inertia/pages/privacy.vue
+++ b/packages/frontendmu-adonis/inertia/pages/privacy.vue
@@ -1,15 +1,10 @@
 <script setup lang="ts">
-import { Head } from '@inertiajs/vue3'
+// Title / meta description / canonical / OG tags are emitted server-side via
+// setSeoMeta in pages_controller.ts → inertia_layout.edge. Keeping a Vue
+// <Head> block here would duplicate the description meta tag at hydration.
 </script>
 
 <template>
-  <Head title="Privacy">
-    <meta
-      head-key="description"
-      name="description"
-      content="How coders.mu handles your personal data — what we collect, why, and how to ask us to remove it."
-    >
-  </Head>
   <main class="relative min-h-screen pt-40 pb-24">
     <div class="contain relative z-10">
       <!-- Page Header -->

--- a/packages/frontendmu-adonis/inertia/pages/terms.vue
+++ b/packages/frontendmu-adonis/inertia/pages/terms.vue
@@ -1,15 +1,10 @@
 <script setup lang="ts">
-import { Head } from '@inertiajs/vue3'
+// Title / meta description / canonical / OG tags are emitted server-side via
+// setSeoMeta in pages_controller.ts → inertia_layout.edge. Keeping a Vue
+// <Head> block here would duplicate the description meta tag at hydration.
 </script>
 
 <template>
-  <Head title="Terms">
-    <meta
-      head-key="description"
-      name="description"
-      content="The rules of the road for using coders.mu — what we expect of you, what you can expect of us."
-    >
-  </Head>
   <main class="relative min-h-screen pt-40 pb-24">
     <div class="contain relative z-10">
       <!-- Page Header -->

--- a/packages/frontendmu-adonis/resources/views/inertia_layout.edge
+++ b/packages/frontendmu-adonis/resources/views/inertia_layout.edge
@@ -6,15 +6,18 @@
     @if(seoMeta)
       <title inertia>{{ seoMeta.title }}</title>
       <meta name="description" content="{{ seoMeta.description }}">
-      <link rel="canonical" href="{{ seoMeta.canonical }}">
       @if(seoMeta.noindex)
         <meta name="robots" content="noindex,follow">
+      @else
+        <link rel="canonical" href="{{ seoMeta.canonical }}">
       @endif
       <meta property="og:site_name" content="coders.mu">
       <meta property="og:type" content="{{ seoMeta.ogType }}">
       <meta property="og:title" content="{{ seoMeta.ogTitle }}">
       <meta property="og:description" content="{{ seoMeta.ogDescription }}">
-      <meta property="og:url" content="{{ seoMeta.canonical }}">
+      @if(!seoMeta.noindex)
+        <meta property="og:url" content="{{ seoMeta.canonical }}">
+      @endif
       @if(seoMeta.ogImage)
         <meta property="og:image" content="{{ seoMeta.ogImage }}">
       @endif

--- a/packages/frontendmu-adonis/start/routes.ts
+++ b/packages/frontendmu-adonis/start/routes.ts
@@ -412,9 +412,21 @@ router
   ])
   .as('admin.media.uploadLocal')
 
-// Wildcard fallback — every unmatched GET should render the Inertia 404 page
-// (the previous router default returned `Cannot GET:...` JSON).
-router.get('*', ({ inertia, response }) => {
+// Wildcard fallback for unmatched GET requests:
+//   - /api/* paths return a JSON 404 (API consumers expect JSON, not the
+//     full Inertia HTML shell).
+//   - everything else renders the Inertia 404 page with noindex meta so the
+//     bogus URL never claims to be canonical.
+router.get('*', async (ctx) => {
+  const { inertia, request, response } = ctx
   response.status(404)
+  if (request.url(false).startsWith('/api/')) {
+    return response.json({
+      error: 'not_found',
+      message: `Route not found: ${request.method()} ${request.url(false)}`,
+    })
+  }
+  const { setSeoMeta } = await import('#utils/seo')
+  setSeoMeta(ctx, { title: 'Page not found', noindex: true })
   return inertia.render('errors/not_found', {})
 })


### PR DESCRIPTION
## Summary

Five medium/low follow-ups from the code review on PR #365 (now merged & deployed).

- **CanonicalUrlMiddleware** skips `/api/*` and `/auth/*` so JSON API consumers and OAuth callbacks aren't 301-redirected for trailing-slash / tracking-param normalization.
- **Wildcard `*` route** splits responses: `/api/*` → JSON envelope, everything else → Inertia 404 page.
- **Error pages stop emitting `<link rel=canonical>` and `<meta og:url>`** when `seoMeta.noindex` is true. The exception handler, the wildcard 404 handler, and the speaker 410 path all set `setSeoMeta({ noindex: true })` explicitly — so a 404/410 page no longer advertises the bogus URL as canonical to itself.
- **privacy.vue / terms.vue** drop their `<Head>` blocks. `setSeoMeta` already covers title + description through the Edge layout; the Vue `<Head>` blocks were creating a second `<meta name=description>` at hydration.
- **Event meta description** runs through a new `app/utils/html_text.ts` that decodes common HTML entities (`&amp;`, `&rsquo;`, numeric refs) before Edge re-escapes them. Avoids double-encoded characters in SERP snippets.
- **Speaker `<lastmod>` in sitemap** is now `MAX(sessions.updated_at)` instead of `user.updated_at`. The previous source churned on every OAuth login refresh.

## Test plan

- [x] `pnpm typecheck` — clean (only pre-existing migration error remains).
- [x] `pnpm lint` — only pre-existing errors in unrelated files remain.
- [x] Local dev sweep with curl:
  - `/api/public/v1/meetups/` → 200 (canonical mw bypasses, returns JSON via the meetups handler)
  - `/api/public/v1/meetups?utm_source=x` → 200 (utm preserved on API path)
  - `/api/public/v1/typo` → 404 with JSON body `{error,message}`
  - `/auth/google?utm_source=x` → 302 (canonical mw bypasses)
  - `/random-bogus-path` → 404 HTML with `<meta robots="noindex,follow">` and NO `<link rel=canonical>`
  - `/privacy` → exactly one `<meta name=description>` in the HTML
  - `/meetup/<slug>` → meta description plain-text (no double-encoded entities)
  - `/sitemap.xml` → 200, speaker entries include `<lastmod>` from session updated_at
- [ ] After deploy: re-run the curl sweep against `https://coders.mu`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Error and not-found pages are now properly marked as non-indexable to search engines.
  * Speaker not-found pages now include appropriate SEO metadata.
  * Improved meetup description formatting for display across the application.

* **Improvements**
  * Enhanced API route handling for 404 responses.
  * Refined speaker sitemap generation for better search engine visibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/frontendmu/frontend.mu/pull/366?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->