### PR TITLE
fix(adonis): build only the client environment under vite 8

### DIFF
--- a/.github/workflows/ci-adonis.yml
+++ b/.github/workflows/ci-adonis.yml
@@ -60,6 +60,11 @@ jobs:
       - name: Build
         run: pnpm build
 
+      # The page still returns 200 when the browser bundle is wrong, so assert
+      # on the build output itself rather than on an HTTP status.
+      - name: Verify build output
+        run: pnpm verify:build
+
   docker-image:
     runs-on: ubuntu-latest
     steps:

--- a/packages/frontendmu-adonis/package.json
+++ b/packages/frontendmu-adonis/package.json
@@ -18,7 +18,8 @@
     "codegen": "node ace codegen",
     "typecheck": "tsc --noEmit",
     "db:sync-local-meetup-details": "node database/scripts/sync_local_sqlite_meetup_details.mjs",
-    "clean:ports": "lsof -t -i:3333 | xargs kill && lsof -t -i:24678 | xargs kill"
+    "clean:ports": "lsof -t -i:3333 | xargs kill && lsof -t -i:24678 | xargs kill",
+    "verify:build": "node scripts/verify_build_output.mjs"
   },
   "imports": {
     "#generated/*": "./.adonisjs/server/*.js",

--- a/packages/frontendmu-adonis/scripts/verify_build_output.mjs
+++ b/packages/frontendmu-adonis/scripts/verify_build_output.mjs
@@ -1,0 +1,58 @@
+/**
+ * Asserts that `node ace build` produced a browser bundle for the Inertia
+ * entrypoint.
+ *
+ * Vite 8 builds every environment it knows about, and both the client and ssr
+ * environments write to public/assets. When the ssr pass runs it overwrites
+ * the browser bundle and the manifest with externalised output: bare "vue"
+ * imports the browser cannot resolve, and no stylesheet. The page still
+ * returns 200, so an HTTP check does not notice; the app simply never mounts.
+ *
+ * Run after a build. Exits non-zero with the reason when the output is wrong.
+ */
+import { readFile } from 'node:fs/promises'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const packageRoot = join(dirname(fileURLToPath(import.meta.url)), '..')
+const assetsDir = join(packageRoot, 'build', 'public', 'assets')
+const entryName = 'inertia/app.ts'
+
+const failures = []
+
+const manifest = JSON.parse(await readFile(join(assetsDir, '.vite', 'manifest.json'), 'utf8'))
+const entry = manifest[entryName]
+
+if (!entry) {
+  failures.push(`manifest has no "${entryName}" entry`)
+} else {
+  const bundle = await readFile(join(assetsDir, entry.file), 'utf8')
+
+  // A browser bundle inlines these; an ssr bundle externalises them and the
+  // browser then fails on "Failed to resolve module specifier".
+  const mustBeBundled = ['vue', '@inertiajs/vue3', '@inertiajs/core']
+  const externalised = mustBeBundled.filter((name) =>
+    new RegExp(`from\\s*["']${name.replace('/', '\\/')}["']`).test(bundle)
+  )
+  if (externalised.length > 0) {
+    failures.push(
+      `${entry.file} imports ${externalised.join(', ')} as bare specifiers — this looks like ssr output`
+    )
+  }
+
+  if (bundle.includes('useSSRContext')) {
+    failures.push(`${entry.file} imports useSSRContext — this is an ssr bundle, not a browser bundle`)
+  }
+
+  if (!entry.css?.length) {
+    failures.push(`manifest entry "${entryName}" lists no css`)
+  }
+}
+
+if (failures.length > 0) {
+  console.error('Build output check failed:')
+  for (const failure of failures) console.error(`  - ${failure}`)
+  process.exit(1)
+}
+
+console.log(`Build output OK: ${entry.file} + ${entry.css.length} stylesheet(s)`)

--- a/packages/frontendmu-adonis/vite.config.ts
+++ b/packages/frontendmu-adonis/vite.config.ts
@@ -29,7 +29,14 @@ export default defineConfig({
     exclude: ['@libsql/sqlite3', 'oracledb', 'knex-dynamic-connection'],
   },
 
-  ssr: {
-    external: ['@libsql/sqlite3', 'oracledb'],
+  // Vite 8 builds every defined environment by default, and both write to
+  // public/assets, so the ssr pass overwrites the browser bundle and its
+  // manifest with externalised, bare-specifier output. Inertia SSR is off
+  // (config/inertia.ts) and no serverEntryPoints are configured, so build
+  // the client environment only.
+  builder: {
+    async buildApp(builder) {
+      await builder.build(builder.environments.client)
+    },
   },
 })

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,3 +3,10 @@ packages:
   - "packages/frontendmu-nuxt/"
   - "packages/frontendmu-data/"
   - "packages/frontendmu-adonis/"
+
+# better-sqlite3 ships prebuilt binaries but still carries a binding.gyp, and
+# package managers default to `node-gyp rebuild` for any package that has one
+# and no install script. Skip that; the prebuilds are what we want to load.
+# Also mirrored in the root package.json "pnpm" field for pnpm 9.
+neverBuiltDependencies:
+  - better-sqlite3


### PR DESCRIPTION
Fixes a production break introduced by the Vite 8 upgrade in #373 and caught after deploying: the site returned 200 everywhere but rendered a blank page.

## What went wrong

`node ace build` was shipping **ssr output as the browser bundle**. Vite 8 builds every environment it knows about, and the client and ssr environments both write to `public/assets`, so the second pass overwrote the first:

```
vite v8.2.2 building client environment for production...
  public/assets/.vite/manifest.json   16.71 kB
vite v8.2.2 building ssr environment for production...
  public/assets/.vite/manifest.json   14.84 kB   <- overwrites
```

The result in the browser:

```
Failed to resolve module specifier "vue".
Refused to apply style from '.../assets/app-DqwfpAzf.css' because its MIME type ('text/html') ...
```

The bundle imported `vue` and `@inertiajs/vue3` as bare specifiers and pulled in `useSSRContext`, and the client stylesheet was never emitted, so the referenced CSS 404'd into the SPA fallback.

## The fix

Inertia SSR is off (`config/inertia.ts`) and no `serverEntryPoints` are configured, so `builder.buildApp` now builds the client environment only. The manifest maps `inertia/app.ts` to a hashed browser bundle with its stylesheet again, as it did on Vite 7.

## Why CI did not catch it

The build succeeded, and my pre-deploy check on the compiled output only asserted HTTP 200 — which a broken bundle still returns, because the server serves the page fine and only the scripts fail.

So this adds `pnpm verify:build`, run in CI right after the build. It reads the manifest, resolves the entry, and fails when the entry externalises `vue` / `@inertiajs/vue3` / `@inertiajs/core`, contains `useSSRContext`, or lists no CSS. Confirmed both ways: it passes on the fixed build and fails on the broken one with exactly those two reasons.

## Also here

`neverBuiltDependencies` moves into `pnpm-workspace.yaml` alongside the `package.json` copy added in #376. pnpm 9, which the image pins, reads the `package.json` field; newer pnpm ignores it and warns. Keeping both means either version skips the needless `node-gyp rebuild` of better-sqlite3.

## Verification

`pnpm codegen`, `pnpm typecheck`, `pnpm lint`, `pnpm test` (18 passed), `pnpm build` (client environment only) and `pnpm verify:build`.

The compiled output was then booted with `NODE_ENV=production node bin/server.js` and driven in Chromium: `/`, `/meetups` and `/speakers` all mount with one title tag each, `Link` navigation works, and there are zero failed non-image requests and zero JS errors. The remaining console noise is image 404s for `public/uploads`, which is gitignored and populated from the server.

## Production status

`production` was rolled back by reverting the release merge, and the rollback deploy has completed. coders.mu is serving and hydrating normally on the pre-upgrade build. The upgrade will be re-released once this merges.
